### PR TITLE
Fix double grouping header "twitter" and "Twitter"

### DIFF
--- a/shared/js/trackers.js
+++ b/shared/js/trackers.js
@@ -37,7 +37,7 @@ require.scopes.trackers = (function() {
         if (settings.getSetting('embeddedTweetsEnabled') === false) {
             if (/platform.twitter.com/.test(urlToCheck)) {
                 console.log('blocking tweet embedded code on ' + urlToCheck)
-                return {parentCompany: 'twitter', url: 'platform.twitter.com', type: 'Analytics'}
+                return {parentCompany: 'Twitter', url: 'platform.twitter.com', type: 'Analytics'}
             }
         }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
While I was testing, I noticed Twitter showing up twice as a tracker network grouping in the subview:
<img width="300" alt="screen shot 2018-01-04 at 11 29 14 am" src="https://user-images.githubusercontent.com/3652195/34578526-527e6ffa-f153-11e7-94ed-81120400a9c4.png">

Subview after the fix:
<img width="300" alt="screen shot 2018-01-04 at 1 24 55 pm" src="https://user-images.githubusercontent.com/3652195/34578566-753552a2-f153-11e7-9e0b-8181a60d5ef6.png">



## Steps to test this PR:
1. Build and reload extension
2. Load sites like huffingtonpost.com or others with twitter trackers
3. Look at the tracker networks subview
4. Twitter trackers should all be grouped under one header


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
