### PR TITLE
Make https puts into indexedDB async

### DIFF
--- a/shared/js/indexed-db.js
+++ b/shared/js/indexed-db.js
@@ -36,7 +36,7 @@ class IndexedDBClient {
         this.db = null
 
         this.serverUpdateUrls = {
-            https: 'http://brian.duckduckgo.com/contentblocking.js?l=https-200k'
+            https: 'http://duckduckgo.com/contentblocking.js?l=https'
             // ...add more here
         }
         this.serverUpdateFails = 0
@@ -246,7 +246,7 @@ const fetchServerUpdate = {
 
                         putNextRecord.call(this).then(() => {
                             counter++
-                            console.log(`IndexedDBClient: ${counter} records added, ${records.length} left to add`)
+                            //console.log(`IndexedDBClient: ${counter} records added, ${records.length} left to add`)
                             putRecords.call(this)
                         }, () => {
                             // on error, just skip and go to the next record

--- a/shared/js/indexed-db.js
+++ b/shared/js/indexed-db.js
@@ -36,7 +36,7 @@ class IndexedDBClient {
         this.db = null
 
         this.serverUpdateUrls = {
-            https: 'http://duckduckgo.com/contentblocking.js?l=https'
+            https: 'http://brian.duckduckgo.com/contentblocking.js?l=https-200k'
             // ...add more here
         }
         this.serverUpdateFails = 0
@@ -58,7 +58,15 @@ class IndexedDBClient {
             return console.warn('IndexedDBClient: this.db does not exist')
         }
         const _store = this.db.transaction(objectStore, 'readwrite').objectStore(objectStore)
-        _store.put(record)
+
+        return new Promise((resolve, reject) => {
+            let request = _store.put(record)
+            request.onsuccess = (event) => resolve()
+            request.onerror = (event) => {
+                console.warn(`IndexedDBClient: put() record: ${record}. Error: {event}`)
+                reject()
+            }
+        })
     }
 
     update (objectStore, record) {
@@ -193,20 +201,31 @@ const fetchServerUpdate = {
 'https': { // object store
     '1': function () { // db version
         return new Promise((resolve) => {
+            console.log("IndexedDBClient: Requesting https list from server");
+
             load.JSONfromExternalFile(
                 this.serverUpdateUrls['https'],
                 (data, response) => {
-
                     if (!(data && data.simpleUpgrade && data.simpleUpgrade.top500)) {
                         console.warn('IndexedDBClient: invalid server response')
                         return
                     }
-                    console.log('Updating list: https everywhere')
 
-                    // Insert each record into db
-                    let counter = 1;
-                    data.simpleUpgrade.top500.forEach((host, index) => {
+                    console.log("IndexedDBClient: Received https list from server, inserting into db.")
+                    
+                    let records = data.simpleUpgrade.top500 // shorthand alias
+                    let counter = 0 // counter is just for logging
+                    let finishUpdate = function() {
+                        // sync new etag to storage
+                        const etag = response.getResponseHeader('etag')
+                        if (etag) settings.updateSetting('httpsEverywhereEtag', etag)
+                        console.log("IndexedDBClient: Finished updating https list");
+                        resolve()
+                    }
 
+                    // function we'll call recursively to add each record
+                    let putNextRecord = function() {
+                        let host = records.shift()
                         let record = {
                             host: host,
                             simpleUpgrade: true,
@@ -214,20 +233,28 @@ const fetchServerUpdate = {
                             lastUpdated: new Date().toString()
                         }
 
-                        this.put('https', record)
-                        // console.log(`IndexedDB: Added record to object store https. Record count: ${counter}`)
-                        counter++;
+                        return this.put('https', record)
+                    }
 
-                        // After we've added last record to db
-                        if (index === (data.simpleUpgrade.top500.length - 1)) {
-                            console.log(`IndexedDBClient: ${data.simpleUpgrade.top500.length} records added to https object store`)
-                            // sync new etag to storage
-                            const etag = response.getResponseHeader('etag')
-                            if (etag) settings.updateSetting('httpsEverywhereEtag', etag)
-                            resolve()
+                    // recursively call putNextRecord asynchronously, until
+                    // all of the records from the response have been inserted.
+                    // - any errors are just skipped, not retried
+                    let putRecords = function() {
+                        if (!records.length) {
+                            return finishUpdate.call(this)
                         }
-                    })
 
+                        putNextRecord.call(this).then(() => {
+                            counter++
+                            console.log(`IndexedDBClient: ${counter} records added, ${records.length} left to add`)
+                            putRecords.call(this)
+                        }, () => {
+                            // on error, just skip and go to the next record
+                            putRecords.call(this)
+                        })
+                    }
+
+                    putRecords.call(this)
                 }
             )
         })

--- a/shared/js/indexed-db.js
+++ b/shared/js/indexed-db.js
@@ -215,6 +215,7 @@ const fetchServerUpdate = {
                     
                     let records = data.simpleUpgrade.top500 // shorthand alias
                     let counter = 0 // counter is just for logging
+                    let throttleMS = 20 // amount to wait between puts
                     let finishUpdate = function() {
                         // sync new etag to storage
                         const etag = response.getResponseHeader('etag')
@@ -247,7 +248,9 @@ const fetchServerUpdate = {
                         putNextRecord.call(this).then(() => {
                             counter++
                             //console.log(`IndexedDBClient: ${counter} records added, ${records.length} left to add`)
-                            putRecords.call(this)
+                            window.setTimeout(() => {
+                              putRecords.call(this)
+                            }, throttleMS)
                         }, () => {
                             // on error, just skip and go to the next record
                             putRecords.call(this)


### PR DESCRIPTION
**Reviewer:**
@laurengarcia 

**CC:** 
@nilnilnil 

<!-- Optional fields
**Depends on:**
-->

## Description:
Making the puts async seems to have solve the issues with Chrome freezing and corrupting the db. Loading the large 200k list took a while and hogged CPU...we may want to throttle the puts even more so they can just run in the background over time?

It seems to all be working and upgrading the sites for me? (though I'm not sure how to fully test).

FYI -- I branched off #4 (Chrome https sync changes), not master.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

  
  