### PR TITLE
Use singular when there's only 1 tracker

### DIFF
--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -35,10 +35,11 @@ function getReasons (site) {
   // only show a message if there's any blocked
   const numTrackerNetworks = site.trackerNetworks.length
   const foundOrBlocked = site.isWhitelisted || numTrackerNetworks === 0 ? 'Found' : 'Blocked'
+  const networkOrNetworks = (site.totalTrackersCount === 1) ? 'Network' : 'Networks'
   if (numTrackerNetworks) {
     reasons.push({
       modifier: 'bad',
-      msg: `${numTrackerNetworks} Tracker Networks ${foundOrBlocked}`
+      msg: `${numTrackerNetworks} Tracker ${networkOrNetworks} ${foundOrBlocked}`
     })
   }
 

--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -1,4 +1,5 @@
 const statusList = require('./status-list.es6.js')
+const trackerNetworksText = require('./tracker-networks-text.es6.js')
 
 module.exports = function (site) {
   const reasons = getReasons(site)
@@ -31,15 +32,12 @@ function getReasons (site) {
     })
   }
 
-  // tracking networks blocked,
-  // only show a message if there's any blocked
-  const numTrackerNetworks = site.trackerNetworks.length
-  const foundOrBlocked = site.isWhitelisted || numTrackerNetworks === 0 ? 'Found' : 'Blocked'
-  const networkOrNetworks = (site.totalTrackersCount === 1) ? 'Network' : 'Networks'
-  if (numTrackerNetworks) {
+  // tracking networks blocked or found,
+  // only show a message if there's any
+  if (site.totalTrackerNetworks !== 0) {
     reasons.push({
       modifier: 'bad',
-      msg: `${numTrackerNetworks} Tracker ${networkOrNetworks} ${foundOrBlocked}`
+      msg: `${trackerNetworksText(site)}`
     })
   }
 

--- a/shared/js/ui/templates/shared/tracker-networks-text.es6.js
+++ b/shared/js/ui/templates/shared/tracker-networks-text.es6.js
@@ -1,0 +1,19 @@
+const bel = require('bel')
+
+module.exports = function (site) {
+  const networkOrNetworks = (site.totalTrackersCount === 1) ? 'Network' : 'Networks'
+
+  const text = site.totalTrackersCount + ' Tracker ' + networkOrNetworks + ' ' + trackersBlockedOrFound(site)
+  return bel`${text}`
+}
+
+function trackersBlockedOrFound (site) {
+  let msg = ''
+  if (site &&
+     (site.isWhitelisted || site.trackerNetworks.length === 0)) {
+    msg = 'Found'
+  } else {
+    msg = 'Blocked'
+  }
+  return bel`${msg}`
+}

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -61,7 +61,7 @@ module.exports = function () {
     const isActive = !isWhitelisted ? 'is-active' : ''
     const foundOrBlocked = isWhitelisted || trackersCount === 0 ? 'Found' : 'Blocked'
     const networkOrNetworks = (trackersCount === 1) ? 'Network' : 'Networks'
-    
+
     return bel`<a href="#" class="js-site-show-page-trackers site-info__trackers link-secondary bold">
       <span class="site-info__trackers-status__icon
           icon-${trackerNetworksIcon(site, isWhitelisted)}"></span>

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -2,6 +2,7 @@ const bel = require('bel')
 const toggleButton = require('./shared/toggle-button.es6.js')
 const ratingHero = require('./shared/rating-hero.es6.js')
 const trackerNetworksIcon = require('./shared/tracker-network-icon.es6.js')
+const trackerNetworksText = require('./shared/tracker-networks-text.es6.js')
 
 module.exports = function () {
   const tosdrMsg = (this.model.tosdr && this.model.tosdr.message) ||
@@ -39,10 +40,7 @@ module.exports = function () {
     </li>
     <li class="site-info__li--trackers padded border--bottom">
       <a href="#" class="js-site-tracker-networks link-secondary bold">
-        ${renderTrackerNetworks(
-            this.model.siteRating,
-            this.model.totalTrackersCount,
-            this.model.isWhitelisted)}
+        ${renderTrackerNetworks(this.model)}
       </a>
     </li>
     <li class="site-info__li--privacy-practices padded border--bottom">
@@ -57,15 +55,13 @@ module.exports = function () {
   </ul>
   </section>`
 
-  function renderTrackerNetworks (site, trackersCount, isWhitelisted) {
-    const isActive = !isWhitelisted ? 'is-active' : ''
-    const foundOrBlocked = isWhitelisted || trackersCount === 0 ? 'Found' : 'Blocked'
-    const networkOrNetworks = (trackersCount === 1) ? 'Network' : 'Networks'
+  function renderTrackerNetworks (model) {
+    const isActive = !model.isWhitelisted ? 'is-active' : ''
 
     return bel`<a href="#" class="js-site-show-page-trackers site-info__trackers link-secondary bold">
       <span class="site-info__trackers-status__icon
-          icon-${trackerNetworksIcon(site, isWhitelisted)}"></span>
-      <span class="${isActive} text-line-after-icon"> ${trackersCount} Tracker ${networkOrNetworks} ${foundOrBlocked}</span>
+          icon-${trackerNetworksIcon(model.siteRating, model.isWhitelisted)}"></span>
+      <span class="${isActive} text-line-after-icon"> ${trackerNetworksText(model)} </span>
       <span class="icon icon__arrow pull-right"></span>
     </a>`
   }

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -60,11 +60,12 @@ module.exports = function () {
   function renderTrackerNetworks (site, trackersCount, isWhitelisted) {
     const isActive = !isWhitelisted ? 'is-active' : ''
     const foundOrBlocked = isWhitelisted || trackersCount === 0 ? 'Found' : 'Blocked'
-
+    const networkOrNetworks = (trackersCount === 1) ? 'Network' : 'Networks'
+    
     return bel`<a href="#" class="js-site-show-page-trackers site-info__trackers link-secondary bold">
       <span class="site-info__trackers-status__icon
           icon-${trackerNetworksIcon(site, isWhitelisted)}"></span>
-      <span class="${isActive} text-line-after-icon"> ${trackersCount} Tracker Networks ${foundOrBlocked}</span>
+      <span class="${isActive} text-line-after-icon"> ${trackersCount} Tracker ${networkOrNetworks} ${foundOrBlocked}</span>
       <span class="icon icon__arrow pull-right"></span>
     </a>`
   }

--- a/shared/js/ui/templates/tracker-networks.es6.js
+++ b/shared/js/ui/templates/tracker-networks.es6.js
@@ -32,11 +32,12 @@ module.exports = function () {
 
 function renderHero (model) {
   const site = model.site || {}
+  const networkOrNetworks = (site.totalTrackersCount === 1) ? 'Network' : 'Networks'
 
   return bel`${hero({
     status: trackerNetworksIcon(site.siteRating, site.isWhitelisted),
     title: site.domain,
-    subtitle: `${site.totalTrackersCount} Tracker Networks ${trackersBlockedOrFound(model)}`,
+    subtitle: `${site.totalTrackersCount} Tracker ${networkOrNetworks} ${trackersBlockedOrFound(model)}`,
     showClose: true
   })}`
 }

--- a/shared/js/ui/templates/tracker-networks.es6.js
+++ b/shared/js/ui/templates/tracker-networks.es6.js
@@ -1,6 +1,7 @@
 const bel = require('bel')
 const hero = require('./shared/hero.es6.js')
 const trackerNetworksIcon = require('./shared/tracker-network-icon.es6.js')
+const trackerNetworksText = require('./shared/tracker-networks-text.es6.js')
 
 module.exports = function () {
   if (!this.model) {
@@ -10,7 +11,7 @@ module.exports = function () {
   } else {
     return bel`<div class="tracker-networks site-info site-info--full-height card">
       <div class="js-tracker-networks-hero">
-        ${renderHero(this.model)}
+        ${renderHero(this.model.site)}
       </div>
       <div class="tracker-networks__explainer padded border--bottom--inner
           text--center">
@@ -30,27 +31,15 @@ module.exports = function () {
   }
 }
 
-function renderHero (model) {
-  const site = model.site || {}
-  const networkOrNetworks = (site.totalTrackersCount === 1) ? 'Network' : 'Networks'
+function renderHero (site) {
+  site = site || {}
 
   return bel`${hero({
     status: trackerNetworksIcon(site.siteRating, site.isWhitelisted),
     title: site.domain,
-    subtitle: `${site.totalTrackersCount} Tracker ${networkOrNetworks} ${trackersBlockedOrFound(model)}`,
+    subtitle: `${trackerNetworksText(site)}`,
     showClose: true
   })}`
-}
-
-function trackersBlockedOrFound (model) {
-  let msg = ''
-  if (model.site &&
-     (model.site.isWhitelisted || model.site.trackerNetworks.length === 0)) {
-    msg = 'Found'
-  } else {
-    msg = 'Blocked'
-  }
-  return bel`${msg}`
 }
 
 function renderTrackerDetails (companyListMap, DOMAIN_MAPPINGS) {

--- a/shared/js/ui/views/tracker-networks.es6.js
+++ b/shared/js/ui/views/tracker-networks.es6.js
@@ -63,7 +63,7 @@ TrackerNetworks.prototype = window.$.extend({},
         )
 
         const blockedOrFound = this.model.site.isWhitelisted ? 'Found' : 'Blocked'
-        const networkOrNetworks = (this.model.site.totalTrackersCount === 1) ?  'Network' : 'Networks'
+        const networkOrNetworks = (this.model.site.totalTrackersCount === 1) ? 'Network' : 'Networks'
 
         this.$hero.html(heroTemplate({
           status: trackerNetworksIconName,

--- a/shared/js/ui/views/tracker-networks.es6.js
+++ b/shared/js/ui/views/tracker-networks.es6.js
@@ -63,11 +63,12 @@ TrackerNetworks.prototype = window.$.extend({},
         )
 
         const blockedOrFound = this.model.site.isWhitelisted ? 'Found' : 'Blocked'
+        const networkOrNetworks = (this.model.site.totalTrackersCount === 1) ?  'Network' : 'Networks'
 
         this.$hero.html(heroTemplate({
           status: trackerNetworksIconName,
           title: this.model.site.domain,
-          subtitle: this.model.site.totalTrackersCount + ' Tracker Networks ' + blockedOrFound,
+          subtitle: this.model.site.totalTrackersCount + ' Tracker ' + networkOrNetworks + ' ' + blockedOrFound,
           showClose: true
         }))
       }

--- a/shared/js/ui/views/tracker-networks.es6.js
+++ b/shared/js/ui/views/tracker-networks.es6.js
@@ -3,6 +3,7 @@ const heroTemplate = require('./../templates/shared/hero.es6.js')
 const CompanyListModel = require('./../models/site-company-list.es6.js')
 const SiteModel = require('./../models/site.es6.js')
 const trackerNetworksIconTemplate = require('./../templates/shared/tracker-network-icon.es6.js')
+const trackerNetworksTextTemplate = require('./../templates/shared/tracker-networks-text.es6.js')
 
 function TrackerNetworks (ops) {
   // model data is async
@@ -62,13 +63,12 @@ TrackerNetworks.prototype = window.$.extend({},
           this.model.site.isWhitelisted
         )
 
-        const blockedOrFound = this.model.site.isWhitelisted ? 'Found' : 'Blocked'
-        const networkOrNetworks = (this.model.site.totalTrackersCount === 1) ? 'Network' : 'Networks'
+        const trackerNetworksText = trackerNetworksTextTemplate(this.model.site)
 
         this.$hero.html(heroTemplate({
           status: trackerNetworksIconName,
           title: this.model.site.domain,
-          subtitle: this.model.site.totalTrackersCount + ' Tracker ' + networkOrNetworks + ' ' + blockedOrFound,
+          subtitle: trackerNetworksText,
           showClose: true
         }))
       }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Small PR as a followup to #14: addressing the case when only 1 tracker is detected.
Text should say "Tracker Network" instead of "Tracker Networks" in that case.
<img width="301" alt="screen shot 2018-01-12 at 9 04 57 am" src="https://user-images.githubusercontent.com/3652195/34878457-3f7985d6-f778-11e7-8a86-a91e9ecbf674.png">


<img width="301" alt="screen shot 2018-01-12 at 8 56 21 am" src="https://user-images.githubusercontent.com/3652195/34878458-3fa04590-f778-11e7-8d30-26a3ecd2abd3.png">




## Steps to test this PR:
1. Build and reload extension
2. Visit a site with one tracker, like https://submit.pandora.com/
3. There should be one tracker, and singular should be used in the main popup, in the tracker networks subview, and in the grade scorecard
4. Visit other sites with more trackers and make sure plural is used in that case


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
