### PR TITLE
Set timeout for rerendering the top blocked pills

### DIFF
--- a/shared/js/ui/views/top-blocked-truncated.es6.js
+++ b/shared/js/ui/views/top-blocked-truncated.es6.js
@@ -9,7 +9,7 @@ function TruncatedTopBlocked (ops) {
 
   this.model.getTopBlocked().then(() => {
     Parent.call(this, ops)
-    this.rerenderList()
+    this._setup()
   })
 
   this.bindEvents([

--- a/shared/js/ui/views/top-blocked-truncated.es6.js
+++ b/shared/js/ui/views/top-blocked-truncated.es6.js
@@ -6,10 +6,9 @@ function TruncatedTopBlocked (ops) {
   this.model = ops.model
   this.pageView = ops.pageView
   this.template = ops.template
-  Parent.call(this, ops)
 
   this.model.getTopBlocked().then(() => {
-    setTimeout(() => this.rerenderList(), 750)
+    Parent.call(this, ops)
     this.rerenderList()
   })
 

--- a/shared/js/ui/views/top-blocked-truncated.es6.js
+++ b/shared/js/ui/views/top-blocked-truncated.es6.js
@@ -9,6 +9,7 @@ function TruncatedTopBlocked (ops) {
   Parent.call(this, ops)
 
   this.model.getTopBlocked().then(() => {
+    setTimeout(() => this.rerenderList(), 750)
     this.rerenderList()
   })
 
@@ -45,6 +46,7 @@ TruncatedTopBlocked.prototype = window.$.extend({},
 
       if (message.action === 'didResetTrackersData') {
         this.model.reset()
+        setTimeout(() => this.rerenderList(), 750)
         this.rerenderList()
       }
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fix for Firefox flashing an empty state for the top blocked networks in the main popup.

## Steps to test this PR:
1. Build and reload extension
2. Visit heavy tracker sites, like alternet.org or msnbc.com
3. Open the popup and make sure the top blocked part doesn't jump or flash empty states
4. Reset global stats and repeat 


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
