### PR TITLE
Default Google remapping to Analytics

### DIFF
--- a/scripts/importers/companyList.js
+++ b/scripts/importers/companyList.js
@@ -83,6 +83,7 @@ global.companyList = function (listData) {
     function remapGoogle(type, name, url){
         var newType;
         if(name === 'Google'){
+            newType = 'Analytics' // default to Analytics
             Object.keys(remapData).some( function(category) {
                 if(remapData[category][0]['Google']['http://www.google.com/'].indexOf(url) !== -1){
                     return newType = category;

--- a/shared/data/tracker_lists/trackersWithParentCompany.json
+++ b/shared/data/tracker_lists/trackersWithParentCompany.json
@@ -222,7 +222,7 @@
         },
         "googletagmanager.com": {
             "c": "Google",
-            "t": "Disconnect"
+            "t": "Analytics"
         },
         "backtype.com": {
             "c": "Twitter",
@@ -7175,6 +7175,10 @@
         "postrank.com": {
             "c": "Google",
             "u": "http://www.google.com/"
+        },
+        "googletagmanager.com": {
+            "c": "Google",
+            "u": "http://www.google.com/"
         }
     },
     "Social": {
@@ -7441,12 +7445,6 @@
         "reddit.com": {
             "c": "reddit",
             "u": "http://www.reddit.com/"
-        }
-    },
-    "Disconnect": {
-        "googletagmanager.com": {
-            "c": "Google",
-            "u": "http://www.google.com/"
         }
     }
 }


### PR DESCRIPTION
**Reviewer:**
@russellholt @jdorweiler @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
There's one url ('googletagmanager.com') that isn't in this google mapping list: https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/master/scripts/importers/companyList.js#L6

As a result it was defaulting to 'Disconnect', which was preventing it from showing in the Google section. This change just defaults the category to 'Analytics' in the Google mapping function (not sure if that's right), to make sure everything maps over from Disconnect into one of the other categories.

nytimes.com before:
![screen shot 2018-01-15 at 11 49 56 am](https://user-images.githubusercontent.com/126358/34958980-2a14185a-fa02-11e7-8bbe-f08f68dedfc5.png)

nytimes.com after:
![screen shot 2018-01-15 at 2 40 39 pm](https://user-images.githubusercontent.com/126358/34958993-31d5c714-fa02-11e7-8d3d-4a155f92d940.png)



## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
