### PR TITLE
Add major missing trackers from disconnect list

### DIFF
--- a/scripts/importers/companyList.js
+++ b/scripts/importers/companyList.js
@@ -12,6 +12,17 @@ var trackerTypes = ['Advertising', 'Analytics', 'Disconnect', 'Social']
 var remapData
 var companyList
 
+// For launch, there are some very common trackers that it would be better to show broken out
+// by company, but they're not in the Disconnect list, so temporarily adding them here:
+const additionalMappings = [
+    ['Advertising', { c: 'Twitter', u: 'https://static.ads-twitter.com/'}, 'static.ads-twitter.com' ],
+    ['Advertising', { c: 'Twitter', u: 'https://syndication.twitter.com/'}, 'syndication.twitter.com' ],
+    ['Advertising', { c: 'Twitter', u: 'https://analytics.twitter.com/'}, 'analytics.twitter.com' ],
+    ['Advertising', { c: 'Facebook', u: 'https://connect.facebook.net/'}, 'connect.facebook.net' ],
+    ['Advertising', { c: 'Pinterest', u: 'https://ct.pinterest.com/'}, 'ct.pinterest.com' ],
+    ['Analytics', { c: 'Optimizely', u: 'https://cdn.optimizely.com/'}, 'cdn.optimizely.com' ]
+];
+
 global.companyList = function (listData) {
     return new Promise ((resolve) => {
         request.get(remapDataLoc, (err, res, body) => {
@@ -40,6 +51,10 @@ global.companyList = function (listData) {
                         }
                     });
                 });
+
+                additionalMappings.forEach(function(item) {
+                    addToList(item[0], item[2], item[1])
+                })
 
                 resolve({'name': 'trackersWithParentCompany.json', 'data': trackerList})
             })

--- a/shared/data/tracker_lists/trackersWithParentCompany.json
+++ b/shared/data/tracker_lists/trackersWithParentCompany.json
@@ -247,6 +247,22 @@
         "twitter.jp": {
             "c": "Twitter",
             "t": "Social"
+        },
+        "static.ads-twitter.com": {
+            "c": "Twitter",
+            "t": "Advertising"
+        },
+        "syndication.twitter.com": {
+            "c": "Twitter",
+            "t": "Advertising"
+        },
+        "analytics.twitter.com": {
+            "c": "Twitter",
+            "t": "Advertising"
+        },
+        "connect.facebook.net": {
+            "c": "Facebook",
+            "t": "Advertising"
         }
     },
     "Advertising": {
@@ -6145,6 +6161,26 @@
         "ytsa.net": {
             "c": "Google",
             "u": "http://www.google.com/"
+        },
+        "static.ads-twitter.com": {
+            "c": "Twitter",
+            "u": "https://static.ads-twitter.com/"
+        },
+        "syndication.twitter.com": {
+            "c": "Twitter",
+            "u": "https://syndication.twitter.com/"
+        },
+        "analytics.twitter.com": {
+            "c": "Twitter",
+            "u": "https://analytics.twitter.com/"
+        },
+        "connect.facebook.net": {
+            "c": "Facebook",
+            "u": "https://connect.facebook.net/"
+        },
+        "ct.pinterest.com": {
+            "c": "Pinterest",
+            "u": "https://ct.pinterest.com/"
         }
     },
     "Analytics": {
@@ -7175,6 +7211,10 @@
         "postrank.com": {
             "c": "Google",
             "u": "http://www.google.com/"
+        },
+        "cdn.optimizely.com": {
+            "c": "Optimizely",
+            "u": "https://cdn.optimizely.com/"
         }
     },
     "Social": {


### PR DESCRIPTION
**Reviewer:**
@russellholt 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Adding a handful of pretty common trackers across the top 20 sites from major companies, but not in the disconnect list.

I'm sure we could do this in a more elegant way, up to you if you think it's worth the time now.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
