### PR TITLE
prevent https redirect loops in safari

### DIFF
--- a/browsers/duckduckgo.safariextension/js/background.js
+++ b/browsers/duckduckgo.safariextension/js/background.js
@@ -162,12 +162,24 @@ var onBeforeNavigation = function (e) {
     // skip upgrading broken sites:
     if (thisTab.site.isBroken) {
         console.log('HTTPS: temporarily skip upgrades for: ' + url)
+
+        // e.preventDefault() here prevents broken
+        // sites from loading via autocomplete. It comes
+        // with the downside that it resets the omnibar 
+        // back to what it's state was before they started typing when ,
+        // but this is probably better than autoloading a site?
+        e.preventDefault()
+
         return
     }
 
     // skip trying again if we've already tried upgrading this url
     if (thisTab.hasUpgradedUrlAlready(url)) {
         console.log('HTTPS: skipping upgrade to avoid redirect loops', url)
+
+        // same as the block above
+        e.preventDefault()
+
         return
     }
 

--- a/browsers/duckduckgo.safariextension/js/background.js
+++ b/browsers/duckduckgo.safariextension/js/background.js
@@ -134,9 +134,9 @@ var onBeforeRequest = function (requestData) {
  * check whether we should upgrade to https
  */
 var onBeforeNavigation = function (e) {
-    if (!e.url || !e.target || e.target.url === 'about:blank' || e.url.match(/com.duckduckgo.safari/)) return
-
     //console.log(`onBeforeNavigation ${e.url} ${e.target.url}`)
+
+    if (!e.url || !e.target || e.target.url === 'about:blank' || e.url.match(/com.duckduckgo.safari/)) return
 
     const url = e.url
     const isMainFrame = true // always main frame in this handler
@@ -192,7 +192,6 @@ var onBeforeNavigation = function (e) {
 
         e.preventDefault()
         e.target.url = upgradedUrl
-        return
     }
 }
 

--- a/browsers/duckduckgo.safariextension/js/tab.js
+++ b/browsers/duckduckgo.safariextension/js/tab.js
@@ -127,8 +127,20 @@ class Tab {
         }
     };
 
-    addHttpsUpgradeRequest (url) {
-        this.httpsRequests.push(url)
+    addHttpsUpgradeRequest (upgradedUrl, originalUrl) {
+        this.httpsRequests.push(upgradedUrl)
+
+        // keep track on the safari tab:
+        let safariTab = this.getSafariTab()
+        if (!safariTab.ddgHttpsRedirects) {
+            safariTab.ddgHttpsRedirects = {}
+        }
+        safariTab.ddgHttpsRedirects[originalUrl] = 1
+    }
+
+    hasUpgradedUrlAlready (url) {
+        let safariTab = this.getSafariTab()
+        return safariTab.ddgHttpsRedirects && safariTab.ddgHttpsRedirects[url]
     }
 
     downgradeHttpsUpgradeRequest (reqData) {
@@ -154,6 +166,20 @@ class Tab {
             const downgrade = this.url.replace(/^https:\/\//i, 'http://')
             //chrome.tabs.update(this.id, { url: downgrade })
         }
+    }
+
+    getSafariTab () {
+        if (this._safariTab) { return this._safariTab }
+
+        safari.application.browserWindows.some((w) => {
+            return w.tabs.some((t) => {
+                if (t.ddgTabId === this.id) {
+                    return this._safariTab = t
+                }
+            })
+        })
+
+        return this._safariTab
     }
 
     endStopwatch () {

--- a/browsers/duckduckgo.safariextension/js/tab.js
+++ b/browsers/duckduckgo.safariextension/js/tab.js
@@ -156,17 +156,17 @@ class Tab {
     }
 
     getSafariTab () {
-        if (this._safariTab) { return this._safariTab }
+        let safariTab
 
         safari.application.browserWindows.some((w) => {
             return w.tabs.some((t) => {
                 if (t.ddgTabId === this.id) {
-                    return this._safariTab = t
+                    return safariTab = t
                 }
             })
         })
 
-        return this._safariTab
+        return safariTab
     }
 
     endStopwatch () {

--- a/browsers/duckduckgo.safariextension/js/tabManager.js
+++ b/browsers/duckduckgo.safariextension/js/tabManager.js
@@ -101,13 +101,6 @@ class TabManager {
 var tabManager = new TabManager();
 
 var closeHandler = function (e) {
-    // only want to delete the tab
-    // when it's being closed. This handler will get
-    // called when the url is changing in the tab
-    // and we don't want to delete it here in those cases
-    // or it breaks things like https upgrades:
-    if (e.type !== 'close') return
-
     let tabId = tabManager.getTabId(e)
     if (tabId) tabManager.delete(tabId)
 }

--- a/browsers/duckduckgo.safariextension/js/tabManager.js
+++ b/browsers/duckduckgo.safariextension/js/tabManager.js
@@ -141,7 +141,7 @@ safari.application.addEventListener('beforeSearch', (e) => {
     }
 }, false)
 
-// rebuild cached tabs
+// called when a page has successfully loaded:
 safari.application.addEventListener('navigate', ((e) => {
     let tabId = e.target.ddgTabId
     let tab = tabManager.get({tabId: tabId})
@@ -165,6 +165,11 @@ safari.application.addEventListener('navigate', ((e) => {
         // stash data in safari tab to handle cached pages
         if(!e.target.ddgCache) e.target.ddgCache = {}
         e.target.ddgCache[tab.url] = tab
+
+        // after the page successfully loads, clear
+        // out the https redirect cache so we don't prevent
+        // subsequent pageloads from being upgraded:
+        delete e.target.ddgHttpsRedirects
     }
     else {
         utils.setBadgeIcon('img/ddg-icon.png', e.target)

--- a/browsers/duckduckgo.safariextension/js/tabManager.js
+++ b/browsers/duckduckgo.safariextension/js/tabManager.js
@@ -33,13 +33,13 @@ class TabManager {
      * 3. When we get a new main_frame request
      */
     create(tabData) {
-        console.log(`CREATE TAB: ${tabData.url}`)
         // when it's created from a message event, use tabData.message.currentURL, but
         // when it's created from a beforeNavigation event, message object won't exist, so use tabData.url:
         let url = tabData.message ? tabData.message.currentURL : tabData.url
         let createTabData = {url: url, id: tabManager.getTabId(tabData)}
         createTabData.target = tabData.target
         
+        console.log(`CREATE TAB: ${url}`)
         console.log(createTabData)
 
         let newTab = new Tab(createTabData);
@@ -101,6 +101,13 @@ class TabManager {
 var tabManager = new TabManager();
 
 var closeHandler = function (e) {
+    // only want to delete the tab
+    // when it's being closed. This handler will get
+    // called when the url is changing in the tab
+    // and we don't want to delete it here in those cases
+    // or it breaks things like https upgrades:
+    if (e.type !== 'close') return
+
     let tabId = tabManager.getTabId(e)
     if (tabId) tabManager.delete(tabId)
 }


### PR DESCRIPTION
**Reviewer:**
@jdorweiler @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
https://app.asana.com/0/72649045549333/524358648218923


## Steps to test this PR:
adobe.com --> should upgrade as usual
businessinsider.com --> shouldn't get stuck in redirect loop, should just fallback to using http

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
