### PR TITLE
Remove safari abp preprocessing from Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,9 +52,6 @@ module.exports = function(grunt) {
         safari: {ui: {
                 '<%= dirs.public.js %>/base.js': ['browsers/duckduckgo.safariextension/js/ui/base/index.es6.js'],
         }, 
-        background: { 
-            '<%= dirs.src.js %>/abp.js': ['browsers/duckduckgo.safariextension/js/abp-preprocessed.es6.js'],
-        }, 
         sass: {}}
     }
 


### PR DESCRIPTION
**Reviewer:**
@jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
I missed this in #40 and it's preventing abp.js from generating correctly for Safari. Removing this line seems to fix it.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
