### PR TITLE
Missing period in privacy practices subview

### DIFF
--- a/shared/js/ui/templates/privacy-practices.es6.js
+++ b/shared/js/ui/templates/privacy-practices.es6.js
@@ -67,7 +67,7 @@ function renderNoDetails () {
       No Privacy Practices Found
     </h1>
     <div class="privacy-practices__details__msg">
-      The Privacy practices of this website have not been reviewed
+      The Privacy practices of this website have not been reviewed.
     </div>
   </div>`
 }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Add missing punctuation in the privacy practices subview, for when the site has not been reviewed
<img width="303" alt="screen shot 2018-01-16 at 2 49 33 pm" src="https://user-images.githubusercontent.com/3652195/35009046-7f53e80c-facc-11e7-80ce-e69b8bc2bd4d.png">


## Steps to test this PR:
1. Build and reload extension
2. Visit website with mixed privacy practices like github.com
3. The text in the privacy practices subview should end with a period after "review"


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
