### PR TITLE
migrate atb

### DIFF
--- a/shared/js/atb.js
+++ b/shared/js/atb.js
@@ -130,9 +130,17 @@ var ATB = (() => {
         },
 
         onInstalled: () => {
-            ATB.setInitialVersions()
             // wait until settings is ready to try and get atb from the page
-            settings.ready().then(() => ATB.inject())
+            settings.ready().then(() => {
+                ATB.inject()
+
+                // migrate localStorage ATB from the old extension over to settings
+                if(!settings.getSetting('atb') && localStorage['atb']) {
+                    settings.updateSetting('atb', localStorage['atb'])
+                }
+                
+                ATB.setInitialVersions()
+            })
         },
 
         getSurveyURL: () => {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
The old chrome extension store atb values in localStorage. We need to move these over to settings in-order to keep atb working.

## Steps to test this PR:
You can setup different test conditions through the extension console:

1. User with old extension who is upgrading 
```
settings.updateSetting('atb', '')
localStorage['atb'] = 'v1-1'
```
Reload the extension and do a search. You should see that 'v1-1' is appended to the url

2. User who already has the new extension and doesn't need to migrate
```
settings.updateSetting('atb', 'v2-1')
localStorage['atb'] = 'v1-1'
```
Reload the extension and do a search. You should see that 'v2-1' is appended to the url

3. User who is installing from the chrome store should have atb generated automatically
```
settings.updateSetting('atb', '')
localStorage['atb'] = ''
```
Reload the extension and do a search. You should see that 'v100-1' is appended to the url. The actual value depends on the date. This is set by `ATB.setInitialVersions()`


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
