### PR TITLE
Fix hero subtitle jumping in main popup

### DIFF
--- a/shared/scss/_mixins.scss
+++ b/shared/scss/_mixins.scss
@@ -50,9 +50,6 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     font-weight: bold;
-    height: 20px;
-    line-height: 21px;
-    text-align: center;
 }
 
 .uppercase {

--- a/shared/scss/_mixins.scss
+++ b/shared/scss/_mixins.scss
@@ -50,6 +50,9 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     font-weight: bold;
+    height: 20px;
+    line-height: 21px;
+    text-align: center;
 }
 
 .uppercase {

--- a/shared/scss/views/_hero.scss
+++ b/shared/scss/views/_hero.scss
@@ -25,6 +25,9 @@
 .hero__subtitle {
     padding-top: 6px;
     @include uppercase_label();
+    height: 20px;
+    line-height: 21px;
+    text-align: center;
 }
 
 .hero__close {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Adding fixed height and line height to prevent the subtitle from looking like it jumps down, whenever we enhancing a site


## Steps to test this PR:
1. Build and reload extension
2. Test on sites with trackers such as msnbc.com or youtube.com - open the popup immediately while the page is still loading
3. The text should switch seamlessly from "calculating" to "privacy grade" to "enhanced from ... to ..." without jumping


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
