### PR TITLE
Sanity check data before adding companies from storage

### DIFF
--- a/shared/js/companies.js
+++ b/shared/js/companies.js
@@ -108,10 +108,6 @@ var Companies = (() => {
 
         sanitizeData: (storageData) => {
             if (storageData.hasOwnProperty('twitter')) {
-              let twitterData = storageData.Twitter || {count: 0, name: 'Twitter',  pagesSeenOn: 0}
-              twitterData.count = (twitterData.count + storageData.twitter.count) || 0
-              twitterData.pagesSeenOn = (twitterData.pagesSeenOn + storageData.twitter.pagesSeenOn) || 0
-              storageData.Twitter = twitterData
               delete storageData.twitter
             }
             return storageData

--- a/shared/js/companies.js
+++ b/shared/js/companies.js
@@ -106,8 +106,22 @@ var Companies = (() => {
             utils.syncToStorage({'lastStatsResetDate': lastStatsResetDate})
         },
 
+        sanitizeData: (storageData) => {
+            if (storageData.hasOwnProperty('twitter')) {
+              let twitterData = storageData.Twitter || {count: 0, name: 'Twitter',  pagesSeenOn: 0}
+              twitterData.count = (twitterData.count + storageData.twitter.count) || 0
+              twitterData.pagesSeenOn = (twitterData.pagesSeenOn + storageData.twitter.pagesSeenOn) || 0
+              storageData.Twitter = twitterData
+              delete storageData.twitter
+            }
+            return storageData
+        },
+
         buildFromStorage: () => {
             utils.getFromStorage(storageName, function (storageData) {
+                // uncomment for testing
+                //storageData.twitter = {count: 10, name: 'twitter', pagesSeenOn: 10}
+                storageData = Companies.sanitizeData(storageData)
                 for (company in storageData) {
                     let newCompany = Companies.add(company)
                     newCompany.set('count', storageData[company].count || 0)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 


**CC:** @jdorweiler 
<!-- Optional fields
**Depends on:** 
-->

## Description:
Followup from #11 - now sanity check and update old data to avoid showing that double header in the top blocked subview.


## Steps to test this PR:
1. Uncomment line 123 in shared/js/companies.js (adds "twitter" manually to the data), add console logs to show the storageData where preferred
2. Build and reload extension
3. The "twitter" property should be gone


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
