### PR TITLE
load tosdr in manifest

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -21,6 +21,7 @@
             "scripts": [
                 "data/defaultSettings.js",
                 "data/constants.js",
+                "data/tosdr.js",
                 "js/require.js",
                 "js/load.js",
                 "js/utils.js",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -26,6 +26,7 @@
             "scripts": [
                 "data/defaultSettings.js",
                 "data/constants.js",
+                "data/tosdr.js",
                 "js/require.js",
                 "js/load.js",
                 "js/utils.js",

--- a/scripts/tosdr.js
+++ b/scripts/tosdr.js
@@ -18,7 +18,7 @@ function getSites() {
 
             // recurse through sites list. Get and process the detailed points data for each
             getSitePoints(sites).then(result => {
-                fs.writeFile('shared/data/tosdr.json', JSON.stringify(processed, null, 4), err => { if(err) console.log(err)} )
+                fs.writeFile('shared/data/tosdr.js', 'const tosdr =' + JSON.stringify(processed, null, 4), err => { if(err) console.log(err)} )
             })
     })
 }

--- a/shared/data/tosdr.js
+++ b/shared/data/tosdr.js
@@ -1,4 +1,4 @@
-{
+const tosdr ={
     "youtube.com": {
         "score": 0,
         "all": {

--- a/shared/js/site.js
+++ b/shared/js/site.js
@@ -9,18 +9,10 @@
 var load = require('load')
 var settings = require('settings')
 
-let tosdr
 let tosdrRegexList
-let tosdrListLoaded
 let trackersWhitelistTemporary
 
-settings.ready().then(() => {
-    load.JSONfromLocalFile(constants.tosdr,(data) => {
-        tosdr = data
-        tosdrRegexList = Object.keys(tosdr).map(x => new RegExp(x))
-        tosdrListLoaded = true
-    })
-})
+tosdrRegexList = Object.keys(tosdr).map(x => new RegExp(x))
 
 const siteScores = ['A', 'B', 'C', 'D']
 const pagesSeenOn = constants.majorTrackingNetworks
@@ -42,9 +34,6 @@ class Score {
 
     getTosdr() {
         let result = {}
-
-        // return if the list hasn't been built yet
-        if (!tosdrListLoaded) return result
 
         tosdrRegexList.some(tosdrSite => {
             let match = tosdrSite.exec(this.domain)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
When you restart the browser with saved tabs there can be a race condition between loading tosdr data and tab loading. The result is that sometimes a saved tab will have the wrong grade assigned. 

To fix this I'm just loading tosdr from the manifest. This way we can guarantee it's loaded in time.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 