### PR TITLE
Update hero header background color in the subviews

### DIFF
--- a/shared/js/ui/templates/shared/hero.es6.js
+++ b/shared/js/ui/templates/shared/hero.es6.js
@@ -1,7 +1,7 @@
 const bel = require('bel')
 
 module.exports = function (ops) {
-  return bel`<div class="hero border--bottom text--center js-hero">
+  return bel`<div class="hero border--bottom text--center js-hero silver-bg">
     ${(ops.showClose) ? renderCloseButton() : ''}
     ${(ops.showOpen) ? renderOpenButton() : ''}
     <div class="hero__icon hero__icon--${ops.status}">

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -10,7 +10,7 @@ module.exports = function () {
 
   return bel`<section class="site-info site-info--main">
     <ul class="default-list">
-    <li class="site-info__rating-li silver-bg">
+    <li class="site-info__rating-li">
       ${ratingHero(this.model, {
         showOpen: !this.model.disabled
       })}

--- a/shared/scss/base/base.scss
+++ b/shared/scss/base/base.scss
@@ -17,7 +17,7 @@ html, body {
     min-height: 100%;
 
     &.body--neutral {
-        background: $color--neutral-bg;
+        background: $color--silver;
     }
 }
 

--- a/shared/scss/views/_privacy-practices.scss
+++ b/shared/scss/views/_privacy-practices.scss
@@ -1,6 +1,6 @@
-.privacy-practices {
+#popup-container .site-info.privacy-practices {
     box-sizing: border-box;
-    padding-top: 9px;
+    margin-top: 9px;
 
     .padded {
         padding: 20px;


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Hero background color in the subviews should be gray, like in the main popup view.
I also had to update the neutral gray background color and tweak privacy practices styles to avoid weird differently colored lines from showing in the subviews.


## Steps to test this PR:
1. Build and reload extension
2. Visit a site, open popup
3. Click into the subviews and make sure the hero header has the same gray color as the main popup view


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
