### PR TITLE
Fix line in toggle on disabled state

### DIFF
--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -170,7 +170,7 @@ body {
     }
 
     .site-info--placeholder {
-        height: 332px;
+        height: 340px;
     }
 
     .site-info {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
The placeholder was too short and it shows through because of 0.5 opacity when popup is disabled.
<img width="306" alt="screen shot 2018-01-18 at 5 26 57 pm" src="https://user-images.githubusercontent.com/3652195/35124766-45aa756c-fc75-11e7-88ed-45dd2a68ce2e.png">


## Steps to test this PR:
1. Build and reload extension
2. Open popup in the extension interface page (or any non-website page)
3. Popup should be disabled and look normal


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
