### PR TITLE
fix re-renders in popup disabled state

### DIFF
--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -71,10 +71,12 @@ Site.prototype = window.$.extend({},
     rerender: function () {
       // console.log('[site view] rerender()')
       if (this.model && this.model.disabled) {
-        console.log('.addClass is-disabled')
-        this.$body.addClass('is-disabled')
-        this._rerender()
-        this._setup()
+        if (!this.$body.hasClass('is-disabled')) {
+          console.log('$body.addClass() is-disabled')
+          this.$body.addClass('is-disabled')
+          this._rerender()
+          this._setup()
+        }
       } else {
         this.$body.removeClass('is-disabled')
         this.unbindEvents()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
The popup recently started re-rendering in the disabled state way too much due to `updateTabData` events from the background process. Is/was causing a memory leak for new tabs (disabled state). I've fixed the re-rendering issue, but think I might be only addressing the symptom here, but the memory leak seems to have gone away with this fix. 

Will keep an eye on this.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
