### PR TITLE
Show unknown privacy practices in the grade scorecard

### DIFF
--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -52,13 +52,13 @@ function getReasons (site) {
   }
 
   // privacy practices from tosdr
-  const privacyMessage = site.tosdr && site.tosdr.message
-  if (privacyMessage && privacyMessage !== window.constants.tosdrMessages.unknown) {
-    reasons.push({
-      modifier: privacyMessage.toLowerCase(),
-      msg: `${privacyMessage} Privacy Practices`
-    })
-  }
+  const unknownPractices = window.constants.tosdrMessages.unknown
+  const privacyMessage = (site.tosdr && site.tosdr.message) || unknownPractices
+  const modifier = (privacyMessage === unknownPractices) ? 'bad' : privacyMessage
+  reasons.push({
+    modifier: modifier,
+    msg: `${privacyMessage} Privacy Practices`
+  })
 
   return reasons
 }

--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -54,7 +54,7 @@ function getReasons (site) {
   // privacy practices from tosdr
   const unknownPractices = window.constants.tosdrMessages.unknown
   const privacyMessage = (site.tosdr && site.tosdr.message) || unknownPractices
-  const modifier = (privacyMessage === unknownPractices) ? 'bad' : privacyMessage
+  const modifier = (privacyMessage === unknownPractices) ? 'bad' : privacyMessage.toLowerCase()
   reasons.push({
     modifier: modifier,
     msg: `${privacyMessage} Privacy Practices`


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @laurengarcia 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Previously we were specifically avoiding showing unknown privacy practices in the grade scorecard.
This change shows them with the red "x" icon.
<img width="302" alt="screen shot 2018-01-18 at 7 20 57 pm" src="https://user-images.githubusercontent.com/3652195/35128633-aa035834-fc85-11e7-8181-a5175ca42b5e.png">


## Steps to test this PR:
1.  Build and reload extension
2. Visit site with unknown privacy practices (eg http://www.azfamily.com/)
3. Main popup should sow "unknown privacy practices"
4. Grade scorecard should show a line for "unknown privacy practices" as well, with a red x icon
5. Other privacy practices ratings are displayed correctly as well, depending on the site


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
