### PR TITLE
Add querystring param to https list request for safari

### DIFF
--- a/shared/js/https.js
+++ b/shared/js/https.js
@@ -50,21 +50,28 @@ class HTTPS {
     }
 
     updateList() {
-        console.log("HTTPS: updateList() check if new list exists")
-
         let etag = settings.getSetting('https-etag') || ''
+        let url = constants.httpsUpgradeList
+
+        // for safari append a querystring param so that we can
+        // serve a different list if needed:
+        if (window.safari) {
+            url += '&b=safari'
+        }
+
+        console.log("HTTPS: updateList() check if new list exists at: " + url)
         
         // try to load an updated file from the server, passing
         // in the latest etag we have and only calling the callback
         // with the new file if the etag on the server is different:
         load.loadExtensionFile({
-            url: constants.httpsUpgradeList,
+            url: url,
             source: 'external',
             etag: etag
         }, (data, res) => {
             // This only gets called if the etag is different
             // and it was able to get a new list from the server:
-            console.log("HTTPS: updateList() got updated list from server")
+            console.log("HTTPS: updateList() got updated list from server: ")
 
             let newEtag = res.getResponseHeader('etag') || ''
 

--- a/shared/js/https.js
+++ b/shared/js/https.js
@@ -71,7 +71,7 @@ class HTTPS {
         }, (data, res) => {
             // This only gets called if the etag is different
             // and it was able to get a new list from the server:
-            console.log("HTTPS: updateList() got updated list from server: ")
+            console.log("HTTPS: updateList() got updated list from server")
 
             let newEtag = res.getResponseHeader('etag') || ''
 


### PR DESCRIPTION
**Reviewer:**
@jdorweiler @nilnilnil 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Adds `&b=safari` to https url request for safari so that we can serve a different list to them if we need to.


## Steps to test this PR:
In Safari, you should see the request in the console after a fresh install, where it's using the new url.
In Chrome/FF it should use the same url as before.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
