### PR TITLE
allow sites with missing url field to use first related url

### DIFF
--- a/scripts/tosdr.js
+++ b/scripts/tosdr.js
@@ -62,6 +62,12 @@ function getSitePoints (sites) {
         let servicesUrl = `${githubRepo}/services/${site}.json`
         request.get(servicesUrl, (err, res, body) => {
             let data = JSON.parse(body)
+            // some sites lack the 'url' field, but have
+            // multiple items in the 'urls' field.
+            if (!data.url && relatedUrls) {
+                data.url = relatedUrls.shift()
+            }
+
             if (data.url) {
                 let parsedUrl = tldjs.parse(data.url)
                 processed[parsedUrl.domain] = points


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 


**CC:** @russellholt 

## Description: 
Some sites in tosdr are missing the url field (see https://github.com/tosdr/tosdr.org/blob/master/services/kolabnow.json for example), yet have multiple items in the urls field. This allows us to take the first item from the urls field in place of the url field in this case.
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:

1. pull this down and run `grunt execute:tosdr --browser=chrome --type=dev`, then check shared/data/tosdr.js and search for 'kolab'. there should now be an entry.


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
