### PR TITLE
need lowercase when checking major tracking networks (do not merge yet)

### DIFF
--- a/shared/js/site.js
+++ b/shared/js/site.js
@@ -168,7 +168,7 @@ class Score {
         else if (event.trackerBlocked) {
 
             // tracker is from one of the top blocked companies
-            if (majorTrackingNetworks[event.trackerBlocked.parentCompany]) {
+            if (majorTrackingNetworks[event.trackerBlocked.parentCompany.toLowerCase()]) {
                 this.inMajorTrackingNetwork = true
             }
 


### PR DESCRIPTION
Do not merge

while this fixes a bug, it changes the grade calculation, which needs to be considered in more depth. See #74 

## Description:

major network names are lowercase on constants.js but parent companies are uppercase in `event.trackerBlocked.parentCompany`

this means many sites like reddit.com and thehill.com were being shown as not in a major network in the grade calculation, sometimes.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
