### PR TITLE
Show green icon for tracker networks when 0 found and site whitelisted

### DIFF
--- a/shared/js/ui/templates/shared/tracker-network-icon.es6.js
+++ b/shared/js/ui/templates/shared/tracker-network-icon.es6.js
@@ -1,9 +1,9 @@
 const bel = require('bel')
 
-module.exports = function (siteRating, isWhitelisted) {
+module.exports = function (siteRating, isWhitelisted, totalTrackersCount) {
   let iconNameModifier = 'blocked'
 
-  if (isWhitelisted && (siteRating.before === 'D')) {
+  if (isWhitelisted && (siteRating.before === 'D') && (totalTrackersCount !== 0)) {
     iconNameModifier = 'warning'
   }
 

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -53,7 +53,7 @@ module.exports = function () {
 
     return bel`<a href="#" class="site-info__trackers link-secondary bold">
       <span class="site-info__trackers-status__icon
-          icon-${trackerNetworksIcon(model.siteRating, model.isWhitelisted)}"></span>
+          icon-${trackerNetworksIcon(model.siteRating, model.isWhitelisted, model.totalTrackersCount)}"></span>
       <span class="${isActive} text-line-after-icon"> ${trackerNetworksText(model)} </span>
       <span class="icon icon__arrow pull-right"></span>
     </a>`

--- a/shared/js/ui/templates/tracker-networks.es6.js
+++ b/shared/js/ui/templates/tracker-networks.es6.js
@@ -35,7 +35,7 @@ function renderHero (site) {
   site = site || {}
 
   return bel`${hero({
-    status: trackerNetworksIcon(site.siteRating, site.isWhitelisted),
+    status: trackerNetworksIcon(site.siteRating, site.isWhitelisted, site.totalTrackersCount),
     title: site.domain,
     subtitle: `${trackerNetworksText(site)}`,
     showClose: true

--- a/shared/js/ui/views/tracker-networks.es6.js
+++ b/shared/js/ui/views/tracker-networks.es6.js
@@ -60,7 +60,8 @@ TrackerNetworks.prototype = window.$.extend({},
       if (this.model.site) {
         const trackerNetworksIconName = trackerNetworksIconTemplate(
           this.model.site.siteRating,
-          this.model.site.isWhitelisted
+          this.model.site.isWhitelisted,
+          this.model.site.totalTrackersCount
         )
 
         const trackerNetworksText = trackerNetworksTextTemplate(this.model.site)


### PR DESCRIPTION


<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Tracker network icon should be green when 0 found and site whitelisted, even though the grade is D.
Before we only looked at the grade to make that decision.
<img width="306" alt="screen shot 2018-01-22 at 1 10 15 pm" src="https://user-images.githubusercontent.com/3652195/35236678-21e0c8a8-ff76-11e7-945f-538aa0639805.png">


## Steps to test this PR:

1. Build and reload extension
2. Go to sites like google.com
3. Whitelist the site - the trackers line and subview should show the green icon, because of the 0 trackers found
4. Other cases should work as usual: major trackers found when whitelisted - red icon; not whitelisted or whitelisted with no major trackers, green icon 


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
