### PR TITLE
Don't open post install page if extension is installed from there

### DIFF
--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -77,10 +77,12 @@ function Background() {
     // only show post install page on install
     if (details.reason.match(/install/)) {
         settings.ready().then( () => {
-          if (!settings.getSetting('hasSeenPostInstall')) {
+          const domain = window.location ? window.location.href : ''
+          const postInstallUrl = 'https://www.duckduckgo.com/app'
+          if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(postInstallUrl))) {
             settings.updateSetting('hasSeenPostInstall', true)
             chrome.tabs.create({
-              url: 'https://www.duckduckgo.com/app?post=1'
+              url: postInstallUrl + '?post=1'
             })
           }
         })

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -74,7 +74,9 @@ function Background() {
         ATB.onInstalled();
     }
 
-    // only show post install page on install
+    // only show post install page on install if:
+    // - the user wasn't already looking at the app install page
+    // - the user hasn't seen the page before
     if (details.reason.match(/install/)) {
         settings.ready().then( () => {
             chrome.tabs.query({currentWindow: true, active: true}, function(tabs) { 

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -77,14 +77,16 @@ function Background() {
     // only show post install page on install
     if (details.reason.match(/install/)) {
         settings.ready().then( () => {
-          const domain = window.location ? window.location.href : ''
-          const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
-          if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
-            settings.updateSetting('hasSeenPostInstall', true)
-            chrome.tabs.create({
-              url: 'https://www.duckduckgo.com/app?post=1'
+            chrome.tabs.query({currentWindow: true, active: true}, function(tabs) { 
+                const domain = (tabs && tabs[0]) ? tabs[0].url : ''
+                const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
+                if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
+                    settings.updateSetting('hasSeenPostInstall', true)
+                    chrome.tabs.create({
+                        url: 'https://www.duckduckgo.com/app?post=1'
+                    })
+                }
             })
-          }
         })
     }
 

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -78,11 +78,11 @@ function Background() {
     if (details.reason.match(/install/)) {
         settings.ready().then( () => {
           const domain = window.location ? window.location.href : ''
-          const postInstallUrl = 'https://www.duckduckgo.com/app'
-          if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(postInstallUrl))) {
+          const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
+          if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
             settings.updateSetting('hasSeenPostInstall', true)
             chrome.tabs.create({
-              url: postInstallUrl + '?post=1'
+              url: 'https://www.duckduckgo.com/app?post=1'
             })
           }
         })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 


**CC:** @jagtalon 
<!-- Optional fields
**Depends on:** 
-->

## Description:
As @jagtalon pointed out, no need to open /app if the user installs the extension from there


## Steps to test this PR: 
1. Remove current extension
2. Build and load from this branch
3. Post install page should open as usual
4. Now change `domain` in background.js to be the same as `postInstallUrl`
5. Repeat from step 1 - this time the post install page should NOT open
6. Feel free to `console.log` the domain and inside the if statement for further verification


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 