### PR TITLE
[WIP] Show 1 tracker when site itself is a major tracking network

### DIFF
--- a/shared/js/site.js
+++ b/shared/js/site.js
@@ -29,6 +29,7 @@ class Score {
         this.hasObscureTracker = false
         this.domain = domain
         this.isaMajorTrackingNetwork = this.isaMajorTrackingNetwork()
+        this.majorTrackingNetwork = this.getMajorTrackingNetwork()
         this.tosdr = this.getTosdr()
     }
 
@@ -91,10 +92,28 @@ class Score {
             if (match) {
                 // remove period at end for lookup in pagesSeenOn
                 let name = match[0].slice(0,-1)
+                this.majorTrackingNetwork = name
                 return result = Math.ceil(pagesSeenOn[name] / 10)
             }
         })
         return result
+    }
+    
+            /* is the parent site itself a major tracking network?
+     * minus one grade for each 10% of the top pages this
+     * network is found on.
+     */
+    getMajorTrackingNetwork() {
+        let name = ''
+        pagesSeenOnRegexList.some(network => {
+            let match = network.exec(this.domain)
+            if (match) {
+                // remove period at end
+                return name = match[0].slice(0,-1)
+            }
+        })
+        console.log(name)
+        return name
     }
 
     /*

--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -19,6 +19,7 @@ function Site (attrs) {
   attrs.trackerNetworks = []
   attrs.tosdr = {}
   attrs.isaMajorTrackingNetwork = false
+  attrs.majorTrackingNetwork = ''
   Parent.call(this, attrs)
 
   this.bindEvents([
@@ -46,6 +47,10 @@ Site.prototype = window.$.extend({},
                 this.set(
                   'isaMajorTrackingNetwork',
                   backgroundTabObj.site.score.isaMajorTrackingNetwork
+                )
+                this.set(
+                  'majorTrackingNetwork',
+                  backgroundTabObj.site.score.majorTrackingNetwork
                 )
               }
               this.setSiteProperties()
@@ -167,6 +172,16 @@ Site.prototype = window.$.extend({},
         if (newUserPrivacy !== this.isUserPrivacyUpgraded) {
           this.set('isUserPrivacyUpgraded', newUserPrivacy)
         }
+       
+        console.log(this.majorTrackingNetwork)
+        const newMajorTrackingNetwork = this.getMajorTrackingNetwork()
+        if (newMajorTrackingNetwork !== this.majorTrackingNetwork) {
+          this.set('majorTrackingNetwork', newMajorTrackingNetwork)
+        }
+
+        if ((this.totalTrackersCount === 0) && this.isPartOfMajorTrackingNetwork && this.majorTrackingNetwork) {
+          this.set('totalTrackersCount', 1)
+        }
       }
     },
 
@@ -213,6 +228,13 @@ Site.prototype = window.$.extend({},
         this.trackerNetworks.some((tracker) =>
           window.constants.majorTrackingNetworks[tracker]
         )
+    },
+
+    getMajorTrackingNetwork: function () {
+      console.log(window.constants.majorTrackingNetworks[this.domain])
+      console.log(this.tab.trackers)
+      console.log(this.trackerNetworks)
+      return this.majorTrackingNetwork || window.constants.majorTrackingNetworks[this.domain]
     },
 
     getTrackerNetworksOnPage: function () {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** TBD

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
We're not showing trackers on sites like Google, Facebook, etc. because being them the parent site, we are not blocking them or we'd break the page.
This PR updates the info in the popup to show "1 tracker" on such sites, for clarity.

TODO:
- show tracker name in the trackers subview
- tracker should be "found" and not "blocked" in this case


## Steps to test this PR:
1. Build and reload extension
2. Go to sites like google.com or facebook.com
3. Open the popup - grade should be D and the tracker networks line should show "1 tracker" with the red icon
4. Tracker networks subview should have the red icon as well and list the tracker network


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
