### PR TITLE
Harden HTTPS redirect loop detection

### DIFF
--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -242,9 +242,15 @@ chrome.webRequest.onBeforeRequest.addListener(
             return
         }
 
+        if (thisTab.downgradedUrls[requestData.url]) {
+            console.log('already tried https upgrades for this URL and failed, skip: ' + requestData.url)
+            return
+        }
+
         // Avoid redirect loops
         if (thisTab.httpsRedirects[requestData.requestId] >= 7) {
             console.log('HTTPS: cancel https upgrade. redirect limit exceeded for url: \n' + requestData.url)
+
             return {redirectUrl: thisTab.downgradeHttpsUpgradeRequest(requestData)}
         }
 

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -274,7 +274,6 @@ chrome.webRequest.onBeforeRequest.addListener(
                 thisTab.upgradedHttps = true
                 thisTab.lastInProgressUrl = requestData.url
             }
-            thisTab.addHttpsUpgradeRequest(url)
             return {redirectUrl: url}
         } else {
           return

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -147,7 +147,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                 let newTab = tabManager.create(requestData)
 
                 // persist the last URL the tab was trying to upgrade to HTTPS
-                newTab.lastUpgrade = thisTab && thisTab.lastUpgrade
+                newTab.lastHttpsUpgrade = thisTab && thisTab.lastHttpsUpgrade
                 thisTab = newTab
             }
 
@@ -246,7 +246,7 @@ chrome.webRequest.onBeforeRequest.addListener(
             return
         }
 
-        if (thisTab.downgradedUrls[requestData.url]) {
+        if (thisTab.failedUpgradeUrls[requestData.url]) {
             console.log('already tried https upgrades for this URL and failed, skip:\n' + requestData.url)
             return
         }
@@ -262,9 +262,9 @@ chrome.webRequest.onBeforeRequest.addListener(
         const isMainFrame = requestData.type === 'main_frame' ? true : false
 
         if (isMainFrame &&
-                thisTab.lastUpgrade &&
-                thisTab.lastUpgrade.url === requestData.url &&
-                Date.now() - thisTab.lastUpgrade.time < 1000) {
+                thisTab.lastHttpsUpgrade &&
+                thisTab.lastHttpsUpgrade.url === requestData.url &&
+                Date.now() - thisTab.lastHttpsUpgrade.time < 1000) {
 
             console.log('already tried upgrading this url on this tab a few moments ago ' +
                 'and it didn\'t complete successfully, abort:\n' +
@@ -279,7 +279,7 @@ chrome.webRequest.onBeforeRequest.addListener(
             console.log('HTTPS: upgrade request url to ' + url)
             if (isMainFrame) {
                 thisTab.upgradedHttps = true
-                thisTab.lastUpgrade = {
+                thisTab.lastHttpsUpgrade = {
                     url: requestData.url,
                     time: Date.now()
                 }

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -265,9 +265,11 @@ chrome.webRequest.onBeforeRequest.addListener(
                 thisTab.lastUpgrade &&
                 thisTab.lastUpgrade.url === requestData.url &&
                 Date.now() - thisTab.lastUpgrade.time < 1000) {
+
             console.log('already tried upgrading this url on this tab a few moments ago ' +
                 'and it didn\'t complete successfully, abort:\n' +
                 requestData.url)
+            thisTab.downgradeHttpsUpgradeRequest(requestData)
             return
         }
 

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -247,7 +247,7 @@ chrome.webRequest.onBeforeRequest.addListener(
         }
 
         if (thisTab.downgradedUrls[requestData.url]) {
-            console.log('already tried https upgrades for this URL and failed, skip: ' + requestData.url)
+            console.log('already tried https upgrades for this URL and failed, skip:\n' + requestData.url)
             return
         }
 

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -146,8 +146,8 @@ chrome.webRequest.onBeforeRequest.addListener(
             if (!thisTab || (thisTab.requestId !== requestData.requestId)) {
                 let newTab = tabManager.create(requestData)
 
-                // persist the last URL the tab was trying to load
-                newTab.lastInProgressUrl = thisTab && thisTab.lastInProgressUrl
+                // persist the last URL the tab was trying to upgrade to HTTPS
+                newTab.lastUpgradeInProgressUrl = thisTab && thisTab.lastUpgradeInProgressUrl
                 thisTab = newTab
             }
 
@@ -261,7 +261,7 @@ chrome.webRequest.onBeforeRequest.addListener(
         // Is this request from the tab's main frame?
         const isMainFrame = requestData.type === 'main_frame' ? true : false
 
-        if (isMainFrame && thisTab.lastInProgressUrl === requestData.url) {
+        if (isMainFrame && thisTab.lastUpgradeInProgressUrl === requestData.url) {
             console.log('already tried upgrading this url and it didn\'t complete successfully:\n' + requestData.url)
             return
         }
@@ -272,7 +272,7 @@ chrome.webRequest.onBeforeRequest.addListener(
             console.log('HTTPS: upgrade request url to ' + url)
             if (isMainFrame) {
                 thisTab.upgradedHttps = true
-                thisTab.lastInProgressUrl = requestData.url
+                thisTab.lastUpgradeInProgressUrl = requestData.url
             }
             return {redirectUrl: url}
         } else {

--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -147,7 +147,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                 let newTab = tabManager.create(requestData)
 
                 // persist the last URL the tab was trying to load
-                newTab = thisTab && thisTab.lastInProgressUrl
+                newTab.lastInProgressUrl = thisTab && thisTab.lastInProgressUrl
                 thisTab = newTab
             }
 

--- a/shared/js/tab.js
+++ b/shared/js/tab.js
@@ -52,9 +52,9 @@ class Tab {
         this.trackersBlocked = {}
         this.url = tabData.url
         this.upgradedHttps = false
-        this.downgradedUrls = {}
+        this.failedUpgradeUrls = {}
         this.httpsRedirects = {} // count redirects here in form of: { <requestId>: <count> }
-        this.lastUpgrade = {}
+        this.lastHttpsUpgrade = {}
         this.requestId = tabData.requestId
         this.status = tabData.status
         this.site = new Site(utils.extractHostFromURL(tabData.url))
@@ -129,7 +129,7 @@ class Tab {
         if (reqData.type === 'main_frame') this.upgradedHttps = false
         delete this.httpsRedirects[reqData.requestId]
         const downgrade = reqData.url.replace(/^https:\/\//i, 'http://')
-        this.downgradedUrls[downgrade] = true
+        this.failedUpgradeUrls[downgrade] = true
         return downgrade
     }
 

--- a/shared/js/tab.js
+++ b/shared/js/tab.js
@@ -54,6 +54,7 @@ class Tab {
         this.upgradedHttps = false
         this.downgradedUrls = {}
         this.httpsRedirects = {} // count redirects here in form of: { <requestId>: <count> }
+        this.lastUpgrade = {}
         this.requestId = tabData.requestId
         this.status = tabData.status
         this.site = new Site(utils.extractHostFromURL(tabData.url))

--- a/shared/js/tab.js
+++ b/shared/js/tab.js
@@ -52,7 +52,6 @@ class Tab {
         this.trackersBlocked = {}
         this.url = tabData.url
         this.upgradedHttps = false
-        this.httpsRequests = [] // array of urls we force-upgraded
         this.downgradedUrls = {}
         this.httpsRedirects = {} // count redirects here in form of: { <requestId>: <count> }
         this.requestId = tabData.requestId
@@ -125,10 +124,6 @@ class Tab {
         }
     };
 
-    addHttpsUpgradeRequest (url) {
-        this.httpsRequests.push(url)
-    }
-
     downgradeHttpsUpgradeRequest (reqData) {
         if (reqData.type === 'main_frame') this.upgradedHttps = false
         delete this.httpsRedirects[reqData.requestId]
@@ -148,21 +143,6 @@ class Tab {
         console.log(`tab.status: complete. site took ${this.stopwatch.completeMs/1000} seconds to load.`)
     }
 }
-
-chrome.webRequest.onHeadersReceived.addListener((header) => {
-    let tab = tabManager.get({'tabId': header.tabId})
-
-    // Remove successful & rewritten requests
-    if (tab && header.statusCode < 400) {
-        tab.httpsRequests = tab.httpsRequests.filter((url) => {
-            // disregard diff between 'https://www.foo.com' and 'https://foo.com'
-            const _url = url.replace('https://www.', 'https://')
-            const _headerUrl = header.url.replace('https://www.', 'https://')
-            return _url !== _headerUrl
-        });
-    }
-
-}, {urls: ['<all_urls>']});
 
 chrome.webRequest.onBeforeRedirect.addListener((req) => {
     // count redirects

--- a/shared/js/tab.js
+++ b/shared/js/tab.js
@@ -53,6 +53,7 @@ class Tab {
         this.url = tabData.url
         this.upgradedHttps = false
         this.httpsRequests = [] // array of urls we force-upgraded
+        this.downgradedUrls = {}
         this.httpsRedirects = {} // count redirects here in form of: { <requestId>: <count> }
         this.requestId = tabData.requestId
         this.status = tabData.status
@@ -132,6 +133,7 @@ class Tab {
         if (reqData.type === 'main_frame') this.upgradedHttps = false
         delete this.httpsRedirects[reqData.requestId]
         const downgrade = reqData.url.replace(/^https:\/\//i, 'http://')
+        this.downgradedUrls[downgrade] = true
         return downgrade
     }
 

--- a/shared/js/tabManager.js
+++ b/shared/js/tabManager.js
@@ -109,7 +109,10 @@ chrome.tabs.onUpdated.addListener( (id, info) => {
                     tab.site.didIncrementCompaniesData = true
                 }
 
-                if (tab.statusCode === 200) tab.endStopwatch()
+                if (tab.statusCode === 200) {
+                    delete tab.lastInProgressUrl
+                    tab.endStopwatch()
+                }
             }
         }
     }

--- a/shared/js/tabManager.js
+++ b/shared/js/tabManager.js
@@ -109,10 +109,7 @@ chrome.tabs.onUpdated.addListener( (id, info) => {
                     tab.site.didIncrementCompaniesData = true
                 }
 
-                if (tab.statusCode === 200) {
-                    delete tab.lastUpgradeInProgressUrl
-                    tab.endStopwatch()
-                }
+                if (tab.statusCode === 200) tab.endStopwatch()
             }
         }
     }

--- a/shared/js/tabManager.js
+++ b/shared/js/tabManager.js
@@ -110,7 +110,7 @@ chrome.tabs.onUpdated.addListener( (id, info) => {
                 }
 
                 if (tab.statusCode === 200) {
-                    delete tab.lastInProgressUrl
+                    delete tab.lastUpgradeInProgressUrl
                     tab.endStopwatch()
                 }
             }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler

**CC:** @bsstoner @laurengarcia 

## Description:

This adds a couple of extra methods to deal with HTTPS redirect loops.

Specifically it deals with two redirect loops that we found, one on http://store.steampowered.com/ (which only happened in FF) and one at http://raisingchildren.net.au/articles/safe_water_temperature.html (both Chrome and FF).

See descriptions inline for more info.

## Steps to test this PR:

Visit both http://raisingchildren.net.au/articles/safe_water_temperature.html and http://store.steampowered.com/ on both Chrome and FF, there should be no HTTPS redirect loops.

Note, we removed the Steam Store rule from our HTTPS ruleset. To fudge it and pretend it's still there, you can add something like `if (reqUrl === 'http://store.steampowered.com/') { return 'https://store.steampowered.com/' }` right around [this line](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/develop/shared/js/https.js#L178).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
