### PR TITLE
Always use ellipsis in the hero title when too long

### DIFF
--- a/shared/scss/views/_hero.scss
+++ b/shared/scss/views/_hero.scss
@@ -21,6 +21,8 @@
     width: 100%;
     max-width: 100%;
     font-size: 17px;
+    word-break: keep-all;
+    white-space: nowrap;
 }
 
 .hero__subtitle {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
We used to break words and wrap whitespace, which leads to inconsistent behaviour for long URLs.
This change makes sure we always use ellipsis on them.
<img width="301" alt="screen shot 2018-01-25 at 12 21 08 pm" src="https://user-images.githubusercontent.com/3652195/35402548-eb4bffcc-01ca-11e8-84d7-5ff70a643602.png">

## Steps to test this PR:
1. Build and reload extension
2. Load a page that breaks  the hero title in 2 lines, like https://user-images.githubusercontent.com/83453/33233089-a915a66a-d1c5-11e7-9d8c-15ec5e32351b.png
3. Text should now have ellipsis instead
4. Normal length URLs are unaffected



## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 