### PR TITLE
only show install page on ddg or gallery

### DIFF
--- a/browsers/duckduckgo.safariextension/Info.plist
+++ b/browsers/duckduckgo.safariextension/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2018.1.25</string>
+	<string>2018.1.30</string>
 	<key>CFBundleVersion</key>
-	<string>40</string>
+	<string>41</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Database Quota</key>

--- a/browsers/duckduckgo.safariextension/js/background.js
+++ b/browsers/duckduckgo.safariextension/js/background.js
@@ -39,16 +39,24 @@ var handleMessage = function (message) {
 settings.ready().then(() => {    
     if(!localStorage['installed']) {
         
+        localStorage['installed'] = true
+        
         ATB.onInstalled()
 
         settings.removeSetting('HTTPSwhitelisted')
 
         let activeTabIndex = 0 
+        let showPostinstallPage = false
 
         safari.application.browserWindows.forEach((safariWindow) => {
             safariWindow.tabs.forEach((safariTab) => {
                 // create a tab id and store in safari tab
                 safariTab.ddgTabId = Math.floor(Math.random() * (10000000 - 10 + 1)) + 10
+
+                // only show postinstall page if one of the existing tabs is ddg with install param or the safari gallery page
+                if (safariTab.url.match(/duckduckgo.com\/\?t=hf|safari-extensions.apple.com\/details\/\?id=com.duckduckgo.safari/)) {
+                    showPostinstallPage = true
+                }
 
                 // make a fake request obj so we can use tabManager to handle creating and storing the tab
                 let req = {
@@ -60,15 +68,15 @@ settings.ready().then(() => {
             })
         })
 
-        let activeTabIdx = utils.getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
-
         // open post install page
-        safari.application.activeBrowserWindow.openTab().url = 'https://duckduckgo.com/app?post=1'
-
-        // reactivate previous tab
-        safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
-
-        localStorage['installed'] = true
+        if (showPostinstallPage) {
+            
+            let activeTabIdx = utils.getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
+            safari.application.activeBrowserWindow.openTab().url = 'https://duckduckgo.com/app?post=1'
+            
+            // reactivate previous tab
+            safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
+        }
     }
 })
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Some users are reporting that the post install page is opening every time they open Safari. I can't repeat it but checking to see that there is an existing DDG page or safari gallery page should fix it. 

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
