### PR TITLE
Remove unnecessary "www" in postinstall URL

### DIFF
--- a/shared/js/background.js
+++ b/shared/js/background.js
@@ -85,7 +85,7 @@ function Background() {
                 if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
                     settings.updateSetting('hasSeenPostInstall', true)
                     chrome.tabs.create({
-                        url: 'https://www.duckduckgo.com/app?post=1'
+                        url: 'https://duckduckgo.com/app?post=1'
                     })
                 }
             })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 


**CC:** @bbraithwaite 
<!-- Optional fields
**Depends on:** 
-->

## Description:
Remove www from postinstall page URL to avoid unnecessary redirect


## Steps to test this PR:

1. Remove current extension
2. Build and load from branch
3. Postinstall page should open in a new tab


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 