### PR TITLE
UI site model: disambiguate site properties

### DIFF
--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -1,5 +1,4 @@
 const Parent = window.DDG.base.Model
-
 const httpsMessages = window.constants.httpsMessages
 
 function Site (attrs) {
@@ -14,8 +13,8 @@ function Site (attrs) {
   attrs.httpsStatusText = ''
   attrs.isUserPrivacyUpgraded = false
   attrs.trackersCount = 0 // unique trackers count
-  attrs.majorTrackersCount = 0
-  attrs.totalTrackersCount = 0
+  attrs.majorTrackerNetworksCount = 0
+  attrs.totalTrackersCount = 0 // TODO: disambiguate - is unique tracker networks count
   attrs.trackerNetworks = []
   attrs.tosdr = {}
   attrs.isaMajorTrackingNetwork = false
@@ -157,9 +156,9 @@ Site.prototype = window.$.extend({},
           this.set('totalTrackersCount', newTotalTrackersCount)
         }
 
-        const newMajorTrackersCount = this.getMajorTrackerNetworksCount()
-        if (newMajorTrackersCount !== this.majorTrackersCount) {
-          this.set('majorTrackersCount', newMajorTrackersCount)
+        const newMajorTrackerNetworksCount = this.getMajorTrackerNetworksCount()
+        if (newMajorTrackerNetworksCount !== this.majorTrackerNetworksCount) {
+          this.set('majorTrackerNetworksCount', newMajorTrackerNetworksCount)
         }
         this.set('isPartOfMajorTrackingNetwork', this.getIsPartOfMajorTrackingNetwork())
 
@@ -201,7 +200,7 @@ Site.prototype = window.$.extend({},
     },
 
     getMajorTrackerNetworksCount: function () {
-      // console.log('[model] getMajorTrackersCount()')
+      // console.log('[model] getMajorTrackerNetworksCount()')
       const count = Object.keys(this.tab.trackers).reduce((total, name) => {
         let tempTracker = name.toLowerCase()
         const majorTrackingNetworks = Object.keys(window.constants.majorTrackingNetworks)

--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -14,7 +14,7 @@ function Site (attrs) {
   attrs.isUserPrivacyUpgraded = false
   attrs.trackersCount = 0 // unique trackers count
   attrs.majorTrackerNetworksCount = 0
-  attrs.totalTrackersCount = 0 // TODO: disambiguate - is unique tracker networks count
+  attrs.totalTrackerNetworksCount = 0
   attrs.trackerNetworks = []
   attrs.tosdr = {}
   attrs.isaMajorTrackingNetwork = false
@@ -151,9 +151,9 @@ Site.prototype = window.$.extend({},
         }
 
         const newUnknownTrackersCount = this.getUnknownTrackersCount()
-        const newTotalTrackersCount = newUnknownTrackersCount + newTrackerNetworks.length
-        if (newTotalTrackersCount !== this.totalTrackersCount) {
-          this.set('totalTrackersCount', newTotalTrackersCount)
+        const newTotalTrackerNetworksCount = newUnknownTrackersCount + newTrackerNetworks.length
+        if (newTotalTrackerNetworksCount !== this.totalTrackerNetworksCount) {
+          this.set('totalTrackerNetworksCount', newTotalTrackerNetworksCount)
         }
 
         const newMajorTrackerNetworksCount = this.getMajorTrackerNetworksCount()

--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -28,7 +28,7 @@ function getReasons (site) {
 
   // tracking networks blocked or found,
   // only show a message if there's any
-  const trackersBadOrGood = (site.totalTrackersCount !== 0) ? 'bad' : 'good'
+  const trackersBadOrGood = (site.totalTrackerNetworksCount !== 0) ? 'bad' : 'good'
   reasons.push({
     modifier: trackersBadOrGood,
     msg: `${trackerNetworksText(site)}`

--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -36,7 +36,7 @@ function getReasons (site) {
 
   // major tracking networks,
   // only show a message if there are any
-  const majorTrackersBadOrGood = (site.majorTrackersCount !== 0) ? 'bad' : 'good'
+  const majorTrackersBadOrGood = (site.majorTrackerNetworksCount !== 0) ? 'bad' : 'good'
   reasons.push({
     modifier: majorTrackersBadOrGood,
     msg: `${trackerNetworksText(site, true)}`

--- a/shared/js/ui/templates/shared/tracker-network-icon.es6.js
+++ b/shared/js/ui/templates/shared/tracker-network-icon.es6.js
@@ -1,9 +1,9 @@
 const bel = require('bel')
 
-module.exports = function (siteRating, isWhitelisted, totalTrackersCount) {
+module.exports = function (siteRating, isWhitelisted, totalTrackerNetworksCount) {
   let iconNameModifier = 'blocked'
 
-  if (isWhitelisted && (siteRating.before === 'D') && (totalTrackersCount !== 0)) {
+  if (isWhitelisted && (siteRating.before === 'D') && (totalTrackerNetworksCount !== 0)) {
     iconNameModifier = 'warning'
   }
 

--- a/shared/js/ui/templates/shared/tracker-networks-text.es6.js
+++ b/shared/js/ui/templates/shared/tracker-networks-text.es6.js
@@ -1,7 +1,7 @@
 const bel = require('bel')
 
 module.exports = function (site, isMajorNetworksCount, includeUniqueTrackersCount) {
-  const trackerNetworksCount = isMajorNetworksCount ? site.majorTrackersCount : site.totalTrackersCount
+  const trackerNetworksCount = isMajorNetworksCount ? site.majorTrackerNetworksCount : site.totalTrackersCount
 
   let trackersText = isMajorNetworksCount ? ' Major Tracker' : ' Tracker'
   trackersText += (trackerNetworksCount === 1) ? ' Network ' : ' Networks '

--- a/shared/js/ui/templates/shared/tracker-networks-text.es6.js
+++ b/shared/js/ui/templates/shared/tracker-networks-text.es6.js
@@ -1,7 +1,7 @@
 const bel = require('bel')
 
 module.exports = function (site, isMajorNetworksCount, includeUniqueTrackersCount) {
-  const trackerNetworksCount = isMajorNetworksCount ? site.majorTrackerNetworksCount : site.totalTrackersCount
+  const trackerNetworksCount = isMajorNetworksCount ? site.majorTrackerNetworksCount : site.totalTrackerNetworksCount
 
   let trackersText = isMajorNetworksCount ? ' Major Tracker' : ' Tracker'
   trackersText += (trackerNetworksCount === 1) ? ' Network ' : ' Networks '

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -53,7 +53,7 @@ module.exports = function () {
 
     return bel`<a href="#" class="site-info__trackers link-secondary bold">
       <span class="site-info__trackers-status__icon
-          icon-${trackerNetworksIcon(model.siteRating, model.isWhitelisted, model.totalTrackersCount)}"></span>
+          icon-${trackerNetworksIcon(model.siteRating, model.isWhitelisted, model.totalTrackerNetworksCount)}"></span>
       <span class="${isActive} text-line-after-icon"> ${trackerNetworksText(model)} </span>
       <span class="icon icon__arrow pull-right"></span>
     </a>`

--- a/shared/js/ui/templates/tracker-networks.es6.js
+++ b/shared/js/ui/templates/tracker-networks.es6.js
@@ -35,7 +35,7 @@ function renderHero (site) {
   site = site || {}
 
   return bel`${hero({
-    status: trackerNetworksIcon(site.siteRating, site.isWhitelisted, site.totalTrackersCount),
+    status: trackerNetworksIcon(site.siteRating, site.isWhitelisted, site.totalTrackerNetworksCount),
     title: site.domain,
     subtitle: `${trackerNetworksText(site, false, true)}`,
     showClose: true

--- a/shared/js/ui/views/tracker-networks.es6.js
+++ b/shared/js/ui/views/tracker-networks.es6.js
@@ -61,7 +61,7 @@ TrackerNetworks.prototype = window.$.extend({},
         const trackerNetworksIconName = trackerNetworksIconTemplate(
           this.model.site.siteRating,
           this.model.site.isWhitelisted,
-          this.model.site.totalTrackersCount
+          this.model.site.totalTrackerNetworksCount
         )
 
         const trackerNetworksText = trackerNetworksTextTemplate(this.model.site, false, true)
@@ -79,7 +79,7 @@ TrackerNetworks.prototype = window.$.extend({},
       if (e && e.change) {
         if (e.change.attribute === 'isPartOfMajorTrackingNetwork' ||
             e.change.attribute === 'isWhitelisted' ||
-            e.change.attribute === 'totalTrackersCount') {
+            e.change.attribute === 'totalTrackerNetworksCount') {
           this._renderHeroTemplate()
           this.unbindEvents()
           this.setup()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
@MariagraziaAlastra 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
This was technical debt that I forgot about.
This PR disambiguates two site model properties that were poorly named and had changed over time.
`this.majorTrackersCount` -> `this.majorTrackerNetworksCount`
`this.totalTrackersCount -> totalTrackerNetworksCount`

## Steps to test this PR:
Build this branch, visit sites and verify that counts are correct and there are no errors in popup console.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
