### PR TITLE
Fix the link and text for gaug.es tracker

### DIFF
--- a/shared/data/tracker_lists/trackersWithParentCompany.json
+++ b/shared/data/tracker_lists/trackersWithParentCompany.json
@@ -6533,8 +6533,8 @@
             "u": "http://www.gfk.com/"
         },
         "gaug.es": {
-            "c": "GitHub",
-            "u": "https://github.com/"
+            "c": "Gauges",
+            "u": "https://get.gaug.es/"
         },
         "godaddy.com": {
             "c": "Go Daddy",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

I saw gaug.es displayed as Github:

<img width="288" alt="2018-02-13 12 26 48" src="https://user-images.githubusercontent.com/16474/36133490-37ac53e2-10b9-11e8-9f98-6e61e1ec05b7.png">

And can't find relationship between these two company, So it might be a typo.

## Steps to test this PR:

1. Open a site using gaug.es
2. See the blocked tracker


This PR only change JSON data so I only validate the JSON file.
Not check items listed below.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
