### PR TITLE
Stop mapping Amazon.com to Amazon

### DIFF
--- a/scripts/importers/companyList.js
+++ b/scripts/importers/companyList.js
@@ -22,15 +22,12 @@ global.companyList = function (listData) {
                     companyList.categories[type].forEach((entry) => {
                     
                         for (var name in entry) {
-                            let normalizedName = name
-                            if (name === 'Amazon.com') normalizedName = 'Amazon'
-
                             // ItIsAtracker is not a real entry in the list
                             if (name !== 'ItIsATracker') {
                                 for (var domain in entry[name]){
                                     if (entry[name][domain].length) {
                                         entry[name][domain].forEach((trackerURL) => {
-                                            addToList(type, trackerURL, {'c': normalizedName, 'u': domain});
+                                            addToList(type, trackerURL, {'c': name, 'u': domain});
                                         });
                                     }
                                 }


### PR DESCRIPTION
**Reviewer:** @russellholt 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
By mapping 'Amazon.com' to 'Amazon', we're not matching amazon requests with their entity data here: https://duckduckgo.com/contentblocking.js?l=entitylist . This is blocking first party requests to other amazon domains on the amazon website.


## Steps to test this PR:
1. reload extension
2. visit amazon.fr
3. type into the search bar on the page. Autocomplete should appear. (the reason this is the case is due to autocomplete requests on amazon.fr going through amazon.co.uk)


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
