### PR TITLE
beta firefox build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,9 @@ moveout: $(ITEMS)
 	find ./build/$(browser)/$(type)/js -type f -name '*.es6.js' -delete
 	rm -rf build/$(browser)/$(type)/js/ui
 	cp -r browsers/$(browser)/* build/$(browser)/$(type)/
+
+remove-firefox-id:
+	sed '/jid1-ZAdIEUB7XOzOJw@jetpack/d' ./browsers/firefox/manifest.json > build/firefox/release/manifest.json
+
+beta-firefox-zip: remove-firefox-id
+	cd build/firefox/release/ && web-ext build

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ moveout: $(ITEMS)
 	rm -rf build/$(browser)/$(type)/js/ui
 	cp -r browsers/$(browser)/* build/$(browser)/$(type)/
 
+beta-firefox: release beta-firefox-zip
+
 remove-firefox-id:
 	sed '/jid1-ZAdIEUB7XOzOJw@jetpack/d' ./browsers/firefox/manifest.json > build/firefox/release/manifest.json
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev-firefox": "make dev browser=firefox type=dev",
     "release-firefox": "make browser=firefox type=release",
     "dev-chrome": "make dev browser=chrome type=dev",
-    "beta-firefox": "npm run release-firefox && make beta-firefox-zip",
+    "beta-firefox": "make beta-firefox browser=firefox type=release",
     "release-chrome": "make browser=chrome type=release && make chrome-release-zip"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "dev-firefox": "make dev browser=firefox type=dev",
     "release-firefox": "make browser=firefox type=release",
     "dev-chrome": "make dev browser=chrome type=dev",
-    "release-chrome": "make browser=chrome type=release && make chrome-release-zip"
+    "beta-firefox": "npm run release-firefox && cd build/firefox/release && npm run remove-firefox-id && web-ext build",
+    "release-chrome": "make browser=chrome type=release && make chrome-release-zip",
+    "remove-firefox-id": "sed '/jid1-ZAdIEUB7XOzOJw@jetpack/d' ./browsers/firefox/manifest.json > build/firefox/release/manifest.json"
   },
   "devDependencies": {
     "babel-preset-env": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     "dev-firefox": "make dev browser=firefox type=dev",
     "release-firefox": "make browser=firefox type=release",
     "dev-chrome": "make dev browser=chrome type=dev",
-    "beta-firefox": "npm run release-firefox && cd build/firefox/release && npm run remove-firefox-id && web-ext build",
-    "release-chrome": "make browser=chrome type=release && make chrome-release-zip",
-    "remove-firefox-id": "sed '/jid1-ZAdIEUB7XOzOJw@jetpack/d' ./browsers/firefox/manifest.json > build/firefox/release/manifest.json"
+    "beta-firefox": "npm run release-firefox && make beta-firefox-zip",
+    "release-chrome": "make browser=chrome type=release && make chrome-release-zip"
   },
   "devDependencies": {
     "babel-preset-env": "^1.4.0",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Firefox is getting rid of the beta channel. I'm adding a beta-firefox target to package.json that will build us a zip file. We can upload the zip file to an unlisted beta extension for testing. The id needs to be removed from the manifest to upload it to the unlisted extension.

## Steps to test this PR:
1. `npm run beta-firefox`
2. You should have a zip file in `build/firefox/release/web-ext-artifacts` 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
