### PR TITLE
Fix linter error on feedback template

### DIFF
--- a/shared/js/ui/templates/shared/email-feedback-footer.es6.js
+++ b/shared/js/ui/templates/shared/email-feedback-footer.es6.js
@@ -1,6 +1,6 @@
 module.exports = function (browserInfo, url) {
   let footer = '---\n'
-  let extensionVersion = chrome.runtime.getManifest().version
+  let extensionVersion = window.chrome.runtime.getManifest().version
 
   // append URL if the user is sending feedback to do with a specific tab
   if (url) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
I was running the linter and noticed an error on the email-feedback-footer. Nothing is actually broken, but it complains saying "chrome" is an undefined variable. 
Prefixing with "window" solves it.


## Steps to test this PR:
1. Build and reload extension
2. Click on feedback
3. Footer should look as in #150 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
