### PR TITLE
Toggle text transition when site is whitelisted

### DIFF
--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -41,13 +41,13 @@ module.exports = function () {
       </a>
     </li>
     <li class="site-info__li--toggle padded ${this.model.isWhitelisted ? '' : 'is-active'}">
-      <h2 class="site-info__protection js-site-protection">Site Privacy Protection</h2>
-      <h2 class="is-hidden site-info__protection js-site-protection-whitelisted">
+      <h2 class="is-transparent site-info__protection--is-whitelisted js-site-protection-whitelisted">
         <span class="icon icon__check"></span>
         <span class="text-line-after-icon">
           Added to Whitelist
         </span>
       </h2>
+      <h2 class="site-info__protection js-site-protection">Site Privacy Protection</h2>
       <div class="site-info__toggle-container">
         ${toggleButton(!this.model.isWhitelisted, 'js-site-toggle pull-right')}
       </div>

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -41,7 +41,7 @@ module.exports = function () {
       </a>
     </li>
     <li class="site-info__li--toggle padded ${this.model.isWhitelisted ? '' : 'is-active'}">
-      <h2 class="is-transparent site-info__protection--is-whitelisted js-site-protection-whitelisted">
+      <h2 class="is-transparent site-info__whitelist-status js-site-whitelist-status">
         <span class="icon icon__check"></span>
         <span class="text-line-after-icon">
           Added to Whitelist

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -47,12 +47,12 @@ Site.prototype = window.$.extend({},
     // otherwise just reload the tab and close the popup
     _showAddedToWhitelistMessage: function () {
       const w = window.chrome.extension.getViews({type: 'popup'})[0]
-      const isHiddenClass = 'is-hidden'
+      const isTransparentClass = 'is-transparent'
       if (this.model.isWhitelisted) {
-        this.$protection.addClass(isHiddenClass)
-        this.$protectionwhitelisted.removeClass(isHiddenClass)
-        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 650)
-        setTimeout(() => w.close(), 650)
+        this.$protection.addClass(isTransparentClass)
+        this.$protectionwhitelisted.removeClass(isTransparentClass)
+        setTimeout(() => w.close(), 6500)
+        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 6500)
       } else {
         window.chrome.tabs.reload(this.model.tab.id)
         w.close()

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -12,7 +12,6 @@ function Site (ops) {
   this.pageView = ops.pageView
   this.template = ops.template
   this.isToggleButtonClicked = false
-  this.donotRerender = false
 
   // cache 'body' selector
   this.$body = window.$('body')
@@ -54,8 +53,8 @@ Site.prototype = window.$.extend({},
       if (this.model.isWhitelisted) {
         this.$protectionwhitelisted.removeClass(isTransparentClass)
         this.$protection.addClass(isTransparentClass)
-        setTimeout(() => w.close(), 6500)
-        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 6500)
+        setTimeout(() => w.close(), 4000)
+        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 4000)
       } else {
         window.chrome.tabs.reload(this.model.tab.id)
         w.close()
@@ -99,21 +98,18 @@ Site.prototype = window.$.extend({},
           this._rerender()
           this._setup()
         }
-      } else if (this.donotRerender) {
+      }else if (this.isToggleButtonClicked) {
         // Avoid rerendering after toggle button click
         // otherwise it overrides the css transition
         // and we're closing and reloading the tab anyway
         return;
-      }else {
+      } else {
         this.$body.removeClass('is-disabled')
         this.unbindEvents()
         this._rerender()
         this._setup()
       }
 
-      if (this.isToggleButtonClicked) {
-        this.donotRerender = true
-      }
     },
 
     _onManageWhitelistClick: function () {

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -41,7 +41,6 @@ Site.prototype = window.$.extend({},
       if (this.$body.hasClass('is-disabled')) return
       this.isToggleButtonClicked = true
       this.model.toggleWhitelist()
-      console.log('isWhitelisted: ', this.model.isWhitelisted)
       this._showAddedToWhitelistMessage()
     },
 
@@ -51,10 +50,13 @@ Site.prototype = window.$.extend({},
       const w = window.chrome.extension.getViews({type: 'popup'})[0]
       const isTransparentClass = 'is-transparent'
       if (this.model.isWhitelisted) {
-        this.$protectionwhitelisted.removeClass(isTransparentClass)
-        this.$protection.addClass(isTransparentClass)
-        setTimeout(() => w.close(), 4000)
-        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 4000)
+        // Wait for the rerendering to be done
+        // 10ms timeout is the minimum to render the transition smoothly 
+        setTimeout(() => this.$protectionwhitelisted.removeClass(isTransparentClass), 10)
+        setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
+        // Wait a bit more before closing the popup and reloading the tab
+        setTimeout(() => w.close(), 3500)
+        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 3500)
       } else {
         window.chrome.tabs.reload(this.model.tab.id)
         w.close()
@@ -98,18 +100,12 @@ Site.prototype = window.$.extend({},
           this._rerender()
           this._setup()
         }
-      }else if (this.isToggleButtonClicked) {
-        // Avoid rerendering after toggle button click
-        // otherwise it overrides the css transition
-        // and we're closing and reloading the tab anyway
-        return;
       } else {
         this.$body.removeClass('is-disabled')
         this.unbindEvents()
         this._rerender()
         this._setup()
       }
-
     },
 
     _onManageWhitelistClick: function () {

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -49,7 +49,7 @@ Site.prototype = window.$.extend({},
       const isTransparentClass = 'is-transparent'
       if (this.model.isWhitelisted) {
         // Wait for the rerendering to be done
-        // 10ms timeout is the minimum to render the transition smoothly 
+        // 10ms timeout is the minimum to render the transition smoothly
         setTimeout(() => this.$whiteliststatus.removeClass(isTransparentClass), 10)
         setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
         // Wait a bit more before closing the popup and reloading the tab

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -11,7 +11,6 @@ function Site (ops) {
   this.model = ops.model
   this.pageView = ops.pageView
   this.template = ops.template
-  this.isToggleButtonClicked = false
 
   // cache 'body' selector
   this.$body = window.$('body')
@@ -39,7 +38,6 @@ Site.prototype = window.$.extend({},
 
     _onWhitelistClick: function (e) {
       if (this.$body.hasClass('is-disabled')) return
-      this.isToggleButtonClicked = true
       this.model.toggleWhitelist()
       this._showAddedToWhitelistMessage()
     },
@@ -52,7 +50,7 @@ Site.prototype = window.$.extend({},
       if (this.model.isWhitelisted) {
         // Wait for the rerendering to be done
         // 10ms timeout is the minimum to render the transition smoothly 
-        setTimeout(() => this.$protectionwhitelisted.removeClass(isTransparentClass), 10)
+        setTimeout(() => this.$whiteliststatus.removeClass(isTransparentClass), 10)
         setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
         // Wait a bit more before closing the popup and reloading the tab
         setTimeout(() => w.close(), 3500)
@@ -70,7 +68,7 @@ Site.prototype = window.$.extend({},
       this._cacheElems('.js-site', [
         'toggle',
         'protection',
-        'protection-whitelisted',
+        'whitelist-status',
         'show-all-trackers',
         'show-page-trackers',
         'manage-whitelist',

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -53,8 +53,8 @@ Site.prototype = window.$.extend({},
         setTimeout(() => this.$whiteliststatus.removeClass(isTransparentClass), 10)
         setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
         // Wait a bit more before closing the popup and reloading the tab
-        setTimeout(() => w.close(), 3500)
-        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 3500)
+        setTimeout(() => w.close(), 1500)
+        setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 1500)
       } else {
         window.chrome.tabs.reload(this.model.tab.id)
         w.close()

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -116,27 +116,30 @@ body {
             margin-left: 12px;
         }
 
-        .site-info__protection--is-whitelisted {
+        .site-info__protection--is-whitelisted:not(.is-transparent) {
             opacity: 100;
             margin-top: 0;
-            transition: all 4s ease;
              
-            &.is-transparent {
-                margin-top: -16px;
-                opacity: 0;
-            }
+        }
+
+        .site-info__protection--is-whitelisted.is-transparent {
+            margin-top: -16px;
+            opacity: 0;
+            transition: all 3s ease-in-out;
+            -webkit-transition: all 3s ease-in-out;
         }
  
-        .site-info__protection {
+        .site-info__protection:not(.is-transparent) {
             opacity: 100;
             margin-top: 0;
+                transition: all 3s ease-in-out;
+                -webkit-transition: all 3s ease-in-out;
              
-            &.is-transparent {
+        }
+        .site-info__protection.is-transparent {
                 margin-top: 16px;
                 opacity: 0;
                 height: 0;
-                transition: all 4s ease;
-            }
         }
 
         .site-info__li--toggle {

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -116,35 +116,37 @@ body {
             margin-left: 12px;
         }
 
-        .site-info__protection--is-whitelisted:not(.is-transparent) {
+        .site-info__protection--is-whitelisted {
             opacity: 100;
             margin-top: 0;
-             
+            transition: all 2s ease 1s;
+            -webkit-transition: all 2s ease 1s;
         }
 
         .site-info__protection--is-whitelisted.is-transparent {
             margin-top: -16px;
             opacity: 0;
-            transition: all 3s ease-in-out;
-            -webkit-transition: all 3s ease-in-out;
         }
  
-        .site-info__protection:not(.is-transparent) {
+        .site-info__protection {
             opacity: 100;
             margin-top: 0;
-                transition: all 3s ease-in-out;
-                -webkit-transition: all 3s ease-in-out;
-             
+            max-height: 20px;
         }
+
         .site-info__protection.is-transparent {
-                margin-top: 16px;
-                opacity: 0;
-                height: 0;
+            margin-top: 16px;
+            opacity: 0;
+            max-height: 0;
+            transition: all 2s ease 1s;
+            -webkit-transition: all 2s ease 1s;
         }
 
         .site-info__li--toggle {
             background-color: $color--medium-slate;
             color: $color--white;
+            max-height: 19px;
+            overflow: hidden;
 
             &.is-active {
                 background-color: $color--green;

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -119,7 +119,7 @@ body {
         .site-info__whitelist-status {
             opacity: 1;
             margin-top: 0;
-            transition: all 1.5s ease;
+            transition: all 0.3s ease;
         }
 
         .site-info__whitelist-status.is-transparent {
@@ -137,7 +137,7 @@ body {
             margin-top: 16px;
             opacity: 0;
             max-height: 0;
-            transition: all 1.5s ease;
+            transition: all 0.3s ease;
         }
 
         .site-info__li--toggle {

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -116,6 +116,29 @@ body {
             margin-left: 12px;
         }
 
+        .site-info__protection--is-whitelisted {
+            opacity: 100;
+            margin-top: 0;
+            transition: all 4s ease;
+             
+            &.is-transparent {
+                margin-top: -16px;
+                opacity: 0;
+            }
+        }
+ 
+        .site-info__protection {
+            opacity: 100;
+            margin-top: 0;
+             
+            &.is-transparent {
+                margin-top: 16px;
+                opacity: 0;
+                height: 0;
+                transition: all 4s ease;
+            }
+        }
+
         .site-info__li--toggle {
             background-color: $color--medium-slate;
             color: $color--white;

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -116,20 +116,19 @@ body {
             margin-left: 12px;
         }
 
-        .site-info__protection--is-whitelisted {
-            opacity: 100;
+        .site-info__whitelist-status {
+            opacity: 1;
             margin-top: 0;
             transition: all 1.5s ease;
-            -webkit-transition: all 1.5s ease;
         }
 
-        .site-info__protection--is-whitelisted.is-transparent {
+        .site-info__whitelist-status.is-transparent {
             margin-top: -16px;
             opacity: 0;
         }
  
         .site-info__protection {
-            opacity: 100;
+            opacity: 1;
             margin-top: 0;
             max-height: 20px;
         }
@@ -139,7 +138,6 @@ body {
             opacity: 0;
             max-height: 0;
             transition: all 1.5s ease;
-            -webkit-transition: all 1.5s ease;
         }
 
         .site-info__li--toggle {

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -119,8 +119,8 @@ body {
         .site-info__protection--is-whitelisted {
             opacity: 100;
             margin-top: 0;
-            transition: all 2s ease 1s;
-            -webkit-transition: all 2s ease 1s;
+            transition: all 1.5s ease;
+            -webkit-transition: all 1.5s ease;
         }
 
         .site-info__protection--is-whitelisted.is-transparent {
@@ -138,8 +138,8 @@ body {
             margin-top: 16px;
             opacity: 0;
             max-height: 0;
-            transition: all 2s ease 1s;
-            -webkit-transition: all 2s ease 1s;
+            transition: all 1.5s ease;
+            -webkit-transition: all 1.5s ease;
         }
 
         .site-info__li--toggle {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Adding transition to the toggle text:
- "Added to whitelist" moves down by 16px while transitioning from 0 to 100 opacity
- "Site Privacy Protection" also moves down by 16px, transitioning from 100 to 0 opacity
- Popup remains visible for 2.5 seconds before reloading the page

## Steps to test this PR:
1. Build and reload extension
2. Go on a site and click on the toggle button to whitelist it
3. A css transition, as described above, should show up
4. Tab should reload and the popup should show the regular whitelisted UI
5. Clicking again on the toggle to remove from whitelist should reload the tab immediately

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
