### PR TITLE
Prevent model from accidentally freezing its own properties

### DIFF
--- a/shared/js/ui/base/model.es6.js
+++ b/shared/js/ui/base/model.es6.js
@@ -57,6 +57,9 @@ BaseModel.prototype = $.extend({},
       const lastValue = this[attr] || null
       this[attr] = val
 
+      // deep clone val in case it's something passed by reference
+      val = JSON.parse(JSON.stringify(val))
+
       this.store.publish({
         notifierName: this.modelName,
         change: {attribute: attr, value: val, lastValue: lastValue},
@@ -107,6 +110,7 @@ BaseModel.prototype = $.extend({},
     send: function (action, data) {
       if (!action) throw new Error('model.send() requires an action argument')
       data = data || null
+      data = JSON.parse(JSON.stringify(data))
       this.store.publish({
         notifierName: this.modelName,
         action: action,

--- a/shared/js/ui/base/model.es6.js
+++ b/shared/js/ui/base/model.es6.js
@@ -58,7 +58,9 @@ BaseModel.prototype = $.extend({},
       this[attr] = val
 
       // deep clone val in case it's something passed by reference
-      val = JSON.parse(JSON.stringify(val))
+      if (val) {
+        val = JSON.parse(JSON.stringify(val))
+      }
 
       this.store.publish({
         notifierName: this.modelName,
@@ -110,7 +112,12 @@ BaseModel.prototype = $.extend({},
     send: function (action, data) {
       if (!action) throw new Error('model.send() requires an action argument')
       data = data || null
-      data = JSON.parse(JSON.stringify(data))
+
+      // deep clone data in case it's something passed by reference
+      if (data) {
+        data = JSON.parse(JSON.stringify(data))
+      }
+
       this.store.publish({
         notifierName: this.modelName,
         action: action,

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -63,15 +63,10 @@ Whitelist.prototype = window.$.extend({},
         whitelist = whitelist || {}
         let wlist = Object.keys(whitelist)
         wlist.sort()
-        
+
         // Publish whitelist change notification via the store
         // used to know when to rerender the view
         self.set('list', wlist)
-        
-        // set() sealed both the model's list and wlist
-        // unpack and wrap to allow adding/removing elements
-        // in the model property
-        self.list = [...wlist]
       })
     }
   }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

In https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/153 we noticed that the model's own properties were accidentally getting frozen (by [this line](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/7d0afb1dbdd0430e30d92f1228d654d28364c7d4/shared/js/ui/base/store.es6.js#L60)) because they were being passed by reference.

This PR makes sure anything passed to the store is deep cloned so that problem doesn't happen. It also removes a hack we had to add in the whitelist model.

## Steps to test this PR:

1. Try adding and removing some items in the whitelist - it should work without any errors
2. Other models should also work fine.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
