### PR TITLE
Fix FF not reloading after whitelisting

### DIFF
--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -53,8 +53,8 @@ Site.prototype = window.$.extend({},
         setTimeout(() => this.$whiteliststatus.removeClass(isTransparentClass), 10)
         setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
         // Wait a bit more before closing the popup and reloading the tab
-        setTimeout(() => w.close(), 1500)
         setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 1500)
+        setTimeout(() => w.close(), 1500)
       } else {
         window.chrome.tabs.reload(this.model.tab.id)
         w.close()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p / @dharb 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Closing the window before reloading the tab somehow breaks reloading on FF.
Inverting the order (like it was before #158) fixes the issue.


## Steps to test this PR:
 1. Build and reload extension in FF
2. Go on a site and click on the toggle button to whitelist it. You should see a CSS transition on the toggle:
3. "Added to whitelist" text moves down by 16px while transitioning from 0 to 1 opacity
4. "Site Privacy Protection" text also moves down by 16px, transitioning from 1 to 0 opacity
5. Popup remains visible for 2.5 seconds before reloading the page
6. Tab should reload and the popup should show the regular whitelisted UI
7. Clicking again on the toggle to remove from whitelist should reload the tab immediately

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
