### PR TITLE
Fix black rectangle glitch on Windows FF

### DIFF
--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -109,24 +109,33 @@ body {
         margin-top: 0;
 
         .default-list {
-            padding-bottom: 0;
+           padding-bottom: 0;
         }
 
         .text-line-after-icon {
-            margin-left: 12px;
+           margin-left: 12px;
         }
 
-        .site-info__whitelist-status {
-            opacity: 1;
-            margin-top: 0;
-            transition: all 0.3s ease;
-        }
+       .site-info__whitelist-status {
+           margin-top: 0;
+           transition: margin 0.3s ease;
 
-        .site-info__whitelist-status.is-transparent {
-            margin-top: -16px;
-            opacity: 0;
-        }
- 
+           .icon.icon__check,
+           .text-line-after-icon {
+               opacity: 1;
+               transition: opacity 0.3s ease;
+           }
+       }
+
+       .site-info__whitelist-status.is-transparent {
+           margin-top: -16px;           
+           
+           .icon.icon__check,
+           .text-line-after-icon {
+               opacity: 0;
+           }
+       }
+
         .site-info__protection {
             opacity: 1;
             margin-top: 0;


### PR DESCRIPTION


<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
On Windows FF, opacity transition on the "Added to whitelist" container element produces an unexpected black rectangle between icon and text when showing the animation and switching from 0 to 1 opacity.

Applying the transition to each child element (text and icon) individually seems to fix the problem.
Tested using virtual environment.


## Steps to test this PR:
1. Build and reload extension on Windows FF
2. Try to whitelist a site via the main popup toggle
3. The animation should show with no glitches
4. Other browsers and platforms also work as expected

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
