### PR TITLE
move oninstall and content scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ setup-build-dir:
 	mkdir -p build/$(browser)
 	rm -rf build/$(browser)/$(type)
 	mkdir build/$(browser)/$(type)
+	mkdir -p build/$(browser)/$(type)/public/js/
 
 chrome-release-zip:
 	rm -f build/chrome/release/chrome-release-*.zip
@@ -37,7 +38,6 @@ fonts:
 
 moveout: $(ITEMS)
 	@echo '** Making build directory: $(type) **'
-	mkdir -p build/$(browser)/$(type)/public/js/
 	cp -r $(ITEMS) build/$(browser)/$(type)
 	cp -r $(ITEMS) build/$(browser)/$(type)
 	cp -r shared/js/content-scripts build/$(browser)/$(type)/public/js/

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ fonts:
 
 moveout: $(ITEMS)
 	@echo '** Making build directory: $(type) **'
+	mkdir -p build/$(browser)/$(type)/public/js/
 	cp -r $(ITEMS) build/$(browser)/$(type)
 	cp -r $(ITEMS) build/$(browser)/$(type)
 	cp -r shared/js/content-scripts build/$(browser)/$(type)/public/js/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ITEMS   := shared/html shared/data shared/img shared/js/content-scripts
+ITEMS   := shared/html shared/data shared/img
 
 release: npm setup-build-dir grunt tosdr moveout fonts
 
@@ -39,6 +39,7 @@ moveout: $(ITEMS)
 	@echo '** Making build directory: $(type) **'
 	cp -r $(ITEMS) build/$(browser)/$(type)
 	cp -r $(ITEMS) build/$(browser)/$(type)
+	cp -r shared/js/content-scripts build/$(browser)/$(type)/public/js/
 	cp -r browsers/$(browser)/* build/$(browser)/$(type)/
 
 beta-firefox: release beta-firefox-zip

--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -43,7 +43,7 @@
       },
       {
           "js": [
-              "content-scripts/social-widgets.js"
+              "public/js/content-scripts/social-widgets.js"
           ],
           "matches": [
               "<all_urls>"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
               "strict_min_version": "57.0"
         }
     },
-    "version": "2018.3.2",
+    "version": "2018.3.15",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",
@@ -46,7 +46,7 @@
       },
       {
           "js": [
-              "content-scripts/social-widgets.js"
+              "public/js/content-scripts/social-widgets.js"
           ],
           "matches": [
               "<all_urls>"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
               "strict_min_version": "57.0"
         }
     },
-    "version": "2018.3.15",
+    "version": "2018.3.2",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",

--- a/shared/js/background/abp-lists.es6.js
+++ b/shared/js/background/abp-lists.es6.js
@@ -10,6 +10,7 @@ const constants = require('../../data/constants')
 const defaultSettings = require('../../data/defaultSettings')
 const surrogates = require('./surrogates.es6')
 const settings = require('./settings.es6')
+const ATB = require('./atb.es6')
 const load = require('./load.es6')
 
 const ONEDAY = 1000*60*60*24
@@ -162,6 +163,40 @@ function getVersionParam () {
 
     return versionParam
 }
+
+chrome.runtime.onInstalled.addListener(function(details) {
+    // only run the following section on install and on update
+    if (details.reason.match(/install|update/)) {
+        ATB.onInstalled();
+    }
+
+    // only show post install page on install if:
+    // - the user wasn't already looking at the app install page
+    // - the user hasn't seen the page before
+    if (details.reason.match(/install/)) {
+        settings.ready().then( () => {
+            chrome.tabs.query({currentWindow: true, active: true}, function(tabs) { 
+                const domain = (tabs && tabs[0]) ? tabs[0].url : ''
+                const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
+                if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
+                    settings.updateSetting('hasSeenPostInstall', true)
+                    chrome.tabs.create({
+                        url: 'https://duckduckgo.com/app?post=1'
+                    })
+                }
+            })
+        })
+    }
+
+    // blow away old indexeddbs that might be there
+    if (details.reason.match(/update/) && window.indexedDB) {
+        const ms = 1000 * 60
+        setTimeout(() => window.indexedDB.deleteDatabase('ddgExtension'), ms)
+    }
+
+    // remove legacy/unused `HTTPSwhitelisted` setting
+    settings.ready().then(settings.removeSetting('HTTPSwhitelisted'))
+})
 
 module.exports = {
     getTemporaryWhitelist,

--- a/shared/js/background/background.es6.js
+++ b/shared/js/background/background.es6.js
@@ -58,40 +58,6 @@ function Background() {
           }
       }
   });
-
-  chrome.runtime.onInstalled.addListener(function(details) {
-    // only run the following section on install and on update
-    if (details.reason.match(/install|update/)) {
-        ATB.onInstalled();
-    }
-
-    // only show post install page on install if:
-    // - the user wasn't already looking at the app install page
-    // - the user hasn't seen the page before
-    if (details.reason.match(/install/)) {
-        settings.ready().then( () => {
-            chrome.tabs.query({currentWindow: true, active: true}, function(tabs) { 
-                const domain = (tabs && tabs[0]) ? tabs[0].url : ''
-                const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
-                if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
-                    settings.updateSetting('hasSeenPostInstall', true)
-                    chrome.tabs.create({
-                        url: 'https://duckduckgo.com/app?post=1'
-                    })
-                }
-            })
-        })
-    }
-
-    // blow away old indexeddbs that might be there
-    if (details.reason.match(/update/) && window.indexedDB) {
-        const ms = 1000 * 60
-        setTimeout(() => window.indexedDB.deleteDatabase('ddgExtension'), ms)
-    }
-
-    // remove legacy/unused `HTTPSwhitelisted` setting
-    settings.ready().then(settings.removeSetting('HTTPSwhitelisted'))
-  })
 }
 
 var background


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
I ran into an problem where the onInstall handler isn't registered before the install event has fired. It's probably related to all the background files being browserifyed and the onInstall not being registered until near the end of the file. Adding it to abp-preprocess moves it up and seems to fix the problem. 

I was also getting some failing tests when build the beta firefox version about not finding the manifest files. The location seem to be relative to the new background.js file so I moved content-scripts to public/js. 

## Steps to test this PR:
1. Install from ddh6. version 2018.3.15.3
2. post install page should open
3. you should have atb values in the url when you do a search.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
