### PR TITLE
Fix 0 found, 1 major blocked edge case

### DIFF
--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -214,7 +214,9 @@ Site.prototype = window.$.extend({},
 
     getMajorTrackerNetworksCount: function () {
       // console.log('[model] getMajorTrackerNetworksCount()')
-      const count = Object.keys(this.tab.trackers).reduce((total, name) => {
+      // Show only blocked major trackers count, unless site is whitelisted
+      const trackers = this.isWhitelisted ? this.tab.trackers : this.tab.trackersBlocked
+      const count = Object.keys(trackers).reduce((total, name) => {
         let tempTracker = name.toLowerCase()
         const majorTrackingNetworks = Object.keys(constants.majorTrackingNetworks)
           .filter((t) => t.toLowerCase() === tempTracker)

--- a/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
+++ b/shared/js/ui/templates/shared/grade-scorecard-reasons.es6.js
@@ -29,7 +29,8 @@ function getReasons (site) {
 
   // tracking networks blocked or found,
   // only show a message if there's any
-  const trackersBadOrGood = (site.totalTrackerNetworksCount !== 0) ? 'bad' : 'good'
+  const trackersCount = site.isWhitelisted ? site.trackersCount : site.trackersBlockedCount
+  const trackersBadOrGood = (trackersCount !== 0) ? 'bad' : 'good'
   reasons.push({
     modifier: trackersBadOrGood,
     msg: `${trackerNetworksText(site)}`


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler / @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fix the following edge case on Google.com:
<img width="302" alt="screen shot 2018-03-29 at 12 40 32 pm" src="https://user-images.githubusercontent.com/3652195/38108299-5bd3eef8-3362-11e8-97fc-f689b6d0872e.png">

Now that we have unblocked trackers in the count, we have to be careful what we use to count major tracker networks.
It looks like the grade scorecard was using a different count for general trackers blocked/found, as well.

We're sticking to only showing the blocked trackers and tracker networks count unless the site is whitelisted, so I fixed accordingly.


## Steps to test this PR:
1. Build and reload extension
2. Go to google.com
3. Site is graded D, 0 trackers found (since we can't block anything first party)
4. Go to the grade scorecard: it should say 0 trackers found and 0 major tracker networks found, both with green icons
5. Check the scorecard for other non-major tracker networks sites as well

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
