### PR TITLE
Add way to debug tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,25 @@ module.exports = function(grunt) {
         background: ['<%= dirs.src.js %>/background/**/*.js','<%= dirs.data %>/*.js']
     }
 
+    let karmaOps = {
+        configFile: 'karma.conf.js',
+        basePath: 'build/test/',
+        files: ['background.js']
+    }
+
+    // override some options to allow the devs
+    // to open the test page manually and debug
+    if (grunt.option('test-debug')) {
+        Object.assign(karmaOps, {
+            // don't kill the process when first test is run
+            singleRun: false,
+            // INFO outputs the url/port for the test page
+            logLevel: 'INFO',
+            // don't run headless chrome tests
+            browsers: []
+        })
+    }
+
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         dirs: {
@@ -150,11 +169,7 @@ module.exports = function(grunt) {
 
         karma: {
             unit: {
-                options: {
-                    configFile: 'karma.conf.js',
-                    basePath: 'build/test/',
-                    files: ['background.js']
-                }
+                options: karmaOps
             }
         }
     })

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "selenium": "cd selenium-test && node test.js",
     "lint": "standard 'shared/js/ui/**/*.js'",
     "test": "grunt test --browser=chrome --type=dev",
+    "test-debug": "grunt test --browser=chrome --type=dev --test-debug",
     "dev-firefox": "make dev browser=firefox type=dev",
     "release-firefox": "make browser=firefox type=release",
     "dev-chrome": "make dev browser=chrome type=dev",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** self (trivial tooling change)

**CC:** @jdorweiler 

## Description:

Adds `npm run test-debug`.

You'll see a URL in the console. You can open that, and the tests will run in your browser.

If there's an error, you can switch on "pause on uncaught errors" to debug.

You can also add `debugger` in your code to start debugging.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
