### PR TITLE
better regex matching

### DIFF
--- a/shared/js/background/classes/score.es6.js
+++ b/shared/js/background/classes/score.es6.js
@@ -1,10 +1,12 @@
 const tosdr = require('../../../data/tosdr')
 const constants = require('../../../data/constants')
-const tosdrRegexList = Object.keys(tosdr).map(x => new RegExp(x))
+
+// regex to match site domains to tosdr entries. Match either start of line or period to prevent false positives.
+const tosdrRegexList = Object.keys(tosdr).map(x => new RegExp(`(^|\.)${x}`))
 const tosdrClassMap = {'A': -1, 'B': 0, 'C': 0, 'D': 1, 'E': 2} // map tosdr class rankings to increase/decrease in grade
 const siteScores = ['A', 'B', 'C', 'D']
 const pagesSeenOn = constants.majorTrackingNetworks
-const pagesSeenOnRegexList = Object.keys(pagesSeenOn).map(x => new RegExp(`${x}\\.`))
+const pagesSeenOnRegexList = Object.keys(pagesSeenOn).map(x => new RegExp(`(^|\.)${x}\\.`))
 
 class Score {
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Our company and tosdr regex is a bit too loose in that it matches any sub string with the site name in it. For example, deletefacebook.com matches for facebook.
I made the regexes a little more specific by adds a start of line `^` or period to the beginning. This way we still can match on exact hostname and subdomains.
The regex for facebook will go from `facebook.` to `(^|.)facebook.`   

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
