### PR TITLE
Allow localhost to be added to white list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,6 @@ module.exports = function(grunt) {
         },
         unitTest: {
             '<%= dirs.unitTest.build %>/background.js': ['<%= dirs.unitTest.background %>/**/*.js'],
-            // TODO uncomment this when we add some UI tests
             '<%= dirs.unitTest.build %>/ui.js': ['<%= dirs.src.js %>/ui/base/index.es6.js', '<%= dirs.unitTest.ui %>/**/*.js']
         },
         sass: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
         unitTest: {
             '<%= dirs.unitTest.build %>/background.js': ['<%= dirs.unitTest.background %>/**/*.js'],
             // TODO uncomment this when we add some UI tests
-            // '<%= dirs.unitTest.build %>/ui.js': ['<%= dirs.unitTest.ui %>/**/*.js']
+            '<%= dirs.unitTest.build %>/ui.js': ['<%= dirs.src.js %>/ui/base/index.es6.js', '<%= dirs.unitTest.ui %>/**/*.js']
         },
         sass: {
             '<%= dirs.public.css %>/noatb.css': ['<%= dirs.src.scss %>/noatb.scss'],
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
     let karmaOps = {
         configFile: 'karma.conf.js',
         basePath: 'build/test/',
-        files: ['background.js']
+        files: ['background.js','ui.js']
     }
 
     // override some options to allow the devs

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -1,4 +1,5 @@
 const index = require('../base/index.es6')
+// TODO tidy up Parent ref so above line isn't necessary
 const Parent = window.DDG.base.Model
 const tldjs = require('tldjs')
 

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -1,3 +1,4 @@
+const index = require('../base/index.es6')
 const Parent = window.DDG.base.Model
 const tldjs = require('tldjs')
 

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -37,8 +37,9 @@ Whitelist.prototype = window.$.extend({},
       // But first, strip the 'www.' part, otherwise getSubDomain will include it
       // and whitelisting won't work for that site
       url = url ? url.replace('www.', '') : ''
+      const localDomain = url.toLowerCase() === 'localhost' ? 'localhost' : null
       const subDomain = tldjs.getSubdomain(url)
-      const domain = tldjs.getDomain(url)
+      const domain = tldjs.getDomain(url) || localDomain
       if (domain) {
         const domainToWhitelist = subDomain ? subDomain + '.' + domain : domain
         console.log(`whitelist: add ${domainToWhitelist}`)

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -1,5 +1,3 @@
-const index = require('../base/index.es6')
-// TODO tidy up Parent ref so above line isn't necessary
 const Parent = window.DDG.base.Model
 const tldjs = require('tldjs')
 

--- a/unit-test/ui/models/whitelist.es6.js
+++ b/unit-test/ui/models/whitelist.es6.js
@@ -1,0 +1,36 @@
+const Whitelist = require('../../../shared/js/ui/models/whitelist.es6')
+
+let whitelist
+
+const domainTestCases = [
+  {
+        "url": "duckduckgo.com",
+        "valid": true
+  },
+  {
+        "url": "duckduck",
+        "valid": false
+  },
+  {
+        "url": "localhost",
+        "valid": true
+  },
+  {
+        "url": "",
+        "valid": false
+  }
+]
+
+describe('whitelist.addDomain()', () => {
+    whitelist = new Whitelist({})
+    domainTestCases.forEach((test) => {
+        it(`should return ${test.valid} for ${test.url}`, () => {
+            let result = whitelist.addDomain(test.url)
+            if (test.valid) {
+                expect(result).toBe(test.url.toLowerCase())
+            } else {
+                expect(result).toBe(null)
+            }
+        })
+    })
+})


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 
<!-- Optional fields
**CC:** 
**Depends on:** 
-->

## Description: 
Update validation to allow localhost to be added to whitelist on settings page.
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:

1. On the options page, add localhost to whitelist. Now visit a localhost address and open the popup. Privacy protection should be turned off.
2. Visit options page again and remove localhost from the whitelist. Privacy protection should be back on for localhost.
3. Add other urls both valid and invalid to the whitelist. Check that the validation still works properly.
4. `npm run test`