### PR TITLE
Fix empty icon in top blocked pills

### DIFF
--- a/shared/js/ui/templates/top-blocked-truncated-list-items.es6.js
+++ b/shared/js/ui/templates/top-blocked-truncated-list-items.es6.js
@@ -19,8 +19,9 @@ module.exports = function (companyListMap) {
 
   function getScssClass (companyName) {
     var genericName = 'generic'
- 
-    if (majorTrackingNetworks[companyName]) {
+
+    // TODO: remove Oath special case when we have an icon for it 
+    if ((companyName !== 'oath') && majorTrackingNetworks[companyName]) {
       return companyName
     } else {
       return genericName


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
We check whether a tracker is part of a major network in order to know when to show the generic pill.
Oath is part of the major networks but doesn't have an icon yet. Added a special case until we can add the icon for it.


## Steps to test this PR:
1. (optional) Mock Oath being a top tracker network in the code
2. Build and reload extension
3. If you didn't do step 1, load 30 sites of which most have third party Oath trackers
4. Top blocked pills should show up - Oath will have the generic icon

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
