### PR TITLE
Add ATB to postinstall page

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -155,8 +155,11 @@ var ATB = (() => {
                     const regExpPostInstall = new RegExp('duckduckgo\.com\/app')
                     if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
                         settings.updateSetting('hasSeenPostInstall', true)
+                        let postInstallURL = 'https://duckduckgo.com/app?post=1'
+                        let versions = ATB.calculateInitialVersions()
+                        postInstallURL += (versions && versions.major && versions.minor) ? `&v${versions.major}-${versions.minor}` : ''
                         chrome.tabs.create({
-                            url: 'https://duckduckgo.com/app?post=1'
+                            url: postInstallURL
                         })
                     }
                 })

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -156,7 +156,7 @@ var ATB = (() => {
                     if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
                         settings.updateSetting('hasSeenPostInstall', true)
                         let postInstallURL = 'https://duckduckgo.com/app?post=1'
-                        let atb = settings.getSetting('atb')
+                        const atb = ATB.getLatestATB()
                         postInstallURL += atb ? `&atb=${atb}` : ''
                         chrome.tabs.create({
                             url: postInstallURL
@@ -194,6 +194,12 @@ var ATB = (() => {
             if (extensionVersion) url += `&v=${extensionVersion}`
 
             return url
+        },
+
+        getLatestATB: () => {
+            let atb = settings.getSetting('set_atb')
+            if (!atb) atb = settings.getSetting('atb')
+            return atb
         }
     }
 })()

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -156,7 +156,7 @@ var ATB = (() => {
                     if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
                         settings.updateSetting('hasSeenPostInstall', true)
                         let postInstallURL = 'https://duckduckgo.com/app?post=1'
-                        const atb = ATB.getLatestATB()
+                        const atb = settings.getSetting('atb')
                         postInstallURL += atb ? `&atb=${atb}` : ''
                         chrome.tabs.create({
                             url: postInstallURL
@@ -194,12 +194,6 @@ var ATB = (() => {
             if (extensionVersion) url += `&v=${extensionVersion}`
 
             return url
-        },
-
-        getLatestATB: () => {
-            let atb = settings.getSetting('set_atb')
-            if (!atb) atb = settings.getSetting('atb')
-            return atb
         }
     }
 })()

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -156,8 +156,8 @@ var ATB = (() => {
                     if ((!settings.getSetting('hasSeenPostInstall')) && (!domain.match(regExpPostInstall))) {
                         settings.updateSetting('hasSeenPostInstall', true)
                         let postInstallURL = 'https://duckduckgo.com/app?post=1'
-                        let versions = ATB.calculateInitialVersions()
-                        postInstallURL += (versions && versions.major && versions.minor) ? `&v${versions.major}-${versions.minor}` : ''
+                        let atb = settings.getSetting('atb')
+                        postInstallURL += atb ? `&atb=${atb}` : ''
                         chrome.tabs.create({
                             url: postInstallURL
                         })

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -13,7 +13,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
     }
 
     if (details.reason.match(/install/)) {
-        ATB.openPostInstallPage()
+        setTimeout(() => ATB.openPostInstallPage(), 500)
     }
 })
 

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -13,6 +13,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
     }
 
     if (details.reason.match(/install/)) {
+        // need to wait at least 750 ms for ATB to be set
         setTimeout(() => ATB.openPostInstallPage(), 750)
     }
 })

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -13,7 +13,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
     }
 
     if (details.reason.match(/install/)) {
-        setTimeout(() => ATB.openPostInstallPage(), 500)
+        setTimeout(() => ATB.openPostInstallPage(), 750)
     }
 })
 

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -57,7 +57,7 @@ let onStartup = (() => {
 
     if (showPostInstallPage) {
         // need at least 750 ms before atb is available
-        setTimeout(() =>
+        setTimeout(() => {
             // we'll open the post install page in a new tab but keep the current tab active. To do this
             // we need to open a tab then reset the active tab
             let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -55,22 +55,22 @@ let onStartup = (() => {
         })
     })
 
-    if (showPostInstallPage) {
-        // we'll open the post install page in a new tab but keep the current tab active. To do this
-        // we need to open a tab then reset the active tab
-        let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
-        let postInstallURL = 'https://duckduckgo.com/app?post=1'
-        // show atb in postinstall page
-        const atb = settings.getSetting('atb')
-        postInstallURL += atb ? `&atb=${atb}` : ''
-        // need at least 750 ms before atb is available
-        setTimeout(function () {
+    setTimeout(function () {
+        if (showPostInstallPage) {
+            // we'll open the post install page in a new tab but keep the current tab active. To do this
+            // we need to open a tab then reset the active tab
+            let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
+            let postInstallURL = 'https://duckduckgo.com/app?post=1'
+            // show atb in postinstall page
+            const atb = settings.getSetting('atb')
+            postInstallURL += atb ? `&atb=${atb}` : ''
+            // need at least 750 ms before atb is available
             safari.application.activeBrowserWindow.openTab().url = postInstallURL
-        }, 750)
-            
-        // reactive the previous tab
-        safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
-    }
+                
+            // reactive the previous tab
+            safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
+        }
+    }, 750)
 
     // reload popup 
     browserWrapper.notifyPopup()

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -55,9 +55,9 @@ let onStartup = (() => {
         })
     })
 
-    // need at least 750 ms before atb is available
-    setTimeout(function () {
-        if (showPostInstallPage) {
+    if (showPostInstallPage) {
+        // need at least 750 ms before atb is available
+        setTimeout(function () {
             // we'll open the post install page in a new tab but keep the current tab active. To do this
             // we need to open a tab then reset the active tab
             let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
@@ -69,8 +69,8 @@ let onStartup = (() => {
                 
             // reactive the previous tab
             safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
-        }
-    }, 750)
+        }, 750)
+    }
 
     // reload popup 
     browserWrapper.notifyPopup()

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -59,7 +59,14 @@ let onStartup = (() => {
         // we'll open the post install page in a new tab but keep the current tab active. To do this
         // we need to open a tab then reset the active tab
         let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)
-        safari.application.activeBrowserWindow.openTab().url = 'https://duckduckgo.com/app?post=1'
+        let postInstallURL = 'https://duckduckgo.com/app?post=1'
+        // show atb in postinstall page
+        const atb = settings.getSetting('atb')
+        postInstallURL += atb ? `&atb=${atb}` : ''
+        // need at least 750 ms before atb is available
+        setTimeout(function () {
+            safari.application.activeBrowserWindow.openTab().url = postInstallURL
+        }, 750)
             
         // reactive the previous tab
         safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -57,7 +57,7 @@ let onStartup = (() => {
 
     if (showPostInstallPage) {
         // need at least 750 ms before atb is available
-        setTimeout(function () {
+        setTimeout(() =>
             // we'll open the post install page in a new tab but keep the current tab active. To do this
             // we need to open a tab then reset the active tab
             let activeTabIdx = _getSafariTabIndex(safari.application.activeBrowserWindow.activeTab)

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -55,6 +55,7 @@ let onStartup = (() => {
         })
     })
 
+    // need at least 750 ms before atb is available
     setTimeout(function () {
         if (showPostInstallPage) {
             // we'll open the post install page in a new tab but keep the current tab active. To do this
@@ -64,7 +65,6 @@ let onStartup = (() => {
             // show atb in postinstall page
             const atb = settings.getSetting('atb')
             postInstallURL += atb ? `&atb=${atb}` : ''
-            // need at least 750 ms before atb is available
             safari.application.activeBrowserWindow.openTab().url = postInstallURL
                 
             // reactive the previous tab


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Add ATB params to post-install page


## Steps to test this PR:
1. Uninstall extension
2. Build and reinstall 
3. Postinstall page should open and the URL should look like https://duckduckgo.com/app?post=1&atb=v113-1 
4. If installing from ddh6, the variant should be there as well, eg https://duckduckgo.com/app?post=1&atb=v113-1_f

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 