### PR TITLE
Safari needs a longer timeout after install

### DIFF
--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -56,7 +56,7 @@ let onStartup = (() => {
     })
 
     if (showPostInstallPage) {
-        // need at least 750 ms before atb is available
+        // need at least 3s before atb is available in safari
         setTimeout(() => {
             // we'll open the post install page in a new tab but keep the current tab active. To do this
             // we need to open a tab then reset the active tab
@@ -69,7 +69,7 @@ let onStartup = (() => {
                 
             // reactive the previous tab
             safari.application.activeBrowserWindow.tabs[activeTabIdx].activate()
-        }, 750)
+        }, 3000)
     }
 
     // reload popup 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
750 ms are not sufficient in Safari to retrieve ATB after install, it needs at least 3 seconds.
Followup from #206 



## Steps to test this PR:
1. Upload to ddh6
2. Uninstall and reinstall extension 
3. post install page should open in a new tab, with URL like https://duckduckgo.com/app?post=1&atb=v113-1_f

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
