### PR TITLE
Temporarily use global tabManager for safari-wrapper

### DIFF
--- a/shared/js/background/safari-wrapper.es6.js
+++ b/shared/js/background/safari-wrapper.es6.js
@@ -1,5 +1,5 @@
-/* global safari:false */
-const tabManager = require('./tab-manager.es6')
+/* global safari:false tabManager:false */
+// const tabManager = require('./tab-manager.es6')
 
 let getExtensionURL = (path) => {
     return safari.extension.baseURI + path


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Revert one of the changes from #212, and add `tabManager` as a global for that file so linting doesn't complain.

I'm gonna look at this in more detail tomorrow.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
