### PR TITLE
When a port is specified for localhost, it should still be accepted as valid

### DIFF
--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -39,7 +39,7 @@ Whitelist.prototype = window.$.extend({},
             // But first, strip the 'www.' part, otherwise getSubDomain will include it
             // and whitelisting won't work for that site
             url = url ? url.replace('www.', '') : ''
-            const localDomain = url.match(/^localhost(\:[0-9]+)?$/i) ? 'localhost' : null
+            const localDomain = url.match(/^localhost(:[0-9]+)?$/i) ? 'localhost' : null
             const subDomain = tldjs.getSubdomain(url)
             const domain = tldjs.getDomain(url) || localDomain
             if (domain) {

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -39,7 +39,7 @@ Whitelist.prototype = window.$.extend({},
             // But first, strip the 'www.' part, otherwise getSubDomain will include it
             // and whitelisting won't work for that site
             url = url ? url.replace('www.', '') : ''
-            const localDomain = url.toLowerCase() === 'localhost' ? 'localhost' : null
+            const localDomain = url.match(/^localhost(\:[0-9]+)?$/i) ? 'localhost' : null
             const subDomain = tldjs.getSubdomain(url)
             const domain = tldjs.getDomain(url) || localDomain
             if (domain) {

--- a/unit-test/ui/models/whitelist.es6.js
+++ b/unit-test/ui/models/whitelist.es6.js
@@ -5,18 +5,47 @@ let whitelist
 const domainTestCases = [
     {
         'url': 'duckduckgo.com',
+        'whitelistedDomain': 'duckduckgo.com',
+        'valid': true
+    },
+    {
+        'url': 'bttf.duckduckgo.com',
+        'whitelistedDomain': 'duckduckgo.com',
+        'valid': true
+    },
+    {
+        'url': 'duckduckgo.com/?q=test&ia=web',
+        'whitelistedDomain': 'duckduckgo.com',
+        'valid': true
+    },
+    {
+        'url': 'www.duckduckgo.com',
+        'whitelistedDomain': 'duckduckgo.com',
         'valid': true
     },
     {
         'url': 'duckduck',
+        'whitelistedDomain': '',
         'valid': false
     },
     {
         'url': 'localhost',
+        'whitelistedDomain': 'localhost',
         'valid': true
     },
     {
+        'url': 'localhost:5000',
+        'whitelistedDomain': 'localhost',
+        'valid': true
+    },
+    {
+        'url': 'localhost:asdasdasd',
+        'whitelistedDomain': '',
+        'valid': false
+    },
+    {
         'url': '',
+        'whitelistedDomain': '',
         'valid': false
     }
 ]
@@ -27,7 +56,7 @@ describe('whitelist.addDomain()', () => {
         it(`should return ${test.valid} for ${test.url}`, () => {
             let result = whitelist.addDomain(test.url)
             if (test.valid) {
-                expect(result).toBe(test.url.toLowerCase())
+                expect(result).toBe(test.whitelistedDomain)
             } else {
                 expect(result).toBe(null)
             }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 


**CC:** @andrey-p 
<!-- Optional fields
**Depends on:** 
-->

## Description:
Following up from #199, this also allows to whitelist the localhost when a port is specified (currently, strings like 'localhost:8080' are not considered valid).


## Steps to test this PR:
1. Build and reload extension
2. Go to the options page
3. Try whitelisting 'localhost', 'localhost:8080' (or use any port) - both should be valid
4. Things like 'localhost:asdlajshdkja' should still be invalid
5. Try whitelisting other domains: they should get validated as usual
6. After whitelisting a domain, navigate to it and make sure it's actually whitelisted
7. Play around with adding and removing domains using the toggle and the options page to make sure functionality is intact


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
