### PR TITLE
Tidy up globals in Safari

### DIFF
--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -128,7 +128,7 @@ safari.extension.globalPage.contentWindow.message = handleUIMessage
 let updateSetting = (e) => {
     let name = e.message.updateSetting.name
     let val = e.message.updateSetting.value
-    if (name && val) {
+    if (name) {
         settings.updateSetting(name, val)
     }
 }

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -6,10 +6,6 @@ const settings = require('./settings.es6')
 const abpLists = require('./abp-lists.es6')
 const browserWrapper = require('./safari-wrapper.es6')
 
-// add these to contentWindow so the popup can access them
-safari.extension.globalPage.contentWindow.tabManager = tabManager
-safari.extension.globalPage.contentWindow.Companies = Companies
-
 let _getSafariTabIndex = (target) => {
     for (let i = 0; i < safari.application.activeBrowserWindow.tabs.length; i++) {
         if (target === safari.application.activeBrowserWindow.tabs[i]) {
@@ -97,6 +93,38 @@ let handleMessage = (e) => {
     }
 }
 
+let getActiveTab = () => {
+    let activeTab = safari.application.activeBrowserWindow.activeTab
+    if (activeTab.ddgTabId) {
+        return tabManager.get({tabId: activeTab.ddgTabId})
+    } else {
+        let id = browserWrapper.getTabId({target: activeTab})
+        return tabManager.get({tabId: id})
+    }
+}
+
+let handleUIMessage = (req, res) => {
+    if (req.getCurrentTab || req.getTab) {
+        res(getActiveTab())
+    } else if (req.getTopBlocked) {
+        res(Companies.getTopBlocked(req.getTopBlocked))
+    } else if (req.getBrowser) {
+        res('safari')
+    } else if (req.whitelisted) {
+        res(tabManager.whitelistDomain(req.whitelisted))
+    } else if (req.getSiteScore) {
+        let tab = tabManager.get({tabId: req.getSiteScore})
+        if (tab) res(tab.site.score.get())
+    } else if (req.getTopBlockedByPages) {
+        res(Companies.getTopBlockedByPages(req.getTopBlockedByPages))
+    } else if (req.resetTrackersData) {
+        Companies.resetData()
+        safari.self.hide()
+    }
+}
+
+safari.extension.globalPage.contentWindow.message = handleUIMessage
+
 let updateSetting = (e) => {
     let name = e.message.updateSetting.name
     let val = e.message.updateSetting.value
@@ -130,7 +158,7 @@ let onBeforeRequest = (requestData) => {
 
     if (!(currentURL && potentialTracker)) return
 
-    let tabId = requestData.target.ddgTabId || tabManager.getTabId(requestData)
+    let tabId = requestData.target.ddgTabId || browserWrapper.getTabId(requestData)
     let thisTab = tabManager.get({tabId: tabId})
     requestData.tabId = tabId
 
@@ -165,7 +193,7 @@ let onBeforeRequest = (requestData) => {
 
 // update the popup when switching browser windows
 let onActivate = (e) => {
-    let activeTab = tabManager.getActiveTab()
+    let activeTab = getActiveTab()
     if (activeTab) {
         activeTab.updateBadgeIcon(e.target)
         safari.extension.popovers[0].contentWindow.location.reload()
@@ -232,7 +260,7 @@ var onBeforeNavigation = function (e) {
     if (!e.url || !e.target || e.target.url === 'about:blank' || e.url.match(/com.duckduckgo.safari/)) return
 
     const url = e.url
-    const tabId = tabManager.getTabId(e)
+    const tabId = browserWrapper.getTabId(e)
 
     let thisTab = tabId && tabManager.get({tabId: tabId})
 

--- a/shared/js/background/safari-wrapper.es6.js
+++ b/shared/js/background/safari-wrapper.es6.js
@@ -89,11 +89,6 @@ let getTabId = (e) => {
     }
 }
 
-let reloadTab = () => {
-    var activeTab = safari.application.activeBrowserWindow.activeTab
-    activeTab.url = activeTab.url
-}
-
 let mergeSavedSettings = (settings, results) => {
     return Object.assign(settings, results)
 }
@@ -107,6 +102,5 @@ module.exports = {
     notifyPopup: notifyPopup,
     normalizeTabData: normalizeTabData,
     getTabId: getTabId,
-    reloadTab: reloadTab,
     mergeSavedSettings: mergeSavedSettings
 }

--- a/shared/js/background/safari-wrapper.es6.js
+++ b/shared/js/background/safari-wrapper.es6.js
@@ -1,6 +1,4 @@
-/* global safari:false tabManager:false */
-// const tabManager = require('./tab-manager.es6')
-
+/* global safari:false */
 let getExtensionURL = (path) => {
     return safari.extension.baseURI + path
 }
@@ -91,16 +89,6 @@ let getTabId = (e) => {
     }
 }
 
-let getActiveTab = () => {
-    let activeTab = safari.application.activeBrowserWindow.activeTab
-    if (activeTab.ddgTabId) {
-        return tabManager.get({tabId: activeTab.ddgTabId})
-    } else {
-        let id = getTabId({target: activeTab})
-        return tabManager.get({tabId: id})
-    }
-}
-
 let reloadTab = () => {
     var activeTab = safari.application.activeBrowserWindow.activeTab
     activeTab.url = activeTab.url
@@ -119,7 +107,6 @@ module.exports = {
     notifyPopup: notifyPopup,
     normalizeTabData: normalizeTabData,
     getTabId: getTabId,
-    getActiveTab: getActiveTab,
     reloadTab: reloadTab,
     mergeSavedSettings: mergeSavedSettings
 }

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -8,48 +8,6 @@ class TabManager {
         this.tabContainer = {}
     };
 
-    /* Get stashed tabId from native safari tabs. This needs to
-     * be here for now. For some reason moving this to the ui
-     * seems to give us a copy of the native tabs without our
-     * stashed tab ids.
-     */
-    getTabId (e) {
-        if (e.target.ddgTabId) return e.target.ddgTabId
-        for (let id in window.safari.application.activeBrowserWindow.tabs) {
-            if (window.safari.application.activeBrowserWindow.tabs[id] === e.target) {
-                // prevent race conditions incase another events set a tabId
-                if (window.safari.application.activeBrowserWindow.tabs[id].ddgTabId) {
-                    return window.safari.application.activeBrowserWindow.tabs[id].ddgTabId
-                }
-
-                let tabId = Math.floor(Math.random() * (100000 - 10 + 1)) + 10
-                window.safari.application.activeBrowserWindow.tabs[id].ddgTabId = tabId
-                console.log(window.safari.application.activeBrowserWindow.tabs[id])
-                console.log(`Created Tab id: ${tabId}`)
-                return tabId
-            }
-        }
-    };
-
-    /* Get active safari tab. Needs to be here for the same reason as
-     * getTabId above
-     */
-    getActiveTab () {
-        let activeTab = window.safari.application.activeBrowserWindow.activeTab
-        if (activeTab.ddgTabId) {
-            return tabManager.get({tabId: activeTab.ddgTabId})
-        } else {
-            let id = tabManager.getTabId({target: activeTab})
-            return tabManager.get({tabId: id})
-        }
-    };
-
-    // reload safari tab. Move this out later with the other safari methods
-    reloadTab () {
-        var activeTab = window.safari.application.activeBrowserWindow.activeTab
-        activeTab.url = activeTab.url
-    };
-
     /* This overwrites the current tab data for a given
      * id and is only called in three cases:
      * 1. When we rebuild saved tabs when the browser is restarted

--- a/shared/js/ui/base/chrome-ui-wrapper.es6.js
+++ b/shared/js/ui/base/chrome-ui-wrapper.es6.js
@@ -49,8 +49,19 @@ let getExtensionVersion = () => {
     return manifest.version
 }
 
+let reloadTab = (id) => {
+    window.chrome.tabs.reload(id)
+}
+
+let closePopup = () => {
+    const w = window.chrome.extension.getViews({type: 'popup'})[0]
+    w.close()
+}
+
 module.exports = {
     fetch: fetch,
+    reloadTab: reloadTab,
+    closePopup: closePopup,
     backgroundMessage: backgroundMessage,
     getBackgroundTabData: getBackgroundTabData,
     createBrowserTab: createBrowserTab,

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -103,6 +103,8 @@ let getExtensionVersion = () => {
 
 module.exports = {
     fetch: fetch,
+    reloadTab: reloadTab,
+    closePopup: closePopup,
     backgroundMessage: backgroundMessage,
     getBackgroundTabData: getBackgroundTabData,
     createBrowserTab: createBrowserTab,

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -1,45 +1,58 @@
 /* global safari:false */
+let context
+
+if (safari &&
+        safari.extension &&
+        safari.extension.globalPage &&
+        safari.extension.globalPage.contentWindow) {
+    context = 'popup'
+} else if (safari &&
+        safari.self &&
+        safari.self.tab) {
+    context = 'options'
+} else {
+    throw new Error('safari-ui-wrapper couldn\'t figure out the context it\'s in')
+}
+
+let sendOptionsMessage = (message, resolve, reject) => {
+    // messages that require an answer need some more complicated logic
+    // since sending a message through the options page doesn't support
+    // two-way messaging
+    if (message.whitelisted) {
+        resolve(safari.self.tab.dispatchMessage('whitelisted', message))
+    } else if (message.getSetting) {
+        // send message random ID so we know which promise to res
+        let id = Math.random()
+        message.id = id
+        safari.self.tab.dispatchMessage('getSetting', message)
+
+        safari.self.addEventListener('message', (e) => {
+            if (e.name === 'getSetting' && e.message.id === id) {
+                delete e.message.id
+                resolve(e.message)
+            }
+        }, true)
+    } else if (message.updateSetting) {
+        resolve(safari.self.tab.dispatchMessage('updateSetting', message))
+    }
+}
+
+let reloadTab = () => {
+    var activeTab = window.safari.application.activeBrowserWindow.activeTab
+    activeTab.url = activeTab.url
+}
+
+let closePopup = () => {
+    window.safari.self.hide()
+}
+
 let fetch = (message) => {
     return new Promise((resolve, reject) => {
         console.log(`Safari Fetch: ${JSON.stringify(message)}`)
-        if (message.getCurrentTab || message.getTab) {
-            resolve(safari.extension.globalPage.contentWindow.tabManager.getActiveTab())
-        } else if (message.getTopBlocked) {
-            resolve(safari.extension.globalPage.contentWindow.Companies.getTopBlocked(message.getTopBlocked))
-        } else if (message.getBrowser) {
-            resolve('safari')
-        } else if (message.whitelisted) {
-            if (message.context && message.context === 'options') {
-                resolve(safari.self.tab.dispatchMessage('whitelisted', message))
-            } else {
-                resolve(safari.extension.globalPage.contentWindow.tabManager.whitelistDomain(message.whitelisted))
-            }
-        } else if (message.getSiteScore) {
-            let tab = safari.extension.globalPage.contentWindow.tabManager.get({tabId: message.getSiteScore})
-            if (tab) resolve(tab.site.score.get())
-        } else if (message.getSetting) {
-            if (message.context && message.context === 'options') {
-                // send message random ID so we know which promise to resolve
-                let id = Math.random()
-                message.id = id
-                safari.self.tab.dispatchMessage('getSetting', message)
-
-                safari.self.addEventListener('message', (e) => {
-                    if (e.name === 'getSetting' && e.message.id === id) {
-                        delete e.message.id
-                        resolve(e.message)
-                    }
-                }, true)
-            }
-        } else if (message.updateSetting) {
-            if (message.context && message.context === 'options') {
-                resolve(safari.self.tab.dispatchMessage('updateSetting', message))
-            }
-        } else if (message.getTopBlockedByPages) {
-            resolve(safari.extension.globalPage.contentWindow.Companies.getTopBlockedByPages(message.getTopBlockedByPages))
-        } else if (message.resetTrackersData) {
-            safari.extension.globalPage.contentWindow.Companies.resetData()
-            safari.self.hide()
+        if (context === 'popup') {
+            safari.extension.globalPage.contentWindow.message(message, resolve)
+        } else if (context === 'options') {
+            sendOptionsMessage(message, resolve, reject)
         }
     })
 }
@@ -58,14 +71,14 @@ let backgroundMessage = (thisModel) => {
 
 let getBackgroundTabData = () => {
     return new Promise((resolve) => {
-        let tab = safari.extension.globalPage.contentWindow.tabManager.getActiveTab()
-
-        if (tab) {
-            let tabCopy = JSON.parse(JSON.stringify(tab))
-            resolve(tabCopy)
-        } else {
-            resolve()
-        }
+        fetch({getCurrentTab: true}).then((tab) => {
+            if (tab) {
+                let tabCopy = JSON.parse(JSON.stringify(tab))
+                resolve(tabCopy)
+            } else {
+                resolve()
+            }
+        })
     })
 }
 

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -15,9 +15,6 @@ if (safari &&
 }
 
 let sendOptionsMessage = (message, resolve, reject) => {
-    // messages that require an answer need some more complicated logic
-    // since sending a message through the options page doesn't support
-    // two-way messaging
     if (message.whitelisted) {
         resolve(safari.self.tab.dispatchMessage('whitelisted', message))
     } else if (message.getSetting) {

--- a/shared/js/ui/models/privacy-options.es6.js
+++ b/shared/js/ui/models/privacy-options.es6.js
@@ -1,8 +1,5 @@
 const Parent = window.DDG.base.Model
 
-// Safari needs to know that a fetch request came from the options page
-const context = 'options'
-
 function PrivacyOptions (attrs) {
     // set some default values for the toggle switches in the template
     attrs.trackerBlockingEnabled = true
@@ -22,14 +19,14 @@ PrivacyOptions.prototype = window.$.extend({},
             if (this.hasOwnProperty(k)) {
                 this[k] = !this[k]
                 console.log(`PrivacyOptions model toggle ${k} is now ${this[k]}`)
-                this.fetch({updateSetting: {name: k, value: this[k]}, context: context})
+                this.fetch({updateSetting: {name: k, value: this[k]}})
             }
         },
 
         getSettings: function () {
             let self = this
             return new Promise((resolve, reject) => {
-                self.fetch({getSetting: 'all', context: context}).then((settings) => {
+                self.fetch({getSetting: 'all'}).then((settings) => {
                     self.trackerBlockingEnabled = settings['trackerBlockingEnabled']
                     self.httpsEverywhereEnabled = settings['httpsEverywhereEnabled']
                     self.embeddedTweetsEnabled = settings['embeddedTweetsEnabled']

--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -23,8 +23,7 @@ Whitelist.prototype = window.$.extend({},
                     list: 'whitelisted',
                     domain: domain,
                     value: false
-                },
-                context: 'options'
+                }
             })
 
             // Update list
@@ -51,8 +50,7 @@ Whitelist.prototype = window.$.extend({},
                         list: 'whitelisted',
                         domain: domainToWhitelist,
                         value: true
-                    },
-                    context: 'options'
+                    }
                 })
 
                 this.setWhitelistFromSettings()
@@ -63,7 +61,7 @@ Whitelist.prototype = window.$.extend({},
 
         setWhitelistFromSettings: function () {
             let self = this
-            this.fetch({getSetting: {name: 'whitelisted'}, context: 'options'}).then((whitelist) => {
+            this.fetch({getSetting: {name: 'whitelisted'}}).then((whitelist) => {
                 whitelist = whitelist || {}
                 let wlist = Object.keys(whitelist)
                 wlist.sort()

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -6,6 +6,7 @@ const gradeScorecardTemplate = require('./../templates/grade-scorecard.es6.js')
 const trackerNetworksTemplate = require('./../templates/tracker-networks.es6.js')
 const privacyPracticesTemplate = require('./../templates/privacy-practices.es6.js')
 const openOptionsPage = require('./mixins/open-options-page.es6.js')
+const browserUIWrapper = require('./../base/$BROWSER-ui-wrapper.es6.js')
 
 function Site (ops) {
     this.model = ops.model
@@ -52,14 +53,12 @@ Site.prototype = window.$.extend({},
             setTimeout(() => this.$protection.addClass(isTransparentClass), 10)
             // Wait a bit more before closing the popup and reloading the tab
 
-            if (window.chrome) {
-                const w = window.chrome.extension.getViews({type: 'popup'})[0]
-                setTimeout(() => window.chrome.tabs.reload(this.model.tab.id), 1500)
-                setTimeout(() => w.close(), 1500)
-            } else if (window.safari) {
-                setTimeout(() => window.safari.extension.globalPage.contentWindow.tabManager.reloadTab(), 1500)
-                setTimeout(() => window.safari.self.hide(), 1500)
-            }
+            setTimeout(() => {
+                browserUIWrapper.reloadTab(this.model.tab.id)
+            }, 1500)
+            setTimeout(() => {
+                browserUIWrapper.closePopup()
+            }, 1500)
         },
 
         // NOTE: after ._setup() is called this view listens for changes to


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

**CC:** @MariagraziaAlastra 

## Description:

This drops the use of globals on `contentWindow` for Safari. See inline comments for more info.

## Steps to test this PR:

1. Make Safari passes information correctly between the background tab and the popup:
    - number of trackers blocked updates
    - top trackers gets updated and reset correctly
    - whitelisting via the toggle works
    - grade is shown correctly
2. Make sure Safari passes information correctly between the background tab and the options page:
    - the embedded tweet blocking toggle should work
    - you can manually add / remove sites to the whitelist, and that gets updated in the popup
3. When you whitelist a site via the popup in Chrome/FF, the popup should close and the page should refresh.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
