### PR TITLE
Fix redirect counting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,13 +1192,19 @@
       "requires": {
         "bin-version": "0.1.0",
         "minimist": "0.1.0",
-        "semver": "5.3.0"
+        "semver": "2.3.2"
       },
       "dependencies": {
         "minimist": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+          "dev": true
+        },
+        "semver": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+          "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
           "dev": true
         }
       }
@@ -7426,7 +7432,7 @@
       "requires": {
         "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.0.3",
         "validate-npm-package-license": "3.0.3"
       }
     },
@@ -8778,10 +8784,10 @@
       }
     },
     "semver": {
-        "version": "5.0.3",
-        "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-        "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-        "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+      "dev": true
     },
     "semver-regex": {
       "version": "0.1.1",
@@ -9727,6 +9733,12 @@
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
       "dev": true,
       "optional": true
+    },
+    "timekeeper": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.1.1.tgz",
+      "integrity": "sha512-rc7RnyF6PrFj6FIpmO6pi4k65v9tq8QldDcElurKrRCCZ9kg31uNIwiPQdyTkFhSBCoR6sd9/T4Rm3C7ZNKFAg==",
+      "dev": true
     },
     "timers-browserify": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "puppeteer": "1.2.0",
     "request": "2.83.0",
     "selenium-webdriver": "3.0.1",
-    "standard": "10.0.3"
+    "standard": "10.0.3",
+    "timekeeper": "^2.1.1"
   },
   "dependencies": {
     "abp-filter-parser": "git://github.com/duckduckgo/abp-filter-parser.git#0.2.0",

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -51,13 +51,6 @@ chrome.webRequest.onHeadersReceived.addListener(
     }
 )
 
-chrome.webRequest.onBeforeRedirect.addListener(
-    tabManager.updateTabRedirectCount,
-    {
-        urls: ['*://*/*']
-    }
-)
-
 /**
  * TABS
  */

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -43,7 +43,7 @@ class HttpsRedirects {
          * 2. The server gives 200 but prints out some HTML that redirects the page to HTTP
          * 3. We try to upgrade again
          *
-         * To prevent this, block we redirects to the same URL for the next few seconds
+         * To prevent this, block redirects to the same URL for the next few seconds
          */
         if (request.type === 'main_frame') {
             if (this.mainFrameRedirect &&

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -1,0 +1,49 @@
+const MAINFRAME_RESET_MS = 3000
+
+class HttpsRedirects {
+    constructor () {
+        this.failedUpgradeUrls = {}
+        this.redirectCounts = {}
+
+        this.mainFrameUpgrade = null
+        this.clearMainFrameTimeout = null
+    }
+
+    registerRedirect (request) {
+        if (request.type === 'main_frame') {
+            this.mainFrameUpgrade = {
+                url: request.url,
+                time: Date.now()
+            }
+
+            clearTimeout(this.clearMainFrameTimeout)
+            this.clearMainFrameTimeout = setTimeout(this.resetMainFrameRedirect, MAINFRAME_RESET_MS)
+        }
+    }
+
+    canRedirect (request) {
+        if (request.type === 'main_frame') {
+            if (this.mainFrameUpgrade &&
+                    this.mainFrameUpgrade.url === request.url) {
+                return Date.now() - this.mainFrameUpgrade.time > MAINFRAME_RESET_MS
+            }
+
+            return true
+        }
+
+        return true
+    }
+
+    persistMainFrameRedirect (redirectData) {
+    }
+
+    getMainFrameRedirect () {
+    }
+
+    resetMainFrameRedirect () {
+        clearTimeout(this.clearMainFrameTimeout)
+        this.mainFrameUpgrade = null
+    }
+}
+
+module.exports = HttpsRedirects

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -30,6 +30,7 @@ class HttpsRedirects {
 
         // this URL previously failed, don't try to upgrade it
         if (this.failedUpgradeUrls[request.url]) {
+            console.log(`HTTPS: not upgrading, url previously failed: ${request.url}`)
             return false
         }
 
@@ -45,6 +46,7 @@ class HttpsRedirects {
         // remember this URL as previously failed, don't try to upgrade it
         if (!canRedirect) {
             this.failedUpgradeUrls[request.url] = true
+            console.log(`HTTPS: not upgrading, redirect loop protection kicked in for url: ${request.url}`)
         }
 
         return canRedirect

--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -24,6 +24,7 @@ const scoreIconLocations = {
 
 const Site = require('./site.es6')
 const Tracker = require('./tracker.es6')
+const HttpsRedirects = require('./https-redirects.es6')
 const utils = require('../utils.es6')
 const Companies = require('../companies.es6')
 const browserWrapper = require('./../$BROWSER-wrapper.es6')
@@ -35,12 +36,10 @@ class Tab {
         this.trackersBlocked = {}
         this.url = tabData.url
         this.upgradedHttps = false
-        this.failedUpgradeUrls = {}
-        this.httpsRedirects = {} // count redirects here in form of: { <requestId>: <count> }
-        this.lastHttpsUpgrade = {}
         this.requestId = tabData.requestId
         this.status = tabData.status
         this.site = new Site(utils.extractHostFromURL(tabData.url))
+        this.httpsRedirects = new HttpsRedirects()
         this.statusCode = null // statusCode is set when headers are recieved in tabManager.js
         this.stopwatch = {
             begin: Date.now(),
@@ -104,14 +103,6 @@ class Tab {
             return newTracker
         }
     };
-
-    downgradeHttpsUpgradeRequest (reqData) {
-        if (reqData.type === 'main_frame') this.upgradedHttps = false
-        delete this.httpsRedirects[reqData.requestId]
-        const downgrade = reqData.url.replace(/^https:\/\//i, 'http://')
-        this.failedUpgradeUrls[downgrade] = true
-        return downgrade
-    }
 
     checkHttpsRequestsOnComplete () {
         // TODO later: watch all requests for http/https status and

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -124,18 +124,6 @@ class TabManager {
             }
         }
     }
-
-    updateTabRedirectCount (request) {
-        // count redirects
-        let tab = tabManager.get({'tabId': request.tabId})
-        if (!tab) return
-
-        if (tab.httpsRedirects[request.requestId]) {
-            tab.httpsRedirects[request.requestId] += 1
-        } else {
-            tab.httpsRedirects[request.requestId] = 1
-        }
-    }
 }
 
 var tabManager = new TabManager()

--- a/unit-test/background/classes/https-redirects.es6.js
+++ b/unit-test/background/classes/https-redirects.es6.js
@@ -1,0 +1,97 @@
+const HttpsRedirects = require('../../../shared/js/background/classes/https-redirects.es6')
+const tk = require('timekeeper')
+let httpsRedirects
+
+const setup = () => {
+    httpsRedirects = new HttpsRedirects()
+}
+
+const teardown = () => {
+    tk.reset()
+}
+
+const fastForward = (ms) => {
+    tk.travel(new Date(Date.now() + ms))
+}
+
+describe('HttpsRedirects', () => {
+    describe('main frame redirecting loop protection', () => {
+        beforeEach(() => {
+            setup()
+            httpsRedirects.registerRedirect({
+                id: 5,
+                url: 'http://example.com',
+                type: 'main_frame'
+            })
+        })
+
+        afterEach(teardown)
+
+        it('should prevent any repeated main frame redirects in the first 3s', () => {
+            fastForward(1500)
+
+            let canRedirect = httpsRedirects.canRedirect({
+                id: 6,
+                url: 'http://example.com',
+                type: 'main_frame'
+            })
+
+            expect(canRedirect).toEqual(false)
+        })
+        it('should allow a repeated main frame redirect after 3s', () => {
+            fastForward(4500)
+
+            let canRedirect = httpsRedirects.canRedirect({
+                id: 6,
+                url: 'http://example.com',
+                type: 'main_frame'
+            })
+
+            expect(canRedirect).toEqual(true)
+        })
+        it('should let other requests pass', () => {
+            fastForward(1500)
+
+            let canRedirect = httpsRedirects.canRedirect({
+                id: 6,
+                url: 'http://example.test',
+                type: 'main_frame'
+            })
+
+            expect(canRedirect).toEqual(true, 'it should let other mainframe redirects pass')
+
+            canRedirect = httpsRedirects.canRedirect({
+                id: 8,
+                url: 'http://example.com/cat.gif',
+                type: 'image'
+            })
+
+            expect(canRedirect).toEqual(true, 'it should let non-mainframe redirects pass')
+        })
+        it('once a main frame redirect has been marked as not working, the URL should be blacklisted', () => {
+            fastForward(1500)
+
+            let canRedirect = httpsRedirects.canRedirect({
+                id: 6,
+                url: 'http://example.com',
+                type: 'main_frame'
+            })
+
+            expect(canRedirect).toEqual(false)
+
+            fastForward(7000)
+
+            canRedirect = httpsRedirects.canRedirect({
+                id: 7,
+                url: 'http://example.com',
+                type: 'main_frame'
+            })
+
+            expect(canRedirect).toEqual(false)
+        })
+    })
+    describe('normal request redirect protection', () => {
+    })
+    describe('getting/persisting the main frame redirect', () => {
+    })
+})


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 
**CC:** @jdorweiler 

## Description:

Fixes redirect loop protection in the extension so it doesn't count any redirects that we haven't initiated.

I also took the opportunity to tidy the implementation up a bit.

## Steps to test this PR:

To test sites that were breaking due to the redirect loop counting:

1. Go to https://fishing-peche.dfo-mpo.gc.ca/
2. Press "English" (page loading shouldn't fail)
3. Go to https://www.canada.ca/en/revenue-agency/services/e-services/e-services-individuals/account-individuals.html
4. Press "Sign-In Partner Login / Register" (page loading shouldn't fail)

To test a site with a redirect loop problem (from https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/83):

1. Fudge the https.js so it upgrades this broken site, e.g. add `if (host.indexOf("raisingchildren") > -1) { return true }` [here](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/develop/shared/js/background/https.es6.js#L140)
2. Go to http://raisingchildren.net.au/articles/safe_water_temperature.html
3. The page should load
4. The logs for the background page should mention that redirecting was blocked for that page 


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
