### PR TITLE
Set default value for entityList variable

### DIFF
--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -10,7 +10,7 @@ const constants = require('../../data/constants')
 const utils = require('./utils.es6')
 const entityMap = require('../../data/tracker_lists/entityMap')
 
-let entityList
+let entityList = {}
 
 function loadLists () {
     load.JSONfromExternalFile(constants.entityList, (list) => { entityList = list })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 


## Description:
If the entityList endpoint is unresponsive when the extension is loaded, the entityList variable remains undefined. The isTracker function later attempts to check request entities against an undefined variable, which throws errors and breaks the extension. This just instantiates entityList as an empty object, which fixes this.


## Steps to test this PR:

1. Change the entityList endpoint in constants.js to a url that doesn't respond.
2. Compile and load extension in browser.
3. Visit a site with trackers. Check popup to see that trackers were found. Check extension console to see that no errors are thrown.

