### PR TITLE
Fix feedback opening in Safari

### DIFF
--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -94,13 +94,21 @@ let openExtensionPage = (path) => {
         path = path.substr(1)
     }
 
-    let tab = safari.application.activeBrowserWindow.openTab()
-    tab.url = getExtensionURL(path)
+    let url = getExtensionURL(path)
+
+    if (context === 'popup') {
+        let tab = safari.application.activeBrowserWindow.openTab()
+        tab.url = url
+        safari.self.hide()
+    } else {
+        // note: this will only work if this is happening as a direct response
+        // to a user click - otherwise it'll be blocked by Safari's popup blocker
+        window.open(url, '_blank')
+    }
 }
 
 let openOptionsPage = () => {
     openExtensionPage('/html/options.html')
-    safari.self.hide()
 }
 
 let getExtensionVersion = () => {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 
**CC:** @jdorweiler 

## Description:

Fixes two issues with how Safari handles feedback opening:

- popup doesn't hide when pressing "report broken site" in the popup
- feedback doesn't open from the options page

## Steps to test this PR:

1. Open feedback from the popup - popup should hide, and feedback page should open
2. Open feedback from the options page - feedback page should open

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
