### PR TITLE
Safari: Fix how ATB and version are passed to extension pages

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -93,6 +93,7 @@ chrome.omnibox.onInputEntered.addListener(function (text) {
 
 const utils = require('./utils.es6')
 const settings = require('./settings.es6')
+const browserWrapper = require('./chrome-wrapper.es6')
 
 // handle any messages that come from content/UI scripts
 // returning `true` makes it possible to send back an async response
@@ -127,6 +128,11 @@ chrome.runtime.onMessage.addListener((req, sender, res) => {
     // popup will ask for the browser type then it is created
     if (req.getBrowser) {
         res(utils.getBrowserName())
+        return true
+    }
+
+    if (req.getExtensionVersion) {
+        res(browserWrapper.getExtensionVersion())
         return true
     }
 

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -145,11 +145,14 @@ let getSetting = (e) => {
 
     // Safari optons page has to send a message to the background
     // and includes an id to help identify the correct response
-    setting.id = e.message.id
+    let message = {
+        data: setting,
+        id: e.message.id
+    }
 
     console.log(`Message setting: ${name}, ${JSON.stringify(setting)}`)
     // send message back to options page
-    e.target.page.dispatchMessage('getSetting', setting)
+    e.target.page.dispatchMessage('getSetting', message)
 }
 
 let onBeforeRequest = (requestData) => {

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -145,15 +145,15 @@ let getSetting = (e) => {
 
     let setting = JSON.parse(JSON.stringify(settings.getSetting(name)))
 
-    // Safari optons page has to send a message to the background
-    // and includes an id to help identify the correct response
+    // Safari extension pages can't pass a callback
+    // so they have to include an id to help identify the correct response
     let message = {
         data: setting,
         id: e.message.id
     }
 
     console.log(`Message setting: ${name}, ${JSON.stringify(setting)}`)
-    // send message back to options page
+    // send message back to extension page
     e.target.page.dispatchMessage('backgroundResponse', message)
 }
 

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -86,6 +86,8 @@ let handleMessage = (e) => {
         onClose(e)
     } else if (e.name === 'getSetting') {
         getSetting(e)
+    } else if (e.name === 'getExtensionVersion') {
+        getExtensionVersion(e)
     } else if (e.name === 'updateSetting') {
         updateSetting(e)
     } else if (e.name === 'whitelisted') {
@@ -152,7 +154,16 @@ let getSetting = (e) => {
 
     console.log(`Message setting: ${name}, ${JSON.stringify(setting)}`)
     // send message back to options page
-    e.target.page.dispatchMessage('getSetting', message)
+    e.target.page.dispatchMessage('backgroundResponse', message)
+}
+
+let getExtensionVersion = (e) => {
+    let message = {
+        data: browserWrapper.getExtensionVersion(),
+        id: e.message.id
+    }
+
+    e.target.page.dispatchMessage('backgroundResponse', message)
 }
 
 let onBeforeRequest = (requestData) => {

--- a/shared/js/ui/base/chrome-ui-wrapper.es6.js
+++ b/shared/js/ui/base/chrome-ui-wrapper.es6.js
@@ -48,11 +48,6 @@ let openOptionsPage = (browser) => {
     }
 }
 
-let getExtensionVersion = () => {
-    const manifest = window.chrome && chrome.runtime.getManifest()
-    return Promise.resolve(manifest.version)
-}
-
 let reloadTab = (id) => {
     window.chrome.tabs.reload(id)
 }
@@ -71,6 +66,5 @@ module.exports = {
     createBrowserTab: createBrowserTab,
     openOptionsPage: openOptionsPage,
     openExtensionPage: openExtensionPage,
-    getExtensionURL: getExtensionURL,
-    getExtensionVersion: getExtensionVersion
+    getExtensionURL: getExtensionURL
 }

--- a/shared/js/ui/base/chrome-ui-wrapper.es6.js
+++ b/shared/js/ui/base/chrome-ui-wrapper.es6.js
@@ -50,7 +50,7 @@ let openOptionsPage = (browser) => {
 
 let getExtensionVersion = () => {
     const manifest = window.chrome && chrome.runtime.getManifest()
-    return manifest.version
+    return Promise.resolve(manifest.version)
 }
 
 let reloadTab = (id) => {

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -26,7 +26,7 @@ let sendOptionsMessage = (message, resolve, reject) => {
         safari.self.addEventListener('message', (e) => {
             if (e.name === 'getSetting' && e.message.id === id) {
                 delete e.message.id
-                resolve(e.message)
+                resolve(e.message.data)
             }
         }, true)
     } else if (message.updateSetting) {

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -9,7 +9,7 @@ if (safari &&
 } else if (safari &&
         safari.self &&
         safari.self.tab) {
-    context = 'options'
+    context = 'extensionPage'
 } else {
     throw new Error('safari-ui-wrapper couldn\'t figure out the context it\'s in')
 }
@@ -36,7 +36,7 @@ let closePopup = () => {
 
 let pendingMessages = {}
 
-let sendOptionsMessage = (message, resolve, reject) => {
+let sendExtensionPageMessage = (message, resolve, reject) => {
     if (message.whitelisted) {
         resolve(safari.self.tab.dispatchMessage('whitelisted', message))
     } else if (message.getSetting) {
@@ -54,7 +54,7 @@ let sendOptionsMessage = (message, resolve, reject) => {
     }
 }
 
-if (context === 'options') {
+if (context === 'extensionPage') {
     safari.self.addEventListener('message', (e) => {
         if (e.name !== 'backgroundResponse' || !e.message.id) {
             return
@@ -74,8 +74,8 @@ let fetch = (message) => {
         console.log(`Safari Fetch: ${JSON.stringify(message)}`)
         if (context === 'popup') {
             safari.extension.globalPage.contentWindow.message(message, resolve)
-        } else if (context === 'options') {
-            sendOptionsMessage(message, resolve, reject)
+        } else if (context === 'extensionPage') {
+            sendExtensionPageMessage(message, resolve, reject)
         }
     })
 }

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -14,7 +14,6 @@ if (safari &&
     throw new Error('safari-ui-wrapper couldn\'t figure out the context it\'s in')
 }
 
-
 let reloadTab = () => {
     var activeTab = window.safari.application.activeBrowserWindow.activeTab
     activeTab.url = activeTab.url

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -137,10 +137,6 @@ let openOptionsPage = () => {
     openExtensionPage('/html/options.html')
 }
 
-let getExtensionVersion = () => {
-    return safari.extension.displayVersion
-}
-
 module.exports = {
     fetch: fetch,
     reloadTab: reloadTab,
@@ -150,6 +146,5 @@ module.exports = {
     createBrowserTab: createBrowserTab,
     openOptionsPage: openOptionsPage,
     openExtensionPage: openExtensionPage,
-    getExtensionURL: getExtensionURL,
-    getExtensionVersion: getExtensionVersion
+    getExtensionURL: getExtensionURL
 }

--- a/shared/js/ui/models/feedback-form.es6.js
+++ b/shared/js/ui/models/feedback-form.es6.js
@@ -11,7 +11,6 @@ function FeedbackForm (attrs) {
 
     attrs.browser = attrs.browser || ''
     attrs.browserVersion = attrs.browserVersion || ''
-    attrs.extensionVersion = attrs.extensionVersion || ''
 
     Parent.call(this, attrs)
 
@@ -20,6 +19,8 @@ function FeedbackForm (attrs) {
     // grab atb value from background process
     this.fetch({ getSetting: { name: 'atb' } })
         .then((atb) => { this.atb = atb })
+    this.fetch({ getExtensionVersion: true })
+        .then((extensionVersion) => { this.extensionVersion = extensionVersion })
 }
 
 FeedbackForm.prototype = window.$.extend({},

--- a/shared/js/ui/models/mixins/parse-user-agent.es6.js
+++ b/shared/js/ui/models/mixins/parse-user-agent.es6.js
@@ -1,14 +1,10 @@
-const browserUIWrapper = require('./../../base/$BROWSER-ui-wrapper.es6.js')
-
 module.exports = {
     parseUserAgentString (uaString) {
         if (!uaString) uaString = window.navigator.userAgent
         const rgx = uaString.match(/(Firefox|Chrome|Safari)\/([0-9.]+)/)
-        const extensionVersion = browserUIWrapper.getExtensionVersion()
         return {
             browser: rgx[1],
-            version: rgx[2],
-            extension: extensionVersion
+            version: rgx[2]
         }
     }
 }

--- a/shared/js/ui/pages/feedback.es6.js
+++ b/shared/js/ui/pages/feedback.es6.js
@@ -30,8 +30,7 @@ Feedback.prototype = window.$.extend({},
                     isBrokenSite: params.broken,
                     url: decodeURIComponent(params.url || ''),
                     browser: browserInfo.browser,
-                    browserVersion: browserInfo.version,
-                    extensionVersion: browserInfo.extension
+                    browserVersion: browserInfo.version
                 })
             })
         }

--- a/unit-test/ui/models/feedback-form.es6.js
+++ b/unit-test/ui/models/feedback-form.es6.js
@@ -69,7 +69,7 @@ describe('toggleBrokenSite', () => {
 describe('submit', () => {
     let spy
 
-    beforeEach(() => {
+    beforeEach((done) => {
         setup()
 
         spy = spyOn(window.$, 'ajax')
@@ -82,6 +82,10 @@ describe('submit', () => {
             browserVersion: '60.5'
         })
         feedbackForm.updateCanSubmit()
+
+        // even though we've got spies for the properties we get via fetch,
+        // they are retrieved asynchronously - give them some time to resolve
+        setTimeout(done, 50)
     })
 
     it('should pass the correct arguments to the AJAX call', () => {

--- a/unit-test/ui/models/feedback-form.es6.js
+++ b/unit-test/ui/models/feedback-form.es6.js
@@ -4,10 +4,14 @@ const browserUIWrapper = require('../../../shared/js/ui/base/$BROWSER-ui-wrapper
 let feedbackForm
 
 function setup () {
-    // make sure we always have an atb version handy
-    spyOn(browserUIWrapper, 'fetch')
-        .withArgs({ getSetting: { name: 'atb' } })
+    // make sure we always have an atb and extension version handy
+    let spy = spyOn(browserUIWrapper, 'fetch')
+
+    spy.withArgs({ getSetting: { name: 'atb' } })
         .and.returnValue(Promise.resolve('v110-1'))
+
+    spy.withArgs({ getExtensionVersion: true })
+        .and.returnValue(Promise.resolve('2018.5.1'))
 
     feedbackForm = new FeedbackForm({
         modelName: Math.random().toString()

--- a/unit-test/ui/models/feedback-form.es6.js
+++ b/unit-test/ui/models/feedback-form.es6.js
@@ -79,8 +79,7 @@ describe('submit', () => {
             message: 'hello',
             url: 'http://example.com',
             browser: 'Chrome',
-            browserVersion: '60.5',
-            extensionVersion: '2018.5.1'
+            browserVersion: '60.5'
         })
         feedbackForm.updateCanSubmit()
     })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

**CC:** @MariagraziaAlastra 
**Depends on:** Will cause a conflict with #227, I'll resolve when either gets merged

## Description:

This PR does two things:

1. Fixes settings (specifically ATB params) not being retrieved correctly from extension pages on Safari
2. Starts retrieving extension version via `fetch` and the background process, since extension pages don't have access to the version in Safari

## Steps to test this PR:

1. Add e.g. `return console.log(this)` where the feedback form is being submitted: https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/d0046ef7723d2a4974d890155ecdcd096706fd5e/shared/js/ui/models/feedback-form.es6.js#L35
2. Go to the feedback page in both Safari and Chrome with console log open
3. Press "submit" and verify that both ATB and extension version are set correctly
4. For good measure, verify that the options page works correctly as well

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
