### PR TITLE
avoid using onreadystatechange, since libraries may hijack it.

### DIFF
--- a/shared/js/content-scripts/element-hiding.js
+++ b/shared/js/content-scripts/element-hiding.js
@@ -118,11 +118,13 @@
      * At this point, kick off process by requesting list of blocked requests from
      * background page.
      */
-    if (document.readyState !== 'complete') {
+    if (document.readyState === 'loading') {
         document.addEventListener('readystatechange', () => {
             if (document.readyState === 'interactive') {
                 chrome.runtime.sendMessage({hideElements: true, url: document.location.href, frame: contentScript.frameType})
             }
         })
+    } else {
+        chrome.runtime.sendMessage({hideElements: true, url: document.location.href, frame: contentScript.frameType})
     }
 })()

--- a/shared/js/content-scripts/element-hiding.js
+++ b/shared/js/content-scripts/element-hiding.js
@@ -118,9 +118,11 @@
      * At this point, kick off process by requesting list of blocked requests from
      * background page.
      */
-    document.onreadystatechange = () => {
-        if (document.readyState === 'interactive') {
-            chrome.runtime.sendMessage({hideElements: true, url: document.location.href, frame: contentScript.frameType})
-        }
+    if (document.readyState !== 'complete') {
+        document.addEventListener('readystatechange', () => {
+            if (document.readyState === 'interactive') {
+                chrome.runtime.sendMessage({hideElements: true, url: document.location.href, frame: contentScript.frameType})
+            }
+        })
     }
 })()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kdzwinel 

cc: @jdorweiler 

## Description: 
It appears that certain libraries, such as cloudflare's rocketloader, hijack the standard document.onreadystatechange event and change what it does. This throws permission errors when we attempt to call it in a content script:
![image](https://user-images.githubusercontent.com/4481594/42848708-81647c2c-89ee-11e8-8c7e-0a03093ad90d.png)

This PR moves away from using the onreadystatechange event, replacing it with a standard event listener. Strangely, this only seems to be an issue in Firefox.



## Steps to test this PR:
1. Visit a site affected by issue in Firefox. One such site is recipetamer.com, another is redsecurity.info.
2. Check console to see that no permission errors are being thrown.
3. Ensure that element hiding still works properly by visiting a site where it's currently active (yahoo.com for one).


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
