### PR TITLE
Fix ATB param on Safari popup search

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -29,8 +29,8 @@ function handleRequest (requestData) {
 
     // For main_frame requests: create a new tab instance whenever we either
     // don't have a tab instance for this tabId or this is a new requestId.
-    if (requestData.type === 'main_frame') {
-        if (!thisTab || (thisTab.requestId !== requestData.requestId)) {
+    if (requestData.type === 'main_frame' && window.chrome) {
+        if (!thisTab || thisTab.requestId !== requestData.requestId) {
             let newTab = tabManager.create(requestData)
 
             // persist the last URL the tab was trying to upgrade to HTTPS

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -29,6 +29,8 @@ function handleRequest (requestData) {
 
     // For main_frame requests: create a new tab instance whenever we either
     // don't have a tab instance for this tabId or this is a new requestId.
+    //
+    // Safari doesn't have specific requests for main frames
     if (requestData.type === 'main_frame' && window.chrome) {
         if (!thisTab || thisTab.requestId !== requestData.requestId) {
             let newTab = tabManager.create(requestData)

--- a/shared/js/background/safari-events.es6.js
+++ b/shared/js/background/safari-events.es6.js
@@ -116,6 +116,10 @@ let handleUIMessage = (req, res) => {
         res('safari')
     } else if (req.whitelisted) {
         res(tabManager.whitelistDomain(req.whitelisted))
+    } else if (req.getSetting) {
+        settings.ready().then(() => {
+            res(settings.getSetting(req.getSetting.name))
+        })
     } else if (req.getSiteScore) {
         let tab = tabManager.get({tabId: req.getSiteScore})
         if (tab) res(tab.site.score.get())

--- a/shared/js/ui/base/chrome-ui-wrapper.es6.js
+++ b/shared/js/ui/base/chrome-ui-wrapper.es6.js
@@ -28,8 +28,8 @@ let getBackgroundTabData = () => {
     })
 }
 
-let createBrowserTab = (url) => {
-    window.chrome.tabs.create({url: `${url}&bext=${window.localStorage['os']}cr`})
+let search = (url) => {
+    window.chrome.tabs.create({url: `https://duckduckgo.com/?q=${url}&bext=${window.localStorage['os']}cr`})
 }
 
 let getExtensionURL = (path) => {
@@ -64,7 +64,7 @@ module.exports = {
     closePopup: closePopup,
     backgroundMessage: backgroundMessage,
     getBackgroundTabData: getBackgroundTabData,
-    createBrowserTab: createBrowserTab,
+    search: search,
     openOptionsPage: openOptionsPage,
     openExtensionPage: openExtensionPage,
     getExtensionURL: getExtensionURL

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -105,6 +105,7 @@ let getBackgroundTabData = () => {
 }
 
 let createBrowserTab = (url) => {
+    // in Chrome, this is handled by ATB.redirectURL()
     fetch({ getSetting: { name: 'atb' }}).then((atb) => {
         safari.application.activeBrowserWindow.openTab().url = `${url}&bext=safari&atb=${atb}`
         safari.self.hide()

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -105,7 +105,8 @@ let getBackgroundTabData = () => {
 }
 
 let search = (url) => {
-    // in Chrome, this is handled by ATB.redirectURL()
+    // in Chrome, adding the ATB param is handled by ATB.redirectURL()
+    // which doesn't happen on Safari
     fetch({ getSetting: { name: 'atb' } }).then((atb) => {
         safari.application.activeBrowserWindow.openTab().url = `https://duckduckgo.com/?q=${url}&bext=safari&atb=${atb}`
         safari.self.hide()

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -104,10 +104,10 @@ let getBackgroundTabData = () => {
     })
 }
 
-let createBrowserTab = (url) => {
+let search = (url) => {
     // in Chrome, this is handled by ATB.redirectURL()
     fetch({ getSetting: { name: 'atb' }}).then((atb) => {
-        safari.application.activeBrowserWindow.openTab().url = `${url}&bext=safari&atb=${atb}`
+        safari.application.activeBrowserWindow.openTab().url = `https://duckduckgo.com/?q=${url}&bext=safari&atb=${atb}`
         safari.self.hide()
     })
 }
@@ -145,7 +145,7 @@ module.exports = {
     closePopup: closePopup,
     backgroundMessage: backgroundMessage,
     getBackgroundTabData: getBackgroundTabData,
-    createBrowserTab: createBrowserTab,
+    search: search,
     openOptionsPage: openOptionsPage,
     openExtensionPage: openExtensionPage,
     getExtensionURL: getExtensionURL

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -106,7 +106,7 @@ let getBackgroundTabData = () => {
 
 let search = (url) => {
     // in Chrome, this is handled by ATB.redirectURL()
-    fetch({ getSetting: { name: 'atb' }}).then((atb) => {
+    fetch({ getSetting: { name: 'atb' } }).then((atb) => {
         safari.application.activeBrowserWindow.openTab().url = `https://duckduckgo.com/?q=${url}&bext=safari&atb=${atb}`
         safari.self.hide()
     })

--- a/shared/js/ui/base/safari-ui-wrapper.es6.js
+++ b/shared/js/ui/base/safari-ui-wrapper.es6.js
@@ -105,8 +105,10 @@ let getBackgroundTabData = () => {
 }
 
 let createBrowserTab = (url) => {
-    safari.application.activeBrowserWindow.openTab().url = `${url}&bext=safari`
-    safari.self.hide()
+    fetch({ getSetting: { name: 'atb' }}).then((atb) => {
+        safari.application.activeBrowserWindow.openTab().url = `${url}&bext=safari&atb=${atb}`
+        safari.self.hide()
+    })
 }
 
 let getExtensionURL = (path) => {

--- a/shared/js/ui/models/search.es6.js
+++ b/shared/js/ui/models/search.es6.js
@@ -17,9 +17,7 @@ Search.prototype = window.$.extend({},
 
             console.log(`doSearch() for ${s}`)
 
-            let url = 'https://duckduckgo.com/?q=' + s
-
-            browserUIWrapper.createBrowserTab(url)
+            browserUIWrapper.search(s)
         }
     }
 )


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 

**CC:** @jdorweiler @jkv 

## Description:

Makes sure the ATB param is added correctly when searching through the popup.

## Steps to test this PR:

1. Search via the popup search box on FF, Chrome, Safari
2. The search should work correctly.
3. The ATB param should be correctly added.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
