### PR TITLE
Handle clients with empty ATB

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -8,6 +8,8 @@ const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es
 const load = require('./load.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 
+const ATB_ERROR_COHORT = 'v1-1'
+
 let dev = false
 
 const ATB = (() => {
@@ -21,23 +23,22 @@ const ATB = (() => {
             let atbSetting = settings.getSetting('atb')
             let setAtbSetting = settings.getSetting('set_atb')
 
-            let randomValue = Math.ceil(Math.random() * 1e7)
-            let url = ddgAtbURL + randomValue + '&atb=' + atbSetting + '&set_atb=' + setAtbSetting
+            let errorParam = ''
 
             // client shouldn't have a falsy ATB value,
             // so mark them as having gone into an errored state
+            // next time they won't send the e=1 param
             if (!atbSetting) {
-                url += '&e=1'
+                atbSetting = ATB_ERROR_COHORT
+                settings.updateSetting('atb', ATB_ERROR_COHORT)
+                errorParam = '&e=1'
             }
+
+            let randomValue = Math.ceil(Math.random() * 1e7)
+            let url = `${ddgAtbURL}${randomValue}&atb=${atbSetting}&set_atb=${setAtbSetting}${errorParam}`
 
             return load.JSONfromExternalFile(url).then((res) => {
                 settings.updateSetting('set_atb', res.data.version)
-
-                // if client errored, place them in the special ATB cohort
-                // next time they won't send the e=1 param
-                if (!atbSetting) {
-                    settings.updateSetting('atb', 'v1-1')
-                }
             })
         },
 

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -26,7 +26,7 @@ const ATB = (() => {
 
             // client shouldn't have a falsy ATB value,
             // so mark them as having gone into an errored state
-            f (!atbSetting) {
+            if (!atbSetting) {
                 url += '&e=1'
             }
 

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -36,7 +36,7 @@ const ATB = (() => {
                 // if client errored, place them in the special ATB cohort
                 // next time they won't send the e=1 param
                 if (!atbSetting) {
-                    settings.updateSetting('atb', 'v0-1')
+                    settings.updateSetting('atb', 'v1-1')
                 }
             })
         },

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -21,13 +21,23 @@ const ATB = (() => {
             let atbSetting = settings.getSetting('atb')
             let setAtbSetting = settings.getSetting('set_atb')
 
-            if (!atbSetting) return Promise.resolve()
-
             let randomValue = Math.ceil(Math.random() * 1e7)
             let url = ddgAtbURL + randomValue + '&atb=' + atbSetting + '&set_atb=' + setAtbSetting
 
+            // client shouldn't have a falsy ATB value,
+            // so mark them as having gone into an errored state
+            f (!atbSetting) {
+                url += '&e=1'
+            }
+
             return load.JSONfromExternalFile(url).then((res) => {
                 settings.updateSetting('set_atb', res.data.version)
+
+                // if client errored, place them in the special ATB cohort
+                // next time they won't send the e=1 param
+                if (!atbSetting) {
+                    settings.updateSetting('atb', 'v0-1')
+                }
             })
         },
 

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -176,7 +176,7 @@ describe('atb.updateSetAtb()', () => {
         let loadJSONSpy = stubLoadJSON({ returnedAtb: 'v112-2' })
 
         atb.updateSetAtb().then(() => {
-            expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/atb=(null|undefined)/))
+            expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/atb=v1-1/))
             expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/set_atb=v112-1/))
             expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/e=1/))
 

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -172,11 +172,17 @@ describe('atb.updateSetAtb()', () => {
     })
 
     it('should be able to handle cases where atb is null', (done) => {
-        settingHelper.stub({ set_atb: 'v112-2' })
+        settingHelper.stub({ set_atb: 'v112-1' })
         let loadJSONSpy = stubLoadJSON({ returnedAtb: 'v112-2' })
 
         atb.updateSetAtb().then(() => {
-            expect(loadJSONSpy).not.toHaveBeenCalled()
+            expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/atb=(null|undefined)/))
+            expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/set_atb=v112-1/))
+            expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/e=1/))
+
+            expect(settings.getSetting('atb')).toEqual('v0-1')
+            expect(settings.getSetting('set_atb')).toEqual('v112-2')
+
             done()
         })
     })

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -180,7 +180,7 @@ describe('atb.updateSetAtb()', () => {
             expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/set_atb=v112-1/))
             expect(loadJSONSpy).toHaveBeenCalledWith(jasmine.stringMatching(/e=1/))
 
-            expect(settings.getSetting('atb')).toEqual('v0-1')
+            expect(settings.getSetting('atb')).toEqual('v1-1')
             expect(settings.getSetting('set_atb')).toEqual('v112-2')
 
             done()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

**CC:** @zachthompson @jkv 

## Description:

Adds handling for clients with missing ATB params.

Basically:

1. When we detect a falsy ATB param, add `e=1` to query string.
2. After that, set ATB to v1-1, which clients can't get into normally.
3. Next time the client searches, ATB will be present so `e=1` shouldn't appear.

## Steps to test this PR:

Here's how to manually test:

1. Install extension
2. Via the console, run `dbg.settings.removeSetting('atb')`
3. Run a search (you should see the set_atb call in the console with e=1)
4. Run a search again (atb param added to the search should be v1-1)

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
