### PR TITLE
Expand failed HTTPS protection to the entire hostname

### DIFF
--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -1,9 +1,11 @@
+const utils = require('../utils.es6')
+
 const MAINFRAME_RESET_MS = 3000
 const REQUEST_REDIRECT_LIMIT = 7
 
 class HttpsRedirects {
     constructor () {
-        this.failedUpgradeUrls = {}
+        this.failedUpgradeHosts = {}
         this.redirectCounts = {}
 
         this.mainFrameRedirect = null
@@ -28,9 +30,11 @@ class HttpsRedirects {
     canRedirect (request) {
         let canRedirect = true
 
-        // this URL previously failed, don't try to upgrade it
-        if (this.failedUpgradeUrls[request.url]) {
-            console.log(`HTTPS: not upgrading, url previously failed: ${request.url}`)
+        const hostname = utils.extractHostFromURL(request.url, true)
+
+        // this hostname previously failed, don't try to upgrade it
+        if (this.failedUpgradeHosts[hostname]) {
+            console.log(`HTTPS: not upgrading ${request.url}, hostname previously failed: ${hostname}`)
             return false
         }
 
@@ -58,9 +62,9 @@ class HttpsRedirects {
             canRedirect = this.redirectCounts[request.requestId] < REQUEST_REDIRECT_LIMIT
         }
 
-        // remember this URL as previously failed, don't try to upgrade it
+        // remember this hostname as previously failed, don't try to upgrade it
         if (!canRedirect) {
-            this.failedUpgradeUrls[request.url] = true
+            this.failedUpgradeHosts[hostname] = true
             console.log(`HTTPS: not upgrading, redirect loop protection kicked in for url: ${request.url}`)
         }
 

--- a/unit-test/background/classes/https-redirects.es6.js
+++ b/unit-test/background/classes/https-redirects.es6.js
@@ -69,7 +69,7 @@ describe('HttpsRedirects', () => {
 
             expect(canRedirect).toEqual(true, 'it should let non-mainframe redirects pass')
         })
-        it('once a main frame redirect has been marked as not working, the URL should be blacklisted', () => {
+        it('once a main frame redirect has been marked as not working, the domain should be blacklisted', () => {
             fastForward(1500)
 
             let canRedirect = httpsRedirects.canRedirect({
@@ -89,6 +89,23 @@ describe('HttpsRedirects', () => {
             })
 
             expect(canRedirect).toEqual(false)
+
+            canRedirect = httpsRedirects.canRedirect({
+                requestId: 12,
+                url: 'http://example.com/foo/bar.jpg',
+                type: 'image'
+            })
+
+            expect(canRedirect).toEqual(false)
+
+            // different subdomains should still be fine
+            canRedirect = httpsRedirects.canRedirect({
+                requestId: 12,
+                url: 'http://www.example.com/foo/bar.jpg',
+                type: 'image'
+            })
+
+            expect(canRedirect).toEqual(true)
         })
     })
     describe('normal request redirect protection', () => {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 
**CC**: @kdzwinel 

## Description:

If the HTTPS domain protection kicks in for the mainframe, remember that domain name as previously failed, don't upgrade any requests made to it.

## Steps to test this PR:

1. Go to http://bl.ocks.org/billdwhite/36d15bc6126e6f6365d0 - it should be working
2. Go to http://ponoko.com and try uploading an image - it should be working

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
