### PR TITLE
Anonymous alert when HTTPS upgrades fail

### DIFF
--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -2,6 +2,7 @@ const utils = require('../utils.es6')
 
 const MAINFRAME_RESET_MS = 3000
 const REQUEST_REDIRECT_LIMIT = 7
+const pixel = require('./../pixel.es6')
 
 class HttpsRedirects {
     constructor () {
@@ -64,6 +65,7 @@ class HttpsRedirects {
 
         // remember this hostname as previously failed, don't try to upgrade it
         if (!canRedirect) {
+            if (request.type === 'main_frame') pixel.fire('ehd')
             this.failedUpgradeHosts[hostname] = true
             console.log(`HTTPS: not upgrading, redirect loop protection kicked in for url: ${request.url}`)
         }

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -1,8 +1,8 @@
 const utils = require('../utils.es6')
+const pixel = require('../pixel.es6')
 
 const MAINFRAME_RESET_MS = 3000
 const REQUEST_REDIRECT_LIMIT = 7
-const pixel = require('./../pixel.es6')
 
 class HttpsRedirects {
     constructor () {
@@ -65,7 +65,10 @@ class HttpsRedirects {
 
         // remember this hostname as previously failed, don't try to upgrade it
         if (!canRedirect) {
-            if (request.type === 'main_frame') pixel.fire('ehd')
+            if (request.type === 'main_frame') {
+                    pixel.fire('ehd')
+            }
+
             this.failedUpgradeHosts[hostname] = true
             console.log(`HTTPS: not upgrading, redirect loop protection kicked in for url: ${request.url}`)
         }

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -66,7 +66,7 @@ class HttpsRedirects {
         // remember this hostname as previously failed, don't try to upgrade it
         if (!canRedirect) {
             if (request.type === 'main_frame') {
-                    pixel.fire('ehd')
+                pixel.fire('ehd')
             }
 
             this.failedUpgradeHosts[hostname] = true

--- a/unit-test/background/classes/https-redirects.es6.js
+++ b/unit-test/background/classes/https-redirects.es6.js
@@ -1,9 +1,11 @@
 const HttpsRedirects = require('../../../shared/js/background/classes/https-redirects.es6')
 const tk = require('timekeeper')
+const pixel = require('../../../shared/js/background/pixel.es6')
 let httpsRedirects
 
 const setup = () => {
     httpsRedirects = new HttpsRedirects()
+    spyOn(pixel, 'fire')
 }
 
 const teardown = () => {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 


**CC:** @zachthompson @nilnilnil 
<!-- Optional fields
**Depends on:** 
-->

## Description:
Fire anonymous pixel on unique (per tab) mainframe HTTPS downgrades.


## Steps to test this PR:
1. Build and reload extension
2. Visit sites that won't upgrade like http://bl.ocks.org/billdwhite/36d15bc6126e6f6365d0 
3. Check the 'edh' pixel fires
4. Run unit tests


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
