### PR TITLE
Split domains in findParent

### DIFF
--- a/shared/js/background/classes/score.es6.js
+++ b/shared/js/background/classes/score.es6.js
@@ -76,7 +76,7 @@ class Score {
     isaMajorTrackingNetwork () {
         let result = 0
         if (this.specialPage || !this.domain) return result
-        const parentCompany = utils.findParent(this.domain.split('.'))
+        const parentCompany = utils.findParent(this.domain)
         if (!parentCompany) return result
         const isMajorNetwork = pagesSeenOn[parentCompany.toLowerCase()]
         if (isMajorNetwork) {

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -287,7 +287,7 @@ function getParentEntity (urlToCheck) {
 
 function getTrackerDetails (trackerUrl, listName) {
     let host = utils.extractHostFromURL(trackerUrl)
-    let parentCompany = utils.findParent(host.split('.')) || 'unknown'
+    let parentCompany = utils.findParent(host) || 'unknown'
     return {
         parentCompany: parentCompany,
         url: host,

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -25,17 +25,15 @@ function extractTopSubdomainFromHost (host) {
 
 // pull off subdomains and look for parent companies
 function findParent (url) {
-    if (typeof url !== 'object') {
-        url = url.split('.')
-    }
+    const parts = extractHostFromURL(url).split('.')
 
-    if (!entityMap || url.length < 2) return
-    let joinURL = url.join('.')
-    if (entityMap[joinURL]) {
-        return entityMap[joinURL]
-    } else {
-        url.shift()
-        return findParent(url)
+    while (parts.length > 1) {
+        const joinURL = parts.join('.')
+
+        if (entityMap[joinURL]) {
+            return entityMap[joinURL]
+        }
+        parts.shift()
     }
 }
 

--- a/unit-test/background/classes/score.es6.js
+++ b/unit-test/background/classes/score.es6.js
@@ -120,8 +120,6 @@ describe('isaMajorNetwork', () => {
 
             let result = score.isaMajorTrackingNetwork
 
-            console.log(`IS major network: ${result}`)
-
             if (test.isZeroResult) {
                 expect(result).toEqual(0)
             } else {

--- a/unit-test/background/classes/score.es6.js
+++ b/unit-test/background/classes/score.es6.js
@@ -5,7 +5,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 0,
         'domain': 'facebook.com',
-        'slicedDomain': ['facebook', 'com'],
+        'callWith': 'facebook.com',
         'parent': 'Facebook',
         'isZeroResult': 0,
         'descr': 'a number greater than zero for Facebook (major network)'
@@ -13,7 +13,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 0,
         'domain': 'encrypted.google.com',
-        'slicedDomain': ['google', 'com'],
+        'callWith': 'google.com',
         'parent': 'Google',
         'isZeroResult': 0,
         'descr': 'a number greater than zero for Google (major network)'
@@ -21,7 +21,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 0,
         'domain': '',
-        'slicedDomain': [],
+        'callWith': '',
         'parent': '',
         'isZeroResult': 1,
         'descr': 'zero, because we have no domain'
@@ -29,7 +29,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 1,
         'domain': '',
-        'slicedDomain': [],
+        'callWith': '',
         'parent': '',
         'isZeroResult': 1,
         'descr': "zero, because it's a special page"
@@ -37,7 +37,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 0,
         'domain': 'duckduckgo.com',
-        'slicedDomain': ['duckduckgo', 'com'],
+        'callWith': 'duckduckgo.com',
         'parent': '',
         'isZeroResult': 1,
         'descr': 'zero, because of no major network parent'
@@ -45,7 +45,7 @@ const isaMajorNetworkTestCases = [
     {
         'specialPage': 0,
         'domain': 'bttf.duckduckgo.com',
-        'slicedDomain': ['duckduckgo', 'com'],
+        'callWith': 'duckduckgo.com',
         'parent': '',
         'isZeroResult': 1,
         'descr': 'zero, because of no major network parent'
@@ -115,10 +115,12 @@ describe('isaMajorNetwork', () => {
             score = new Score(test.specialPage, test.domain)
 
             if (test.parent) {
-                expect(utils.findParent).toHaveBeenCalledWith(test.slicedDomain)
+                expect(utils.findParent).toHaveBeenCalledWith(test.callWith)
             }
 
             let result = score.isaMajorTrackingNetwork
+
+            console.log(`IS major network: ${result}`)
 
             if (test.isZeroResult) {
                 expect(result).toEqual(0)

--- a/unit-test/background/utils.es6.js
+++ b/unit-test/background/utils.es6.js
@@ -49,7 +49,7 @@ const extractHostFromURLTestCases = [
 describe('utils.findParent()', () => {
     findParentTestCases.forEach((test) => {
         it(`should return ${test.parent} as a parent for: ${test.url}`, () => {
-            let result = utils.findParent(test.url.split('.'))
+            let result = utils.findParent(test.url)
             if (test.parent === 'undefined') {
                 expect(result).toBe(undefined)
             } else {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Update find parent. Instead of splitting the domain before calling the function, it will do it for you now.

## Steps to test this PR:
1. npm test
2. Check sites that have first party trackers like yahoo.com. You should see unblocked first party trackers in the tracker detail subview. 


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
