### PR TITLE
Fixed mixed content issues by appending 'upgrade-insecure-request' header

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -21,6 +21,7 @@ const constants = require('../../data/constants')
 const redirect = require('./redirect.es6')
 const tabManager = require('./tab-manager.es6')
 const pixel = require('./pixel.es6')
+const https = require('./https.es6')
 
 chrome.webRequest.onBeforeRequest.addListener(
     redirect.handleRequest,
@@ -45,6 +46,14 @@ chrome.webRequest.onHeadersReceived.addListener(
     {
         urls: ['<all_urls>']
     }
+)
+
+chrome.webRequest.onHeadersReceived.addListener(
+    https.setUpgradeInsecureRequestHeader,
+    {
+        urls: ['<all_urls>']
+    },
+    ['blocking', 'responseHeaders']
 )
 
 /**
@@ -166,7 +175,6 @@ chrome.runtime.onMessage.addListener((req, sender, res) => {
  */
 
 const abpLists = require('./abp-lists.es6')
-const https = require('./https.es6')
 const httpsStorage = require('./storage/https.es6')
 
 // recheck adblock plus and https lists every 30 minutes

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -49,7 +49,16 @@ chrome.webRequest.onHeadersReceived.addListener(
 )
 
 chrome.webRequest.onHeadersReceived.addListener(
-    https.setUpgradeInsecureRequestHeader,
+    (request) => {
+        // ignore background requests and requests without urls
+        if (request.tabId === -1 || !request.url) return {}
+
+        const tab = tabManager.get(request)
+
+        if (tab && tab.site && !tab.site.whitelisted) {
+            return https.setUpgradeInsecureRequestHeader(request)
+        }
+    },
     {
         urls: ['<all_urls>']
     },

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -142,7 +142,7 @@ class HTTPS {
                     // exit loop if no http urls found
                     if (!accessControlValue.match(/http:/i)) break
 
-                    request.responseHeaders[header].value = accessControlValue.replace(/http:/g, 'https:')
+                    request.responseHeaders[header].value = accessControlValue.replace(/http:/ig, 'https:')
                     headersChanged = true
                 }
             }

--- a/unit-test/background/https.es6.js
+++ b/unit-test/background/https.es6.js
@@ -61,7 +61,6 @@ describe('Https upgrades', () => {
 
         httpsRequests.forEach((test) => {
             it(`should ${test.testCase}`, () => {
-                console.log(test.expectedResult)
                 expect(https.setUpgradeInsecureRequestHeader(test.request)).toEqual(test.expectedResult)
             })
         })

--- a/unit-test/background/https.es6.js
+++ b/unit-test/background/https.es6.js
@@ -53,7 +53,7 @@ describe('Https upgrades', () => {
             expect(https.isReady).toEqual(false)
         })
     })
-    
+
     describe('https headers', () => {
         beforeAll(() => {
             https.isReady = true

--- a/unit-test/background/https.es6.js
+++ b/unit-test/background/https.es6.js
@@ -3,6 +3,7 @@ const https = require('../../shared/js/background/https.es6')
 const httpsStorage = require('../../shared/js/background/storage/https.es6')
 const httpsBloom = require('./../data/httpsBloom.json')
 const httpsWhitelist = require('./../data/httpsWhitelist.json')
+const httpsRequests = require('./../data/httpsRequests.json')
 const load = require('./../helpers/https.es6')
 
 describe('Https upgrades', () => {
@@ -50,6 +51,19 @@ describe('Https upgrades', () => {
 
         it('failed update should turn https off', () => {
             expect(https.isReady).toEqual(false)
+        })
+    })
+    
+    describe('https headers', () => {
+        beforeAll(() => {
+            https.isReady = true
+        })
+
+        httpsRequests.forEach((test) => {
+            it(`should ${test.testCase}`, () => {
+                console.log(test.expectedResult)
+                expect(https.setUpgradeInsecureRequestHeader(test.request)).toEqual(test.expectedResult)
+            })
         })
     })
 })

--- a/unit-test/data/httpsRequests.json
+++ b/unit-test/data/httpsRequests.json
@@ -1,0 +1,120 @@
+[
+    {
+        "request": {
+            "frameId": 0,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {
+            "responseHeaders": [
+                {
+                    "name": "status",
+                    "value": "200"
+                },
+                {
+                    "name": "Content-Security-Policy",
+                    "value": "upgrade-insecure-requests"
+                }
+            ]
+        },
+        "testCase": "create new upgrade-insecure-requests header when no CSP present"
+    },
+    {
+        "request": {
+            "frameId": 0,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Content-Security-Policy",
+                  "value": "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {
+            "responseHeaders": [
+                {
+                    "name": "status",
+                    "value": "200"
+                },
+                {
+                    "name": "Content-Security-Policy",
+                    "value": "upgrade-insecure-requests; default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'"
+                }
+            ]
+        },
+        "testCase": "prepend upgrade-insecure-requests header to existing CSP"
+    },
+    {
+        "request": {
+            "frameId": 0,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Content-Security-Policy",
+                  "value": "frame-ancestors 'self'; upgrade-insecure-requests"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {},
+        "testCase": "not alter CSP header when upgrade-insecure-requests directive already present"
+    },
+    {
+        "request": {
+            "frameId": 0,
+            "initiator": "http://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "http://www.duckduckgo.com"
+        },
+        "expectedResult": {},
+        "testCase": "not alter headers on http sites"
+    }
+]

--- a/unit-test/data/httpsRequests.json
+++ b/unit-test/data/httpsRequests.json
@@ -116,5 +116,105 @@
         },
         "expectedResult": {},
         "testCase": "not alter headers on http sites"
+    },
+    {
+        "request": {
+            "frameId": 1,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": 0,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "image",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {},
+        "testCase": "not alter CSP on subrequests"
+    },
+    {
+        "request": {
+            "frameId": 0,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Access-Control-Allow-Origin",
+                  "value": "http://duckduckgo.com"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Access-Control-Allow-Origin",
+                  "value": "http://duckduckgo.com"
+              },
+              {
+                  "name": "Content-Security-Policy",
+                  "value": "upgrade-insecure-requests"
+              }
+            ]
+        },
+        "testCase": "not alter Access-Control-Allow-Origin header on main frame"
+    },
+    {
+        "request": {
+            "frameId": 1,
+            "initiator": "https://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": 0,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Access-Control-Allow-Origin",
+                  "value": "http://duckduckgo.com"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "image",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Access-Control-Allow-Origin",
+                  "value": "https://duckduckgo.com"
+              }
+            ]
+        },
+        "testCase": "convert http domains in Access-Contorl-Allow-Origin to https for subrequests"
     }
 ]

--- a/unit-test/data/httpsRequests.json
+++ b/unit-test/data/httpsRequests.json
@@ -215,6 +215,6 @@
               }
             ]
         },
-        "testCase": "convert http domains in Access-Contorl-Allow-Origin to https for subrequests"
+        "testCase": "convert http domains in Access-Control-Allow-Origin header to https for subrequests"
     }
 ]


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 
cc: @jdorweiler @zachthompson @russellholt 
<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When a site is loaded over https, all active mixed content is blocked at the browser level before we have a chance to upgrade the requests to https. Mixed passive content is often blocked for several reasons (block-mixed-content header/meta tag, user agent). This PR fixes many sites broken due to improperly set up https websites that contain http resource links by appending the 'upgrade-insecure-requests' response header to the document.

## Steps to test this PR:
1. npm run test
2. visit site with mixed content, such as https://www.protrails.com/trail/744/aspen-snowmass-4-pass-loop. The mixed content should now load over https.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications 
