### PR TITLE
Block requests with type "beacon" or "ping"

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -26,7 +26,7 @@ const pixel = require('./pixel.es6')
 // Shallow copy of request types
 // And add beacon type based on browser, so we can block it
 let requestListenerTypes = constants.requestListenerTypes.slice()
-requestListenerTypes.push(utils.getBeacon())
+requestListenerTypes.push(utils.getBeaconName())
 
 chrome.webRequest.onBeforeRequest.addListener(
     redirect.handleRequest,

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -5,31 +5,34 @@
  * if we do too much before adding it
  */
 const ATB = require('./atb.es6')
-const utils = require('./utils.es6')
 
 chrome.runtime.onInstalled.addListener(function (details) {
     if (details.reason.match(/install/)) {
         ATB.updateATBValues()
             .then(ATB.openPostInstallPage)
     }
-
-    utils.updateRequestListenerTypes()
 })
 
 /**
  * REQUESTS
  */
 
+const utils = require('./utils.es6')
 const constants = require('../../data/constants')
 const redirect = require('./redirect.es6')
 const tabManager = require('./tab-manager.es6')
 const pixel = require('./pixel.es6')
 
+// Shallow copy of request types
+// And add beacon type based on browser, so we can block it
+let requestListenerTypes = constants.requestListenerTypes.slice()
+requestListenerTypes.push(utils.getBeacon())
+
 chrome.webRequest.onBeforeRequest.addListener(
     redirect.handleRequest,
     {
         urls: ['<all_urls>'],
-        types: constants.requestListenerTypes
+        types: requestListenerTypes
     },
     ['blocking']
 )

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -5,12 +5,15 @@
  * if we do too much before adding it
  */
 const ATB = require('./atb.es6')
+const utils = require('./utils.es6')
 
 chrome.runtime.onInstalled.addListener(function (details) {
     if (details.reason.match(/install/)) {
         ATB.updateATBValues()
             .then(ATB.openPostInstallPage)
     }
+
+    utils.updateRequestListenerTypes()
 })
 
 /**
@@ -87,7 +90,6 @@ chrome.omnibox.onInputEntered.addListener(function (text) {
  * MESSAGES
  */
 
-const utils = require('./utils.es6')
 const settings = require('./settings.es6')
 const browserWrapper = require('./chrome-wrapper.es6')
 

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -88,6 +88,7 @@ function isTracker (urlToCheck, thisTab, request) {
         // same as a first party requrest and return
         let trackerByParentCompany = checkTrackersWithParentCompany(urlSplit, siteDomain, request)
         if (trackerByParentCompany) {
+            trackerByParentCompany = checkReason(trackerByParentCompany)
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
                 return addCommonParent(trackerByParentCompany, commonParent)
@@ -96,6 +97,15 @@ function isTracker (urlToCheck, thisTab, request) {
         }
     }
     return false
+}
+
+// Check for reason to block the tracker
+// And add it
+// For now it just adds "beacon" if that's the tracker type
+function checkReason (trackerObj) {
+    if (trackerObj.type === utils.getBeaconName()) {
+        trackerObj.reason = 'beacon'
+    }
 }
 
 // add common parent info to the final tracker object returned by isTracker

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -88,7 +88,7 @@ function isTracker (urlToCheck, thisTab, request) {
         // same as a first party requrest and return
         let trackerByParentCompany = checkTrackersWithParentCompany(urlSplit, siteDomain, request)
         if (trackerByParentCompany) {
-            trackerByParentCompany = checkReason(trackerByParentCompany)
+            trackerByParentCompany = addBeaconReason(trackerByParentCompany)
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
                 return addCommonParent(trackerByParentCompany, commonParent)
@@ -99,10 +99,9 @@ function isTracker (urlToCheck, thisTab, request) {
     return false
 }
 
-// Check for reason to block the tracker
-// And add it
-// For now it just adds "beacon" if that's the tracker type
-function checkReason (trackerObj) {
+// Adds "beacon" as a reason to block
+// if that's the tracker type
+function addBeaconReason (trackerObj) {
     if (trackerObj.type === utils.getBeaconName()) {
         trackerObj.reason = 'beacon'
     }

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -105,6 +105,8 @@ function addBeaconReason (trackerObj) {
     if (trackerObj.type === utils.getBeaconName()) {
         trackerObj.reason = 'beacon'
     }
+
+    return trackerObj
 }
 
 // add common parent info to the final tracker object returned by isTracker

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -88,7 +88,10 @@ function isTracker (urlToCheck, thisTab, request) {
         // same as a first party requrest and return
         let trackerByParentCompany = checkTrackersWithParentCompany(urlSplit, siteDomain, request)
         if (trackerByParentCompany) {
-            trackerByParentCompany = addBeaconReason(trackerByParentCompany)
+            if (trackerByParentCompany.type === utils.getBeaconName()) {
+                trackerByParentCompany.reason = 'beacon'
+            }
+
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
                 return addCommonParent(trackerByParentCompany, commonParent)
@@ -97,16 +100,6 @@ function isTracker (urlToCheck, thisTab, request) {
         }
     }
     return false
-}
-
-// Adds "beacon" as a reason to block
-// if that's the tracker type
-function addBeaconReason (trackerObj) {
-    if (trackerObj.type === utils.getBeaconName()) {
-        trackerObj.reason = 'beacon'
-    }
-
-    return trackerObj
 }
 
 // add common parent info to the final tracker object returned by isTracker

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -113,6 +113,5 @@ module.exports = {
     getBrowserName: getBrowserName,
     getUpgradeToSecureSupport: getUpgradeToSecureSupport,
     findParent: findParent,
-    getBeaconName: getBeaconName,
-    updateRequestListenerTypes: updateRequestListenerTypes
+    getBeaconName: getBeaconName
 }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -1,5 +1,4 @@
 const tldjs = require('tldjs')
-const constants = require('../../data/constants')
 const entityMap = require('../../data/tracker_lists/entityMap')
 
 function extractHostFromURL (url, shouldKeepWWW) {

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -100,17 +100,6 @@ const beaconNamesByBrowser = {
 }
 const beaconName = beaconNamesByBrowser[browser]
 
-// Add beacon or ping to the blocked types of requests
-// Depending on browser
-function updateRequestListenerTypes () {
-    if (!constants.requestListenerTypes ||
-        constants.requestListenerTypes.find(beaconName)) {
-        return
-    }
-
-    constants.requestListenerTypes.push(beaconName)
-}
-
 function getBeaconName () {
     return beaconName
 }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -92,20 +92,27 @@ function getUpgradeToSecureSupport () {
     return upgradeToSecureSupport
 }
 
-// Add beacon or ping to the blocked types of requests
-// Depending on browser
 // Chrome errors with 'beacon', but supports 'ping'
 // Firefox only blocks 'beacon' (even though it should support 'ping')
+const beaconNamesByBrowser = {
+    'chrome': 'ping',
+    'moz': 'beacon'
+}
+const beaconName = beaconNamesByBrowser[browser]
+
+// Add beacon or ping to the blocked types of requests
+// Depending on browser
 function updateRequestListenerTypes () {
-    if (!constants.requestListenerTypes) return
-
-    const beaconName = {
-        'chrome': 'ping',
-        'moz': 'beacon'
+    if (!constants.requestListenerTypes ||
+        constants.requestListenerTypes.find(beaconName)) {
+        return
     }
-    if (constants.requestListenerTypes.find(beaconName[browser])) return
 
-    constants.requestListenerTypes.push(beaconName[browser])
+    constants.requestListenerTypes.push(beaconName)
+}
+
+function getBeaconName () {
+    return beaconName
 }
 
 module.exports = {
@@ -117,5 +124,6 @@ module.exports = {
     getBrowserName: getBrowserName,
     getUpgradeToSecureSupport: getUpgradeToSecureSupport,
     findParent: findParent,
+    getBeaconName: getBeaconName,
     updateRequestListenerTypes: updateRequestListenerTypes
 }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -1,4 +1,5 @@
 const tldjs = require('tldjs')
+const constants = require('../../data/constants')
 const entityMap = require('../../data/tracker_lists/entityMap')
 
 function extractHostFromURL (url, shouldKeepWWW) {
@@ -91,6 +92,22 @@ function getUpgradeToSecureSupport () {
     return upgradeToSecureSupport
 }
 
+// Add beacon or ping to the blocked types of requests
+// Depending on browser
+// Chrome errors with 'beacon', but supports 'ping'
+// Firefox only blocks 'beacon' (even though it should support 'ping')
+function updateRequestListenerTypes () {
+    if (!constants.requestListenerTypes) return
+
+    const beaconName = {
+        'chrome': 'ping',
+        'moz': 'beacon'
+    }
+    if (constants.requestListenerTypes.find(beaconName[browser])) return
+
+    constants.requestListenerTypes.push(beaconName[browser])
+}
+
 module.exports = {
     extractHostFromURL: extractHostFromURL,
     extractTopSubdomainFromHost: extractTopSubdomainFromHost,
@@ -99,5 +116,6 @@ module.exports = {
     getProtocol: getProtocol,
     getBrowserName: getBrowserName,
     getUpgradeToSecureSupport: getUpgradeToSecureSupport,
-    findParent: findParent
+    findParent: findParent,
+    updateRequestListenerTypes: updateRequestListenerTypes
 }

--- a/unit-test/background/utils.es6.js
+++ b/unit-test/background/utils.es6.js
@@ -88,9 +88,9 @@ describe('utils.extractHostFromURL()', () => {
 })
 
 describe('utils.getUpgradeToSecureSupport()', () => {
-    const chromeBeaconName = "ping"
-    it('should return ${chromeBeaconName} in headless chrome', () => {
+    it('should return ping in headless chrome', () => {
         let result = utils.getBeaconName()
+        const chromeBeaconName = 'ping'
         expect(result).toEqual(chromeBeaconName)
     })
 })

--- a/unit-test/background/utils.es6.js
+++ b/unit-test/background/utils.es6.js
@@ -86,3 +86,11 @@ describe('utils.extractHostFromURL()', () => {
         })
     })
 })
+
+describe('utils.getUpgradeToSecureSupport()', () => {
+    const chromeBeaconName = "ping"
+    it('should return ${chromeBeaconName} in headless chrome', () => {
+        let result = utils.getBeaconName()
+        expect(result).toEqual(chromeBeaconName)
+    })
+})


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Beacon and ping type requests are slipping through currently, because they're not included in the list of resource types we recognize and block.
However, adding "beacon" to the list errors on Chrome, while "ping" doesn't seem to block anything in Firefox.
With this change we'll add either beacon or ping on extension install/update depending on the browser.
Also add "beacon" as a reason for blocking these requests.



## Steps to test this PR:
1. build and reload extension
2. check both firefox and chrome.
3. visit a site that uses beacons (google, youtube, amazon etc) and disable privacy protection
4. in the network tab you should be able to see the beacons loading (usually you can filter by "analytics" to make them show up)
5. enable privacy protection; now the beacon requests should be blocked
6. also run unit tests

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
