### PR TITLE
Set hostname to empty string if it's null so extractHostFromUrl returns something

### DIFF
--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -5,7 +5,7 @@ function extractHostFromURL (url, shouldKeepWWW) {
     if (!url) return
 
     let urlObj = tldjs.parse(url)
-    let hostname = urlObj.hostname
+    let hostname = urlObj.hostname || ''
 
     if (!shouldKeepWWW) {
         hostname = hostname.replace(/^www\./, '')


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @andrey-p 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
For whatever reason it appears that tldjs.parse(url) in extractHostFromUrl is returning an urlObj without a hostname. I would assume that this is due to tldjs choking on some kind of url, but I haven't been able to reproduce it so I'm not 100% sure. I just saw this error cropping up in the new chrome extension error page:
<img width="321" alt="chrome_2018-09-25_22-51-18" src="https://user-images.githubusercontent.com/4481594/46054504-8be03200-c115-11e8-8132-82e0716ad75f.png">

This just makes sure that hostname is defined so no errors are thrown.
