### PR TITLE
Send https upgrade failure total

### DIFF
--- a/shared/data/defaultSettings.js
+++ b/shared/data/defaultSettings.js
@@ -24,5 +24,5 @@ module.exports = {
     "hasSeenPostInstall": false,
     "extiSent": false,
     "failedUpgrades": 0,
-    "attemptedUpgrades": 0
+    "totalUpgrades": 0
 }

--- a/shared/data/defaultSettings.js
+++ b/shared/data/defaultSettings.js
@@ -22,5 +22,7 @@ module.exports = {
     "httpsWhitelist-etag": null,
     "httpsUpgradeList-etag": null,
     "hasSeenPostInstall": false,
-    "extiSent": false
+    "extiSent": false,
+    "failedUpgrades": 0,
+    "attemptedUpgrades": 0
 }

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -187,6 +187,8 @@ chrome.alarms.onAlarm.addListener(alarmEvent => {
             httpsStorage.getLists(constants.httpsLists)
                 .then(lists => https.setLists(lists))
                 .catch(e => console.log(e))
+
+            https.sendHttpsUpgradeTotals()
         })
     } else if (alarmEvent.name === 'updateUninstallURL') {
         chrome.runtime.setUninstallURL(ATB.getSurveyURL())
@@ -211,6 +213,8 @@ let onStartup = () => {
         httpsStorage.getLists(constants.httpsLists)
             .then(lists => https.setLists(lists))
             .catch(e => console.log(e))
+
+        https.sendHttpsUpgradeTotals()
     })
 }
 
@@ -227,10 +231,12 @@ chrome.webRequest.onErrorOccurred.addListener((e) => {
     }
 
     if (e.error && e.url.match(/^https/)) {
-        const errCode = constants.httpsErrorCodes[e.error]
+        // map error message to an int code or zero if we haven't defined this code yet
+        const errCode = constants.httpsErrorCodes[e.error] || 0
         tab.hasHttpsError = true
 
         if (errCode) {
+            https.incrementUpgradeCount('failedUpgrades')
             const url = new URL(e.url)
             pixel.fire('ehd', {
                 'url': `${encodeURIComponent(url.hostname + url.pathname)}`,

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -231,8 +231,7 @@ chrome.webRequest.onErrorOccurred.addListener((e) => {
     }
 
     if (e.error && e.url.match(/^https/)) {
-        // map error message to an int code or zero if we haven't defined this code yet
-        const errCode = constants.httpsErrorCodes[e.error] || 0
+        const errCode = constants.httpsErrorCodes[e.error]
         tab.hasHttpsError = true
 
         if (errCode) {

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -92,7 +92,7 @@ class HTTPS {
         if (host && this.canUpgradeHost(host)) {
             if (isMainFrame) {
                 tab.mainFrameUpgraded = true
-                this.incrementUpgradeCount('attemptedUpgrades')
+                this.incrementUpgradeCount('totalUpgrades')
             }
 
             return reqUrl.replace(/^(http|https):\/\//i, 'https://')
@@ -104,14 +104,14 @@ class HTTPS {
 
     // Send https upgrade and failure totals
     sendHttpsUpgradeTotals () {
-        const upgrades = settings.getSetting('attemptedUpgrades')
+        const upgrades = settings.getSetting('totalUpgrades')
         const failed = settings.getSetting('failedUpgrades')
 
         // only send if we have data
         if (upgrades || failed) {
-            settings.updateSetting('attemptedUpgrades', 0)
+            settings.updateSetting('totalUpgrades', 0)
             settings.updateSetting('failedUpgrades', 0)
-            pixel.fire('ehs', {'successes': upgrades, 'failures': failed})
+            pixel.fire('ehs', {'total': upgrades, 'failures': failed})
         }
     }
 

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -1,6 +1,7 @@
 const settings = require('./settings.es6')
 const utils = require('./utils.es6')
 const BloomFilter = require('jsbloom').filter
+const pixel = require('./pixel.es6')
 
 class HTTPS {
     constructor () {
@@ -89,12 +90,36 @@ class HTTPS {
         const host = utils.extractHostFromURL(reqUrl, true) || ''
 
         if (host && this.canUpgradeHost(host)) {
-            if (isMainFrame) tab.mainFrameUpgraded = true
+            if (isMainFrame) {
+                tab.mainFrameUpgraded = true
+                this.incrementUpgradeCount('attemptedUpgrades')
+            }
+
             return reqUrl.replace(/^(http|https):\/\//i, 'https://')
         }
 
         // If it falls to here, default to reqUrl
         return reqUrl
+    }
+
+    // Send https upgrade and failure totals
+    sendHttpsUpgradeTotals () {
+        const upgrades = settings.getSetting('attemptedUpgrades')
+        const failed = settings.getSetting('failedUpgrades')
+
+        // only send if we have data
+        if (upgrades || failed) {
+            settings.updateSetting('attemptedUpgrades', 0)
+            settings.updateSetting('failedUpgrades', 0)
+            pixel.fire('ehs', {'successes': upgrades,'failures': failed})
+        }
+    }
+
+    // Increment upgrade or failed upgrade settings
+    incrementUpgradeCount(setting) {
+        let value = parseInt(settings.getSetting(setting)) || 0
+        value += 1
+        settings.updateSetting(setting, value)
     }
 }
 

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -109,6 +109,7 @@ class HTTPS {
 
         // only send if we have data
         if (upgrades || failed) {
+            // clear the counts
             settings.updateSetting('totalUpgrades', 0)
             settings.updateSetting('failedUpgrades', 0)
             pixel.fire('ehs', {'total': upgrades, 'failures': failed})

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -121,6 +121,7 @@ class HTTPS {
         let value = parseInt(settings.getSetting(setting)) || 0
         value += 1
         settings.updateSetting(setting, value)
+    }
 
     /**
      * Modify response headers on https pages to fix mixed content.

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -111,12 +111,12 @@ class HTTPS {
         if (upgrades || failed) {
             settings.updateSetting('attemptedUpgrades', 0)
             settings.updateSetting('failedUpgrades', 0)
-            pixel.fire('ehs', {'successes': upgrades,'failures': failed})
+            pixel.fire('ehs', {'successes': upgrades, 'failures': failed})
         }
     }
 
     // Increment upgrade or failed upgrade settings
-    incrementUpgradeCount(setting) {
+    incrementUpgradeCount (setting) {
         let value = parseInt(settings.getSetting(setting)) || 0
         value += 1
         settings.updateSetting(setting, value)

--- a/shared/js/background/pixel.es6.js
+++ b/shared/js/background/pixel.es6.js
@@ -90,8 +90,7 @@ function concatParams (args) {
         if (typeof arg === 'object') {
             objParamString += Object.keys(arg).reduce((params, key) => {
                 const val = arg[key]
-                // val can be zero
-                if (typeof val !== 'undefined') return `${params}&${key}=${val}`
+                if (val || val === 0) return `${params}&${key}=${val}`
             }, '')
         } else if (arg) {
             // otherwise just add args separated by _

--- a/shared/js/background/pixel.es6.js
+++ b/shared/js/background/pixel.es6.js
@@ -90,7 +90,8 @@ function concatParams (args) {
         if (typeof arg === 'object') {
             objParamString += Object.keys(arg).reduce((params, key) => {
                 const val = arg[key]
-                if (val) return `${params}&${key}=${val}`
+                // val can be zero
+                if (typeof val !== 'undefined') return `${params}&${key}=${val}`
             }, '')
         } else if (arg) {
             // otherwise just add args separated by _

--- a/unit-test/background/pixel.es6.js
+++ b/unit-test/background/pixel.es6.js
@@ -56,6 +56,16 @@ const concatParamsTestCases = [
     {
         'params': [
             {
+                'p2': 1,
+                'p3': 0
+            },
+            'param1'
+        ],
+        'result': '_param1?1000000&p2=1&p3=0'
+    },
+    {
+        'params': [
+            {
                 'p3': 'param3',
                 'p4': 'param4'
             },


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Count the number of attempted and failed https upgrades.


## Steps to test this PR:
1. When first loading the extension both counts should be zero
```
window.dbg.settings.getSetting('attemptedUpgrades')
window.dbg.settings.getSetting('failedUpgrades')
```
2. Visit some http sites and the attempted total should increment each time.
```
window.dbg.settings.getSetting('attemptedUpgrades')
```
3. Clear the https whitelist and visit some broken https sites `failedUpgrades` should increment.
```
window.dbg.https.whitelist = []
window.dbg.settings.getSetting('failedUpgrades')
```
4. Reload the extension. You should see a network request with the successes and failure parameters go out. 
5. The totals should reset to zero.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
