### PR TITLE
Make sure redirect protection doesn't trigger accidentally

### DIFF
--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -9,7 +9,7 @@ const REQUEST_REDIRECT_LIMIT = 7
  * This class protects users from accidentally being sent into a redirect loop
  * if a site we've included into our HTTPS list redirects them back to HTTP.
  *
- * Every redirect we perform on a tab gets registered against this class.
+ * Every redirect we perform on a tab gets registered against an instance of this class.
  * If we hit too many redirects for a request, we block it via canRedirect().
  */
 
@@ -101,6 +101,12 @@ class HttpsRedirects {
         return canRedirect
     }
 
+    /**
+     * We regenerate tab objects every time a new main_frame request is made.
+     *
+     * persistMainFrameRedirect() is used whenever a tab object is regenerated,
+     * so we can maintain redirect loop protection across multiple main_frame requests
+     */
     persistMainFrameRedirect (redirectData) {
         if (!redirectData) { return }
 

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -74,7 +74,6 @@ class HttpsRedirects {
                 const timeSinceFirstHit = Date.now() - this.mainFrameRedirect.time
 
                 if (timeSinceFirstHit < MAINFRAME_RESET_MS && this.mainFrameRedirect.count >= REQUEST_REDIRECT_LIMIT) {
-                    console.log(`blocking redirect time: ${timeSinceFirstHit}, hits: ${this.mainFrameRedirect.count}`)
                     canRedirect = false
                 }
             }

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -38,7 +38,7 @@ function handleRequest (requestData) {
             // andrey: temporary disable this. it was letting redirect loops through on Tumblr
             // persist the last URL the tab was trying to upgrade to HTTPS
             // if (thisTab && thisTab.httpsRedirects) {
-                // newTab.httpsRedirects.persistMainFrameRedirect(thisTab.httpsRedirects.getMainFrameRedirect())
+            //     newTab.httpsRedirects.persistMainFrameRedirect(thisTab.httpsRedirects.getMainFrameRedirect())
             // }
             thisTab = newTab
         }

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -35,10 +35,11 @@ function handleRequest (requestData) {
         if (!thisTab || thisTab.requestId !== requestData.requestId) {
             let newTab = tabManager.create(requestData)
 
+            // andrey: temporary disable this. it was letting redirect loops through on Tumblr
             // persist the last URL the tab was trying to upgrade to HTTPS
-            if (thisTab && thisTab.httpsRedirects) {
-                newTab.httpsRedirects.persistMainFrameRedirect(thisTab.httpsRedirects.getMainFrameRedirect())
-            }
+            // if (thisTab && thisTab.httpsRedirects) {
+                // newTab.httpsRedirects.persistMainFrameRedirect(thisTab.httpsRedirects.getMainFrameRedirect())
+            // }
             thisTab = newTab
         }
 

--- a/unit-test/background/classes/https-redirects.es6.js
+++ b/unit-test/background/classes/https-redirects.es6.js
@@ -120,7 +120,7 @@ describe('HttpsRedirects', () => {
         it('once a main frame redirect has been marked as not working, the domain should be blacklisted', () => {
             fastForward(1500)
 
-            for (let i =0; i < 8; i++) {
+            for (let i = 0; i < 8; i++) {
                 httpsRedirects.registerRedirect(getMainFrameRequest())
             }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 
**CC:** @nilnilnil @jdorweiler 

## Description:
It's currently possible for redirect protection to be triggered manually, e.g. if a user presses enter multiple times on the URL bar while it's loading.

This PR adds a limit of 7 hits per main frame URL within 3s. This should be pretty easy for a redirect loop to hit, not so much for a human being.

## Steps to test this PR:

1. Open a site which is currently vulnerable to HTTPS redirect loops (some NSFW Tumblr ones apparently?) and verify the redirect protection still does its thing
2. Try opening the same HTTP link manually, end verify that redirect protection doesn't trigger (e.g. no `ehd` pixel with error code `13`.)

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
