### PR TITLE
catch potential https redirect loop caused by upgrade-insecure-requests header

### DIFF
--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -136,6 +136,14 @@ class HTTPS {
         let headersChanged = false
 
         if (request.type === 'main_frame') {
+            // Catch edge case where a webpage served over https redirects to the
+            // http version of itself via a js window.location rewrite. Request
+            // objects include an attr when they are when they are triggered by a
+            // webpage. Chrome calls this initiator; firefox calls it originUrl.
+            let requestInitiator = request.originUrl || request.initiator
+
+            if (requestInitiator && (requestInitiator.replace(/\/$/, '') === request.url.replace(/\/$/, ''))) return {}
+
             let cspHeaderExists = false
 
             for (const header in request.responseHeaders) {

--- a/unit-test/data/httpsRequests.json
+++ b/unit-test/data/httpsRequests.json
@@ -2,7 +2,6 @@
     {
         "request": {
             "frameId": 0,
-            "initiator": "https://www.duckduckgo.com",
             "method": "GET",
             "parentFrameId": -1,
             "requestId": "1",
@@ -35,7 +34,6 @@
     {
         "request": {
             "frameId": 0,
-            "initiator": "https://www.duckduckgo.com",
             "method": "GET",
             "parentFrameId": -1,
             "requestId": "1",
@@ -83,6 +81,31 @@
               },
               {
                   "name": "Content-Security-Policy",
+                  "value": "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "main_frame",
+            "url": "https://www.duckduckgo.com"
+        },
+        "expectedResult": {},
+        "testCase": "not alter headers when main frame request is made to same url as main frame to avoid redirect loop"
+    },
+    {
+        "request": {
+            "frameId": 0,
+            "method": "GET",
+            "parentFrameId": -1,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Content-Security-Policy",
                   "value": "frame-ancestors 'self'; upgrade-insecure-requests"
               }
             ],
@@ -98,7 +121,6 @@
     {
         "request": {
             "frameId": 0,
-            "initiator": "http://www.duckduckgo.com",
             "method": "GET",
             "parentFrameId": -1,
             "requestId": "1",
@@ -134,7 +156,7 @@
             "statusLine": "HTTP/1.1 200",
             "tabId": 1,
             "type": "image",
-            "url": "https://www.duckduckgo.com"
+            "url": "https://www.duckduckgo.com/image.png"
         },
         "expectedResult": {},
         "testCase": "not alter CSP on subrequests"
@@ -142,7 +164,6 @@
     {
         "request": {
             "frameId": 0,
-            "initiator": "https://www.duckduckgo.com",
             "method": "GET",
             "parentFrameId": -1,
             "requestId": "1",
@@ -201,7 +222,7 @@
             "statusLine": "HTTP/1.1 200",
             "tabId": 1,
             "type": "image",
-            "url": "https://www.duckduckgo.com"
+            "url": "https://www.duckduckgo.com/image.png"
         },
         "expectedResult": {
             "responseHeaders": [


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 


**CC:** @jdorweiler @MariagraziaAlastra 


## Description:
It turns out there's a potential redirect loop caused by adding the `upgrade-insecure-requests` header to webpages. When a site loads over https but includes js that rewrites the site url to http, the `upgrade-insecure-requests` header on the main document causes that request to be upgraded to https. It's definitely a rare edge case, but this fixes it anyway. I also added a test for this specific case.


## Steps to test this PR:
1. rebuild extension
2. visit site that does a silly http rewrite, like https://slither.io (we don't even upgrade this site anyway, in order to trigger the redirect loop you have to manually type https in the address bar)
3. site should not get stuck in redirect loop. give it a min to load, the site is quite slow.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
