### PR TITLE
Make sure headers aren't modified on non-https sites

### DIFF
--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -169,7 +169,7 @@ class HTTPS {
         } else {
             // Don't alter headers of subrequests served over https when they are
             // coming from http pages.
-            if (requestInitiator && (requestInitiator.indexOf('https://') !==0)) return {}
+            if (requestInitiator && (requestInitiator.indexOf('https://') !== 0)) return {}
 
             for (const header in request.responseHeaders) {
                 // If Access-Control-Allow-Origin header exists and contains http urls,

--- a/unit-test/data/httpsRequests.json
+++ b/unit-test/data/httpsRequests.json
@@ -237,5 +237,31 @@
             ]
         },
         "testCase": "convert http domains in Access-Control-Allow-Origin header to https for subrequests"
+    },
+    {
+        "request": {
+            "frameId": 1,
+            "initiator": "http://www.duckduckgo.com",
+            "method": "GET",
+            "parentFrameId": 0,
+            "requestId": "1",
+            "responseHeaders": [
+              {
+                  "name": "status",
+                  "value": "200"
+              },
+              {
+                  "name": "Access-Control-Allow-Origin",
+                  "value": "http://duckduckgo.com"
+              }
+            ],
+            "statusCode": 200,
+            "statusLine": "HTTP/1.1 200",
+            "tabId": 1,
+            "type": "image",
+            "url": "https://www.duckduckgo.com/image.png"
+        },
+        "expectedResult": {},
+        "testCase": "not change http domains in Access-Control-Allow-Origin header to https on http pages"
     }
 ]


### PR DESCRIPTION
**Reviewer:** @jdorweiler / @MariagraziaAlastra 

## Description:
Insert extra check to make sure that we aren't touching headers of subrequests on non-https sites. This was causing issues especially during local development.. Fixes https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/322. 

I think we can probably tighten up this logic even further by pulling the tab object into the `setUpgradeInsecureRequest` function, but this should solve the issue for now. I'll revisit when I get back next week.

## Steps to test this PR:
1. Navigate to `http://armorgames.com/play/14775/strike-force-heroes-2?via-search=1`
2. Open network tab, look for stripe request that includes 'manhattan'
3. Check that `Access-Control-Allow-Origin` of that request contains an http url, not https.
4. `npm run test`


## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
