### PR TITLE
Fix adding 'beacon' as blockable request type on FF

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -5,6 +5,7 @@
  * if we do too much before adding it
  */
 const ATB = require('./atb.es6')
+const utils = require('./utils.es6')
 
 chrome.runtime.onInstalled.addListener(function (details) {
     if (details.reason.match(/install/)) {
@@ -17,18 +18,15 @@ chrome.runtime.onInstalled.addListener(function (details) {
  * REQUESTS
  */
 
-const utils = require('./utils.es6')
-const constants = require('../../data/constants')
 const redirect = require('./redirect.es6')
 const tabManager = require('./tab-manager.es6')
 const pixel = require('./pixel.es6')
 const https = require('./https.es6')
+const constants = require('../../data/constants')
+let requestListenerTypes = utils.getUpdatedRequestListenerTypes()
 
 // Shallow copy of request types
 // And add beacon type based on browser, so we can block it
-let requestListenerTypes = constants.requestListenerTypes.slice()
-requestListenerTypes.push(utils.getBeaconName())
-
 chrome.webRequest.onBeforeRequest.addListener(
     redirect.handleRequest,
     {

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -5,7 +5,6 @@ const Companies = require('./companies.es6')
 const tabManager = require('./tab-manager.es6')
 const ATB = require('./atb.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
-const constants = require('../../data/constants')
 
 var debugRequest = false
 

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -5,6 +5,7 @@ const Companies = require('./companies.es6')
 const tabManager = require('./tab-manager.es6')
 const ATB = require('./atb.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
+const constants = require('../../data/constants')
 
 var debugRequest = false
 
@@ -21,7 +22,6 @@ trackers.loadLists()
 
 function handleRequest (requestData) {
     let tabId = requestData.tabId
-
     // Skip requests to background tabs
     if (tabId === -1) { return }
 

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -1,6 +1,8 @@
 const tldjs = require('tldjs')
 const entityMap = require('../../data/tracker_lists/entityMap')
 const constants = require('../../data/constants')
+const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es6')
+const browserInfo = parseUserAgentString()
 
 function extractHostFromURL (url, shouldKeepWWW) {
     if (!url) return ''
@@ -63,35 +65,24 @@ function getCurrentTab (callback) {
 }
 
 // Browser / Version detection
-
-// Get browser name for popup asset paths 
-// and beacon vs ping request type
+// Get correct name for fetching UI assets
 function getBrowserName () {
-    let uaString = window.navigator.userAgent
-    let browserName = 'chrome'
-    try {
-        if (uaString.match(/(Firefox)/)) {
-            browserName = 'moz'
-        }
-    } catch (e) {}
+    if (!browserInfo || !browserInfo.browser) return
 
-    return browserName
+    let browser = browserInfo.browser.toLowerCase()
+    if (browser === 'firefox') browser = 'moz'
+
+    return browser
 }
 
-// Determine if upgradeToSecure supported (firefox 59+)
-// Chrome doesn't have getBrowserInfo so we'll default to Chrome
-// and try to detect if this is Firefox.
+// Determine if upgradeToSecure supported (Firefox 59+)
 function getUpgradeToSecureSupport () {
     let canUpgrade = false
     if (getBrowserName() !== 'moz') return canUpgrade
 
-    let uaString = window.navigator.userAgent
-    try {
-        const browserVersion = uaString.match(/([0-9]+)/)
-        if (browserVersion >= 59) {
-            canUpgrade = true
-        }
-    } catch (e) {}
+    if (browserInfo && browserInfo.version >= 59) {
+        canUpgrade = true
+    }
 
     return canUpgrade
 }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -65,7 +65,6 @@ function getCurrentTab (callback) {
 // Browser / Version detection
 // 1. Set browser for popup asset paths
 // 2. Determine if upgradeToSecure supported (firefox 59+)
-// 3. Set beacon request type name ('beacon' or 'ping')
 // chrome doesn't have getBrowserInfo so we'll default to chrome
 // and try to detect if this is firefox.
 
@@ -112,6 +111,7 @@ function getBeaconName () {
     return beaconNamesByBrowser[getBrowserName()]
 }
 
+// Return requestListenerTypes + beacon or ping
 function getUpdatedRequestListenerTypes () {
     let requestListenerTypes = constants.requestListenerTypes.slice()
     requestListenerTypes.push(getBeaconName())

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -116,5 +116,5 @@ module.exports = {
     getUpgradeToSecureSupport: getUpgradeToSecureSupport,
     findParent: findParent,
     getBeaconName: getBeaconName,
-    getUpdatedRequestListenerTypes
+    getUpdatedRequestListenerTypes: getUpdatedRequestListenerTypes
 }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -76,7 +76,6 @@ try {
     chrome.runtime.getBrowserInfo((info) => {
         if (info.name === 'Firefox') {
             browser = 'moz'
-            console.log(browser)
             var browserVersion = info.version.match(/^(\d+)/)[1]
             if (browserVersion >= 59) {
                 upgradeToSecureSupport = true

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -63,41 +63,37 @@ function getCurrentTab (callback) {
 }
 
 // Browser / Version detection
-// 1. Set browser for popup asset paths
-// 2. Determine if upgradeToSecure supported (firefox 59+)
-// chrome doesn't have getBrowserInfo so we'll default to chrome
-// and try to detect if this is firefox.
 
-var browser = 'chrome'
-var upgradeToSecureSupport = false
-
-try {
-    chrome.runtime.getBrowserInfo((info) => {
-        if (info.name === 'Firefox') {
-            browser = 'moz'
-            var browserVersion = info.version.match(/^(\d+)/)[1]
-            if (browserVersion >= 59) {
-                upgradeToSecureSupport = true
-            }
-        }
-    })
-} catch (e) {}
-
-// Sometimes getBrowserInfo won't be available yet at this point
-// Double check the user agent to get at least the right browser name
+// Get browser name for popup asset paths 
+// and beacon vs ping request type
 function getBrowserName () {
     let uaString = window.navigator.userAgent
+    let browserName = 'chrome'
     try {
         if (uaString.match(/(Firefox)/)) {
-            browser = 'moz'
+            browserName = 'moz'
         }
     } catch (e) {}
 
-    return browser
+    return browserName
 }
 
+// Determine if upgradeToSecure supported (firefox 59+)
+// Chrome doesn't have getBrowserInfo so we'll default to Chrome
+// and try to detect if this is Firefox.
 function getUpgradeToSecureSupport () {
-    return upgradeToSecureSupport
+    let canUpgrade = false
+    if (getBrowserName() !== 'moz') return canUpgrade
+
+    let uaString = window.navigator.userAgent
+    try {
+        const browserVersion = uaString.match(/([0-9]+)/)
+        if (browserVersion >= 59) {
+            canUpgrade = true
+        }
+    } catch (e) {}
+
+    return canUpgrade
 }
 
 // Chrome errors with 'beacon', but supports 'ping'


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
#311 Added the beacon or ping type to the list of blockable requests, but Firefox sometimes gets mistaken as Chrome and we add "ping" (which FF claims is supported but doesn't do anything) instead of "beacon" to the list.
This happens because Chrome is the default browser name we use, in case getBrowserInfo() is not available. However, sometimes it takes a while for it to be available on FF and we set the request types for the onBeforeRequest handler too early.

This PR fixes that by double checking the UA string before returning the browser name.


## Steps to test this PR:
1. Build and reload extension
2. Go on sites with beacons like github.com
3. Check on the network tab and in the background that beacon requests (in github's case, it's google analytics) are blocked
4. Open the popup: all popup UI assets are properly loaded and the beacon is included in the blocked trackers count
5. Make sure to test both Chrome and Firefox


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
