### PR TITLE
Apply temp whitelist rules independently of the subdomain

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -54,12 +54,10 @@ class Site {
     checkBrokenSites (domain) {
         let trackersWhitelistTemporary = abpLists.getTemporaryWhitelist()
 
-        if (!trackersWhitelistTemporary) {
+        if (!trackersWhitelistTemporary) return
 
-        } else {
-            return trackersWhitelistTemporary.indexOf(domain) !== -1
-        }
-    };
+        return trackersWhitelistTemporary.some(brokenSiteDomain => brokenSiteDomain.match(new RegExp(domain + '$')))
+    }
 
     /*
      * When site objects are created we check the stored whitelists

--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -13,6 +13,7 @@ const privacyPractices = require('../privacy-practices.es6')
 const Grade = require('@duckduckgo/privacy-grade').Grade
 const trackerPrevalence = require('../../../data/tracker_lists/prevalence')
 const browserWrapper = require('../$BROWSER-wrapper.es6')
+const tldjs = require('tldjs')
 
 class Site {
     constructor (url) {
@@ -56,6 +57,11 @@ class Site {
 
         if (!trackersWhitelistTemporary) return
 
+        // Match independently of subdomain
+        domain = tldjs.getDomain(domain) || domain
+
+        // Make sure we match at the end of the URL
+        // so we're extra sure it's the legit main domain
         return trackersWhitelistTemporary.some(brokenSiteDomain => brokenSiteDomain.match(new RegExp(domain + '$')))
     }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
The temp whitelist used to only apply to main domains, which means if we attempt fixing a broken site by adding it to the whitelist, it won't work for any of its subdomains.
This PR fixes that.


## Steps to test this PR:
1. build and reload extension
2. navigate to suntrust.com - the site should be whitelisted and nothing should be blocked
3. try logging in with random credentials - now you'll be redirected to a subdomain
4. at this point, the site should still be whitelisted
5. try other sites in the temp whitelist: https://github.com/duckduckgo/content-blocking-whitelist/blob/master/trackers-whitelist-temporary.txt
6. check normal sites - they should still have protection on

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
