### PR TITLE
Disable privacy protection on localhost

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -109,13 +109,21 @@ class Site {
     getSpecialDomain () {
         const extensionId = browserWrapper.getExtensionId()
         const url = this.url
+        const localhostName = 'localhost'
         let domain = this.domain
 
         if (url === '') {
             return 'new tab'
         }
 
-        if (domain === 'localhost') {
+        // Both 'localhost' and the loopback ip have to be specified
+        // since they're treated as different domains
+        if (domain === localhostName || domain.match(/^127\.0\.0\.1/)) {
+            return localhostName
+        }
+
+        // Handle non-routable meta-address
+        if (domain.match(/^0\.0\.0\.0/)) {
             return domain
         }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 


**CC:** @andrey-p @jdorweiler 
<!-- Optional fields
**Depends on:** 
-->

## Description:
We've received feedback a few times from users who have run into issues with the extension while doing local development, and there's no reason to keep privacy protection on for local addresses.
We were already not grading localhost domains, as long as the address was written in the form of http://localhost:... etc

This PR disables grading when localhost is written as 127.0.0.1, and for non routable meta-addresses (0.0.0.0 which is also local): they'll be treated as a special page.


## Steps to test this PR:
1. Build and reload extension
2. To see localhost, you can just use Python's SimpleHTTPServer, eg: `python -m SimpleHTTPServer 8000`
2. Visit localhost in the form of eg http://localhost:8000
3. Open the popup - the grading should be disabled and the domain in the hero header should be "localhost"
4. Repeat steps 2 and 3 with eg 127.0.0.1:800. The domain in the hero header should still be "localhost"
5. Repeat 2 and 3 using eg 0.0.0.0:8000 - this time the domain should be 0.0.0.0 but the grading should still be disabled as special page
6. Try normal websites and make sure grading works there
5. Try pinging some websites and navigate to them using their IP address instead of the hostname. Grading should also work in this case


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
