### PR TITLE
Reenable feedback button correctly

### DIFF
--- a/integration-test/config.json
+++ b/integration-test/config.json
@@ -1,6 +1,7 @@
 {
     "spec_dir": "integration-test",
     "spec_files": [
-        "background/*.js"
+        "background/*.js",
+        "ui/*.js"
     ]
 }

--- a/integration-test/ui/feedback.js
+++ b/integration-test/ui/feedback.js
@@ -1,19 +1,14 @@
-/* global dbg:false */
 const harness = require('../helpers/harness')
-const wait = require('../helpers/wait')
-const request = require('request-promise-native')
-
 const EXAMPLE_URL = `https://example.com/test`
 
 let browser
 let bgPage
-let requests
 let feedbackUrl
 let feedbackPage
 
 describe('feedback flow', () => {
     beforeAll(async () => {
-        ({ browser, bgPage, requests } = await harness.setup())
+        ({ browser, bgPage } = await harness.setup())
 
         const extId = await bgPage.evaluate(() => chrome.runtime.id)
 
@@ -48,15 +43,15 @@ describe('feedback flow', () => {
             const val = await feedbackPage.evaluate(() => document.querySelector('.js-feedback-url').value)
 
             expect(val).toMatch(EXAMPLE_URL)
-        });
+        })
         it('should be possible to submit after everything has been filled out', async () => {
             await feedbackPage.goto(`${feedbackUrl}?broken=1`)
             await feedbackPage.waitForSelector('.js-feedback-submit')
 
             // clicking times out for some reason, so we try and enter instead
             // (stolen from https://github.com/GoogleChrome/puppeteer/issues/1805#issuecomment-418965009)
-            await feedbackPage.focus('.js-feedback-submit' )
-            await feedbackPage.keyboard.type('\n');
+            await feedbackPage.focus('.js-feedback-submit')
+            await feedbackPage.keyboard.type('\n')
 
             let content = await feedbackPage.content()
             expect(content).not.toMatch(/thank you/i)
@@ -64,8 +59,8 @@ describe('feedback flow', () => {
             await feedbackPage.type('.js-feedback-url', EXAMPLE_URL)
             await feedbackPage.type('.js-feedback-message', 'Everything is broken!')
 
-            await feedbackPage.focus('.js-feedback-submit' )
-            await feedbackPage.keyboard.type('\n');
+            await feedbackPage.focus('.js-feedback-submit')
+            await feedbackPage.keyboard.type('\n')
 
             await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
 
@@ -78,16 +73,16 @@ describe('feedback flow', () => {
             await feedbackPage.goto(`${feedbackUrl}`)
             await feedbackPage.waitForSelector('.js-feedback-submit')
 
-            await feedbackPage.focus('.js-feedback-submit' )
-            await feedbackPage.keyboard.type('\n');
+            await feedbackPage.focus('.js-feedback-submit')
+            await feedbackPage.keyboard.type('\n')
 
             let content = await feedbackPage.content()
             expect(content).not.toMatch(/thank you/i)
 
             await feedbackPage.type('.js-feedback-message', 'Everything is good!')
 
-            await feedbackPage.focus('.js-feedback-submit' )
-            await feedbackPage.keyboard.type('\n');
+            await feedbackPage.focus('.js-feedback-submit')
+            await feedbackPage.keyboard.type('\n')
 
             await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
 

--- a/integration-test/ui/feedback.js
+++ b/integration-test/ui/feedback.js
@@ -1,0 +1,98 @@
+/* global dbg:false */
+const harness = require('../helpers/harness')
+const wait = require('../helpers/wait')
+const request = require('request-promise-native')
+
+const EXAMPLE_URL = `https://example.com/test`
+
+let browser
+let bgPage
+let requests
+let feedbackUrl
+let feedbackPage
+
+describe('feedback flow', () => {
+    beforeAll(async () => {
+        ({ browser, bgPage, requests } = await harness.setup())
+
+        const extId = await bgPage.evaluate(() => chrome.runtime.id)
+
+        feedbackUrl = `chrome-extension://${extId}/html/feedback.html`
+    })
+    afterAll(async () => {
+        await harness.teardown(browser)
+    })
+    beforeEach(async () => {
+        feedbackPage = await browser.newPage()
+
+        await feedbackPage.setRequestInterception(true)
+        feedbackPage.on('request', async (req) => {
+            if (req.url().match(/duckduckgo\.com\/feedback\.js/)) {
+                await req.respond({
+                    status: 200,
+                    contentType: 'text/json',
+                    body: '{ "status": "success" }'
+                })
+            } else {
+                await req.continue()
+            }
+        })
+    })
+    afterEach(async () => {
+        await feedbackPage.close()
+    })
+    describe('broken site', () => {
+        it('should prefill the site if we pass it via the query string', async () => {
+            await feedbackPage.goto(`${feedbackUrl}?broken=1&url=${encodeURIComponent(EXAMPLE_URL)}`)
+
+            const val = await feedbackPage.evaluate(() => document.querySelector('.js-feedback-url').value)
+
+            expect(val).toMatch(EXAMPLE_URL)
+        });
+        it('should be possible to submit after everything has been filled out', async () => {
+            await feedbackPage.goto(`${feedbackUrl}?broken=1`)
+            await feedbackPage.waitForSelector('.js-feedback-submit')
+
+            // clicking times out for some reason, so we try and enter instead
+            // (stolen from https://github.com/GoogleChrome/puppeteer/issues/1805#issuecomment-418965009)
+            await feedbackPage.focus('.js-feedback-submit' )
+            await feedbackPage.keyboard.type('\n');
+
+            let content = await feedbackPage.content()
+            expect(content).not.toMatch(/thank you/i)
+
+            await feedbackPage.type('.js-feedback-url', EXAMPLE_URL)
+            await feedbackPage.type('.js-feedback-message', 'Everything is broken!')
+
+            await feedbackPage.focus('.js-feedback-submit' )
+            await feedbackPage.keyboard.type('\n');
+
+            await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
+
+            content = await feedbackPage.content()
+            expect(content).toMatch(/thank you/i)
+        })
+    })
+    describe('general feedback', () => {
+        it('should be possible to submit after everything has been filled out', async () => {
+            await feedbackPage.goto(`${feedbackUrl}`)
+            await feedbackPage.waitForSelector('.js-feedback-submit')
+
+            await feedbackPage.focus('.js-feedback-submit' )
+            await feedbackPage.keyboard.type('\n');
+
+            let content = await feedbackPage.content()
+            expect(content).not.toMatch(/thank you/i)
+
+            await feedbackPage.type('.js-feedback-message', 'Everything is good!')
+
+            await feedbackPage.focus('.js-feedback-submit' )
+            await feedbackPage.keyboard.type('\n');
+
+            await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
+
+            content = await feedbackPage.content()
+            expect(content).toMatch(/thank you/i)
+        })
+    })
+})

--- a/integration-test/ui/feedback.js
+++ b/integration-test/ui/feedback.js
@@ -20,6 +20,7 @@ describe('feedback flow', () => {
     beforeEach(async () => {
         feedbackPage = await browser.newPage()
 
+        // make sure running the tests doesn't spam our feedback endpoint
         await feedbackPage.setRequestInterception(true)
         feedbackPage.on('request', async (req) => {
             if (req.url().match(/duckduckgo\.com\/feedback\.js/)) {

--- a/integration-test/ui/feedback.js
+++ b/integration-test/ui/feedback.js
@@ -54,6 +54,7 @@ describe('feedback flow', () => {
             await feedbackPage.keyboard.type('\n')
 
             let content = await feedbackPage.content()
+            expect(content).toContain('js-feedback-submit')
             expect(content).not.toMatch(/thank you/i)
 
             await feedbackPage.type('.js-feedback-url', EXAMPLE_URL)
@@ -65,6 +66,7 @@ describe('feedback flow', () => {
             await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
 
             content = await feedbackPage.content()
+            expect(content).not.toContain('js-feedback-message')
             expect(content).toMatch(/thank you/i)
         })
     })
@@ -77,6 +79,7 @@ describe('feedback flow', () => {
             await feedbackPage.keyboard.type('\n')
 
             let content = await feedbackPage.content()
+            expect(content).toContain('js-feedback-submit')
             expect(content).not.toMatch(/thank you/i)
 
             await feedbackPage.type('.js-feedback-message', 'Everything is good!')
@@ -87,6 +90,7 @@ describe('feedback flow', () => {
             await feedbackPage.waitForResponse(r => r.url().match(/feedback\.js/))
 
             content = await feedbackPage.content()
+            expect(content).not.toContain('js-feedback-message')
             expect(content).toMatch(/thank you/i)
         })
     })

--- a/shared/js/ui/views/feedback-form.es6.js
+++ b/shared/js/ui/views/feedback-form.es6.js
@@ -39,6 +39,7 @@ FeedbackForm.prototype = window.$.extend({},
                 this._setup()
             } else if (e.change.attribute === 'canSubmit') {
                 this.$submit.toggleClass('is-disabled', !this.model.canSubmit)
+                this.$submit.attr('disabled', !this.model.canSubmit)
             }
         },
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Makes sure the disabled state for the submit feedback button is correctly reset. I broke it by merging https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/328 without testing fully :(

I've also added some integration tests to prevent this from happening again.

## Steps to test this PR:

1. Play around with the feedback form (both broken site mode and non-broken site mode)
2. Make sure it's possible to submit the form when everything is filled out in both cases.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
