### PR TITLE
Site score can't be read by screen readers 👓 #263:

### DIFF
--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -11,6 +11,11 @@ let setBadgeIcon = (badgeData) => {
     chrome.browserAction.setIcon(badgeData)
 }
 
+let setBadgeTitle = (grade) => {
+    const title = `Privacy Grade: ${grade} - ${chrome.i18n.getMessage('appName')}`
+    chrome.browserAction.setTitle({ title: title })
+}
+
 let syncToStorage = (data) => {
     chrome.storage.local.set(data, function () { })
 }
@@ -61,6 +66,7 @@ module.exports = {
     getExtensionURL: getExtensionURL,
     getExtensionVersion: getExtensionVersion,
     setBadgeIcon: setBadgeIcon,
+    setBadgeTitle: setBadgeTitle,
     syncToStorage: syncToStorage,
     getFromStorage: getFromStorage,
     notifyPopup: notifyPopup,

--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -78,6 +78,7 @@ class Tab {
             if (target) badgeData.target = target
 
             browserWrapper.setBadgeIcon(badgeData)
+            browserWrapper.setBadgeTitle(this.site.whitelisted ? grade.site.grade : grade.enhanced.grade)
         }
     }
 

--- a/shared/js/background/safari-wrapper.es6.js
+++ b/shared/js/background/safari-wrapper.es6.js
@@ -27,6 +27,17 @@ let setBadgeIcon = (badgeUpdate) => {
     }
 }
 
+let setBadgeTitle = (badgeUpdate) => {
+    if (badgeUpdate.target && badgeUpdate.target.activeTab) {
+        badgeUpdate.target = badgeUpdate.target.activeTab
+    }
+
+    let windowId = _getSafariWindowId(badgeUpdate.target);
+    if (windowId !== undefined) {
+        safari.extension.toolbarItems[windowId].label = grade;
+    }
+}
+
 let syncToStorage = (data) => {
     if (data) {
         let key = Object.keys(data)[0]
@@ -106,6 +117,7 @@ module.exports = {
     getExtensionURL: getExtensionURL,
     getExtensionVersion: getExtensionVersion,
     setBadgeIcon: setBadgeIcon,
+    setBadgeTitle: setBadgeTitle,
     syncToStorage: syncToStorage,
     getFromStorage: getFromStorage,
     notifyPopup: notifyPopup,


### PR DESCRIPTION
- Prepend site score to icon's "title"

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Prepended the site score to the button's "title" in order to make it visible on hover and by voice-over/screen readers.

## Steps to test this PR:
1. Visit any URL
2. Wait for the extension's button to display the grading score.
3. Hover or voice-over the button to see/hear the grading score for the page.


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
