### PR TITLE
"Tracker Networks Top Offenders" section semantically comes before the site details 📄 #250

### DIFF
--- a/shared/js/ui/pages/popup.es6.js
+++ b/shared/js/ui/pages/popup.es6.js
@@ -17,7 +17,7 @@ const AutocompleteModel = require('./../models/autocomplete.es6.js')
 const autocompleteTemplate = require('./../templates/autocomplete.es6.js')
 const BackgroundMessageModel = require('./../models/background-message.es6.js')
 
-function Trackers(ops) {
+function Trackers (ops) {
     this.$parent = window.$('#popup-container')
     Parent.call(this, ops)
 }
@@ -36,7 +36,7 @@ Trackers.prototype = window.$.extend({},
 
             this.views.search = new SearchView({
                 pageView: this,
-                model: new SearchModel({ searchText: '' }),
+                model: new SearchModel({searchText: ''}),
                 appendTo: this.$parent,
                 template: searchTemplate
             })
@@ -58,7 +58,7 @@ Trackers.prototype = window.$.extend({},
 
             this.views.topblocked = new TopBlockedView({
                 pageView: this,
-                model: new TopBlockedModel({ numCompanies: 3 }),
+                model: new TopBlockedModel({numCompanies: 3}),
                 appendTo: this.$parent,
                 template: topBlockedTemplate
             })
@@ -69,7 +69,7 @@ Trackers.prototype = window.$.extend({},
             // store.subscribe()
             this.views.autocomplete = new AutocompleteView({
                 pageView: this,
-                model: new AutocompleteModel({ suggestions: [] }),
+                model: new AutocompleteModel({suggestions: []}),
                 // appendTo: this.views.search.$el,
                 appendTo: null,
                 template: autocompleteTemplate

--- a/shared/js/ui/pages/popup.es6.js
+++ b/shared/js/ui/pages/popup.es6.js
@@ -52,7 +52,6 @@ Trackers.prototype = window.$.extend({},
                 pageView: this,
                 model: new SiteModel(),
                 appendTo: this.$parent,
-                before: '.top-blocked',
                 template: siteTemplate
             })
 

--- a/shared/js/ui/pages/popup.es6.js
+++ b/shared/js/ui/pages/popup.es6.js
@@ -52,6 +52,7 @@ Trackers.prototype = window.$.extend({},
                 pageView: this,
                 model: new SiteModel(),
                 appendTo: this.$parent,
+                before: '.top-blocked',
                 template: siteTemplate
             })
 

--- a/shared/js/ui/pages/popup.es6.js
+++ b/shared/js/ui/pages/popup.es6.js
@@ -17,7 +17,7 @@ const AutocompleteModel = require('./../models/autocomplete.es6.js')
 const autocompleteTemplate = require('./../templates/autocomplete.es6.js')
 const BackgroundMessageModel = require('./../models/background-message.es6.js')
 
-function Trackers (ops) {
+function Trackers(ops) {
     this.$parent = window.$('#popup-container')
     Parent.call(this, ops)
 }
@@ -36,7 +36,7 @@ Trackers.prototype = window.$.extend({},
 
             this.views.search = new SearchView({
                 pageView: this,
-                model: new SearchModel({searchText: ''}),
+                model: new SearchModel({ searchText: '' }),
                 appendTo: this.$parent,
                 template: searchTemplate
             })
@@ -52,12 +52,13 @@ Trackers.prototype = window.$.extend({},
                 pageView: this,
                 model: new SiteModel(),
                 appendTo: this.$parent,
+                before: '.top-blocked',
                 template: siteTemplate
             })
 
             this.views.topblocked = new TopBlockedView({
                 pageView: this,
-                model: new TopBlockedModel({numCompanies: 3}),
+                model: new TopBlockedModel({ numCompanies: 3 }),
                 appendTo: this.$parent,
                 template: topBlockedTemplate
             })
@@ -68,7 +69,7 @@ Trackers.prototype = window.$.extend({},
             // store.subscribe()
             this.views.autocomplete = new AutocompleteView({
                 pageView: this,
-                model: new AutocompleteModel({suggestions: []}),
+                model: new AutocompleteModel({ suggestions: [] }),
                 // appendTo: this.views.search.$el,
                 appendTo: null,
                 template: autocompleteTemplate

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -103,7 +103,6 @@ body {
 
     .site-info {
         position: absolute;
-        z-index: 1;
         top: 50px;
         left: 0;
         right: 0;

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -103,6 +103,7 @@ body {
 
     .site-info {
         position: absolute;
+        z-index: 1;
         top: 50px;
         left: 0;
         right: 0;


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
- Adjusted CSS index
- Specified a 'before' selector to ensure the .site-info section appears before the Tracker Networks Top Offenders


## Steps to test this PR:
1. Right-click on popup, select "Inspect" to open the developer tools.
2. Observe order of sections in the "Elements" tab.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 