### PR TITLE
Memoize Tracker Checks

### DIFF
--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -36,6 +36,7 @@ class Tab {
     constructor (tabData) {
         this.id = tabData.id || tabData.tabId
         this.trackers = {}
+        this.trackerChecks = {}
         this.trackersBlocked = {}
         this.url = tabData.url
         this.upgradedHttps = false

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -31,6 +31,7 @@ function loadLists () {
 function isTracker (urlToCheck, thisTab, request) {
     let currLocation = thisTab.url || ''
     let siteDomain = thisTab.site ? thisTab.site.domain : ''
+    let abbrUrl = urlToCheck.slice(0, urlToCheck.indexOf('?')).substring(0, 75)
     if (!siteDomain) return
 
     // DEMO embedded tweet option
@@ -44,6 +45,11 @@ function isTracker (urlToCheck, thisTab, request) {
     }
 
     if (settings.getSetting('trackerBlockingEnabled')) {
+
+        if (abbrUrl in thisTab.trackerChecks) {
+            return thisTab.trackerChecks[abbrUrl]
+        }
+
         let parsedUrl = tldjs.parse(urlToCheck)
         let hostname
 
@@ -69,8 +75,11 @@ function isTracker (urlToCheck, thisTab, request) {
         if (whitelistedTracker) {
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
-                return addCommonParent(whitelistedTracker, commonParent)
+                let commonParentTracker = addCommonParent(whitelistedTracker, commonParent)
+                thisTab.trackerChecks[abbrUrl] = commonParentTracker
+                return commonParentTracker
             }
+            thisTab.trackerChecks[abbrUrl] = whitelistedTracker
             return whitelistedTracker
         }
 
@@ -78,8 +87,11 @@ function isTracker (urlToCheck, thisTab, request) {
         if (surrogateTracker) {
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
-                return addCommonParent(surrogateTracker, commonParent)
+                let commonParentTracker = addCommonParent(surrogateTracker, commonParent)
+                thisTab.trackerChecks[abbrUrl] = commonParentTracker
+                return commonParentTracker
             }
+            thisTab.trackerChecks[abbrUrl] = surrogateTracker
             return surrogateTracker
         }
 
@@ -94,8 +106,11 @@ function isTracker (urlToCheck, thisTab, request) {
 
             let commonParent = getCommonParentEntity(currLocation, urlToCheck)
             if (commonParent) {
-                return addCommonParent(trackerByParentCompany, commonParent)
+                let commonParentTracker = addCommonParent(trackerByParentCompany, commonParent)
+                thisTab.trackerChecks[abbrUrl] = commonParentTracker
+                return commonParentTracker
             }
+            thisTab.trackerChecks[abbrUrl] = trackerByParentCompany
             return trackerByParentCompany
         }
     }

--- a/shared/js/background/trackers.es6.js
+++ b/shared/js/background/trackers.es6.js
@@ -45,7 +45,6 @@ function isTracker (urlToCheck, thisTab, request) {
     }
 
     if (settings.getSetting('trackerBlockingEnabled')) {
-
         if (abbrUrl in thisTab.trackerChecks) {
             return thisTab.trackerChecks[abbrUrl]
         }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Many sites use trackers that continuously send requests to the same url as you browse a website. These often take the form of pixels, but they can also be beacons, scripts or even xhr requests. There are also tracking scripts that repeatedly attempt to phone home when they realize that their requests aren't completing successfully. 
Here's an example of comscore making repeated requests on yahoo.com:
![image](https://user-images.githubusercontent.com/4481594/48296213-e208fa80-e461-11e8-8520-ef8eb4f56a45.png)

We currently handle each request individually, and do a full lookup to identify it as a tracker. This ends up being a lot of unnecessary overhead, since we often already know the result of the look up. This PR simply memoizes the isTracker function so that only one full lookup is required per request url.

TODO: add tests


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
