### PR TITLE
add one-off block rule to fix comments section on gizmodo sites

### DIFF
--- a/shared/data/tracker_lists/trackersWithParentCompany.json
+++ b/shared/data/tracker_lists/trackersWithParentCompany.json
@@ -7258,6 +7258,13 @@
                 {"rule": "linkedin\\.com\\/csp\\/dtag\\?"},
                 {"rule": "linkedin\\.com\\/emimp\\/", "options": {"types": ["image"]}}
             ]
+        },
+        "kinja-static.com": {
+            "c": "Gizmodo",
+            "u": "https://kinja-static.com",
+            "rules": [
+                {"rule": "x\\.kinja-static\\.com\\/assets\\/packaged-js\\/OnionAM\\.", "options": {"types": ["script"], "domains": ["avclub.com","deadspin.com","earther.com","gizmodo.com","jalopnik.com","jezebel.com","kotaku.com","lifehacker.com","splinternews.com","theroot.com","thetakeout.com"]}}
+            ]
         }
     }
 }


### PR DESCRIPTION
**Reviewer:** @jdorweiler 

## Description:
Serving a surrogate for gpt.js causes gizmodo sites to throw errors and halt js execution, which is leading to comments not loading. This PR adds a simple one-off block rule to block the script that was making calls to gpt.js and throwing errors. 

The reason I'm adding a specific block rule here is that the other option to fix these sites was to whitelist gpt.js, which is not ideal.


## Steps to test this PR:
1. Visit https://lifehacker.com/how-to-maximize-your-browsing-privacy-using-duckduckgo-1830659232
2. Scroll down until you get to the comments section. It should load properly.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
