### PR TITLE
Root domains of subdomains on temp whitelist should not be whitelisted

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -60,9 +60,8 @@ class Site {
         // Match independently of subdomain
         domain = tldjs.getDomain(domain) || domain
 
-        // Make sure we match at the end of the URL
-        // so we're extra sure it's the legit main domain
-        return trackersWhitelistTemporary.some(brokenSiteDomain => brokenSiteDomain.match(new RegExp(domain + '$')))
+        // If root domain in temp whitelist, return true
+        return trackersWhitelistTemporary.indexOf(domain) !== -1
     }
 
     /*

--- a/unit-test/background/classes/site.es6.js
+++ b/unit-test/background/classes/site.es6.js
@@ -1,11 +1,14 @@
 const Site = require('../../../shared/js/background/classes/site.es6')
 const browserWrapper = require('../../../shared/js/background/chrome-wrapper.es6')
+const abpLists = require('../../../shared/js/background/abp-lists.es6')
 
 const EXT_ID = `ogigmfedpbpnnbcpgjloacccaibkaoip`
+const tempWhitelist = ['suntrust.com', 'onlinebanking.nationwide.co.uk']
 
 describe('Site', () => {
     beforeEach(() => {
         spyOn(browserWrapper, 'getExtensionId').and.returnValue(EXT_ID)
+        spyOn(abpLists, 'getTemporaryWhitelist').and.returnValue(tempWhitelist)
     })
 
     describe('getSpecialDomain()', () => {
@@ -38,6 +41,22 @@ describe('Site', () => {
                 const site = new Site(test.url)
 
                 expect(site.specialDomainName).toEqual(test.expected)
+            })
+        })
+    })
+
+    describe('checkBrokenSites()', () => {
+        const tests = [
+            { url: 'https://suntrust.com', expected: true },
+            { url: 'https://www1.onlinebanking.suntrust.com', expected: true },
+            { url: 'https://nationwide.co.uk', expected: false }
+        ]
+
+        tests.forEach((test) => {
+            it(`should return "${test.expected}" for: ${test.url}`, () => {
+                const site = new Site(test.url)
+
+                expect(site.checkBrokenSites(test.url)).toEqual(test.expected)
             })
         })
     })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 

## Description:
When we expanded temp whitelist matching to apply to subdomains in https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/334, we did it a little too broadly. This resulted in whitelist rules for subdomains applying to the entire root domain. What we intended to happen was for whitelist rules for root domains to apply to subdomains. This PR fixes that issue, and adds a few tests.


## Steps to test this PR:
1. npm run test
2. visit subdomain of domain on temp whitelist (eg www1.onlinebanking.suntrust.com), check that it's whitelisted
3. visit root domain of subdomain on temp whitelist (eg nationwide.co.uk), check that it's not whitelisted

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
