### PR TITLE
hide lastError from sendMessage

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -92,7 +92,7 @@ chrome.tabs.onRemoved.addListener((id, info) => {
 })
 
 // message popup to close when the active tab changes
-chrome.tabs.onActivated.addListener(() => chrome.runtime.sendMessage({closePopup: true}))
+chrome.tabs.onActivated.addListener(() => chrome.runtime.sendMessage({closePopup: true}, () => chrome.runtime.lastError))
 
 // search via omnibox
 

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -91,7 +91,7 @@ chrome.tabs.onRemoved.addListener((id, info) => {
     tabManager.delete(id)
 })
 
-// message popup to close when the active tab changes
+// message popup to close when the active tab changes. this can send an error message when the popup is not open. check lastError to hide it
 chrome.tabs.onActivated.addListener(() => chrome.runtime.sendMessage({closePopup: true}, () => chrome.runtime.lastError))
 
 // search via omnibox

--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -26,7 +26,8 @@ let getExtensionId = () => {
 }
 
 let notifyPopup = (message) => {
-    chrome.runtime.sendMessage(message)
+    // this can send an error message when the popup is not open. check lastError to hide it
+    chrome.runtime.sendMessage(message, () => chrome.runtime.lastError)
 }
 
 let normalizeTabData = (tabData) => {

--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -84,7 +84,7 @@ class Site {
      * Send message to the popup to rerender the whitelist
      */
     notifyWhitelistChanged () {
-        chrome.runtime.sendMessage({'whitelistChanged': true})
+        chrome.runtime.sendMessage({'whitelistChanged': true}, () => chrome.runtime.lastError)
     }
 
     isWhiteListed () { return this.whitelisted }

--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -84,6 +84,7 @@ class Site {
      * Send message to the popup to rerender the whitelist
      */
     notifyWhitelistChanged () {
+        // this can send an error message when the popup is not open check lastError to hide it
         chrome.runtime.sendMessage({'whitelistChanged': true}, () => chrome.runtime.lastError)
     }
 

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -67,7 +67,7 @@ function handleRequest (requestData) {
          * If request is a tracker, cancel the request
          */
         if (window.chrome) {
-            chrome.runtime.sendMessage({'updateTabData': true})
+            chrome.runtime.sendMessage({'updateTabData': true}, () => chrome.runtime.lastError)
         }
 
         var tracker = trackers.isTracker(requestData.url, thisTab, requestData)

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -67,6 +67,7 @@ function handleRequest (requestData) {
          * If request is a tracker, cancel the request
          */
         if (window.chrome) {
+            // this can send an error message when the popup is not open. check lastError to hide it
             chrome.runtime.sendMessage({'updateTabData': true}, () => chrome.runtime.lastError)
         }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Fix for #362 
Hides sendMessage error in Firefox. `Unchecked lastError value: Error: Could not establish connection. Receiving end does not exist.`

## Steps to test this PR:
1. npm run dev-firefox
2. load extension and open debug console
3. navigate to some sites. You shouldn't see any `Unchecked lastError value: Error: Could not establish connection. Receiving end does not exist.` errors


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
