### PR TITLE
Add logic to generalize atb param if the atb service tells us to

### DIFF
--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -140,11 +140,12 @@ describe('search workflow', () => {
         todaysAtb = data.version
         lastWeeksAtb = `v${data.majorVersion - 1}-${data.minorVersion}`
         twoWeeksAgoAtb = `v${data.majorVersion - 2}-${data.minorVersion}`
-
-        await bgPage.evaluate((atb) => dbg.settings.updateSetting('atb', atb), twoWeeksAgoAtb)
     })
     afterAll(async () => {
         await harness.teardown(browser)
+    })
+    beforeEach(async () => {
+        await bgPage.evaluate((atb) => dbg.settings.updateSetting('atb', atb), twoWeeksAgoAtb)
     })
     it('should not update set_atb if a repeat search is made on the same day', async () => {
         // set set_atb to today's version

--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -194,5 +194,5 @@ describe('search workflow', () => {
         const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
         expect(newSetAtb).toEqual(todaysAtb)
         expect(atb).toEqual('v123-1')
-    });
+    })
 })

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -39,6 +39,10 @@ const ATB = (() => {
 
             return load.JSONfromExternalFile(url).then((res) => {
                 settings.updateSetting('set_atb', res.data.version)
+
+                if (res.data.updateVersion) {
+                    settings.updateSetting('atb', res.data.updateVersion)
+                }
             })
         },
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 
**CC:** @jkv 


## Description:
<!-- Explain what is being changed, why, etc -->

Adds logic to set a generalized ATB param that the ATB service passes us.

## Steps to test this PR:

1. Manually set your ATB to e.g. `v123-4`
2. Do a search
3. Your ATB should now be `v123-1`
4. A more recent ATB like `v161-5` should be unaffected
5. Tests should be passing (`npm run test-int`)

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
