### PR TITLE
Check for and parse additional success page params

### DIFF
--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -94,7 +94,7 @@ describe('install workflow', () => {
         it('should get its ATB param from the success page when one is present', async () => {
             // open a success page and wait for it to have finished loading
             const successPage = await browser.newPage()
-            await successPage.goto('https://duckduckgo.com/?natb=v123-4ab')
+            await successPage.goto('https://duckduckgo.com/?natb=v123-4ab&cp=atbhc')
 
             // try get ATB params again
             await bgPage.evaluate(() => dbg.atb.updateATBValues())
@@ -115,6 +115,7 @@ describe('install workflow', () => {
                 if (url.match(/exti/)) {
                     numExtiCalled += 1
                     expect(url).toContain(`atb=${atb}`)
+                    expect(url).toContain(`cp=atbhc`)
                 }
             })
 

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -134,11 +134,6 @@ const ATB = (() => {
                         param === 'natb' ? 'atb' : param,
                         parsedParams.get(param)
                     )
-
-                    // Remove 'natb' after renaming it to 'atb'
-                    if (param === 'natb') {
-                        parsedParams.delete(param)
-                    }
                 }
             })
 

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -9,7 +9,7 @@ const load = require('./load.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 
 const ATB_ERROR_COHORT = 'v1-1'
-const ATB_FORMAT_RE = /(v\d+-\d(?:[a-z_]{2})?)/
+const ATB_FORMAT_RE = /(v\d+-\d(?:[a-z_]{2})?)$/
 
 // list of accepted params in ATB url
 const ACCEPTED_URL_PARAMS = ['natb', 'cp']
@@ -109,6 +109,9 @@ const ATB = (() => {
         finalizeATB: (params) => {
             let atb = settings.getSetting('atb')
 
+            // build query string when atb param wasn't acquired from any URLs
+            const paramString = params && params.has('atb') ? params.toString() : `atb=${atb}`
+
             // make this request only once
             if (settings.getSetting('extiSent')) return
 
@@ -116,7 +119,7 @@ const ATB = (() => {
             settings.updateSetting('set_atb', atb)
 
             // just a GET request, we only care that the request was made
-            load.url(`https://duckduckgo.com/exti/?${params.toString()}`)
+            load.url(`https://duckduckgo.com/exti/?${paramString}`)
         },
 
         // iterate over a list of accepted params, and retrieve them from a URL
@@ -131,6 +134,11 @@ const ATB = (() => {
                         param === 'natb' ? 'atb' : param,
                         parsedParams.get(param)
                     )
+
+                    // Remove 'natb' after renaming it to 'atb'
+                    if (param === 'natb') {
+                        parsedParams.delete(param)
+                    }
                 }
             })
 
@@ -161,7 +169,6 @@ const ATB = (() => {
                         settings.updateSetting('atb', atb)
                     }
 
-                    // only pass params if we have an ATB
                     ATB.finalizeATB(params)
                 })
         },

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -115,7 +115,7 @@ const ATB = (() => {
             settings.updateSetting('set_atb', atb)
 
             // just a GET request, we only care that the request was made
-            load.url(`https://duckduckgo.com/exti/?atb=${atb}${params}`)
+            load.url(`https://duckduckgo.com/exti/?atb=${atb}&${params}`)
         },
 
         getNewATBFromURL: (url) => {

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -188,14 +188,14 @@ describe('atb.updateSetAtb()', () => {
     })
 })
 
-describe('getNewATBFromURL()', () => {
+describe('getAcceptedParamsFromURL()', () => {
     const tests = [
-        { url: 'https://duckduckgo.com/?natb=v123-4ab', output: 'v123-4ab' },
-        { url: 'https://duckduckgo.com/?natb=v123-4', output: 'v123-4' },
-        { url: 'https://duckduckgo.com/?natb=v123-4_b', output: 'v123-4_b' },
-        { url: 'https://duckduckgo.com/?natb=v123-4__', output: 'v123-4__' },
-        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__', output: 'v123-4__' },
-        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&foo=bar', output: 'v123-4__' },
+        { url: 'https://duckduckgo.com/?natb=v123-4ab&cp=atbhc', output: 'atb=v123-4ab&cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4&cp=atbhc', output: 'atb=v123-4&cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4_b&cp=atbhc', output: 'atb=v123-4_b&cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4__&cp=atbhc', output: 'atb=v123-4__&cp=atbhc' },
+        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&cp=atbhc', output: 'atb=v123-4__&cp=atbhc' },
+        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&foo=bar&cp=atbhc', output: 'atb=v123-4__&cp=atbhc' },
 
         { url: 'https://duckduckgo.com/about', output: '' },
         { url: 'https://duckduckgo.com/?natb=v123-4a', output: '' },
@@ -204,35 +204,13 @@ describe('getNewATBFromURL()', () => {
         { url: 'https://duckduckgo.com/?natb=v123-4___', output: '' },
         { url: 'https://duckduckgo.com/?natb=v123_sdf', output: '' },
         { url: 'https://duckduckgo.com/?natb=v11111111', output: '' },
-        { url: 'https://duckduckgo.com/?natb=v111-4444', output: '' }
+        { url: 'https://duckduckgo.com/?natb=v111-4444', output: '' },
+        { url: 'https://duckduckgo.com/?natb=v123-4abcd&foo=bar', output: '' }
     ]
 
     tests.forEach((test) => {
         it(`should get atb ${test.output} from ${test.url}`, () => {
-            expect(atb.getNewATBFromURL(test.url)).toEqual(test.output)
-        })
-    })
-})
-
-describe('getAcceptedParamsFromURL()', () => {
-    const tests = [
-        { url: 'https://duckduckgo.com/?natb=v123-4ab&cp=atbhc', output: 'cp=atbhc' },
-        { url: 'https://duckduckgo.com/?natb=v123-4&cp=atbhc', output: 'cp=atbhc' },
-        { url: 'https://duckduckgo.com/?natb=v123-4_b&cp=atbhc', output: 'cp=atbhc' },
-        { url: 'https://duckduckgo.com/?natb=v123-4__&cp=atbhc', output: 'cp=atbhc' },
-        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&cp=atbhc', output: 'cp=atbhc' },
-        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&foo=bar&cp=atbhc', output: 'cp=atbhc' },
-
-        { url: 'https://duckduckgo.com/about', output: '' },
-        { url: 'https://duckduckgo.com/?natb=v123-4a', output: '' },
-        { url: 'https://duckduckgo.com/?nnatb=v123-4ab', output: '' },
-        { url: 'https://duckduckgo.com/?natb=v123-4abc', output: '' },
-        { url: 'https://duckduckgo.com/?natb=v123-4ab&foo=bar', output: '' }
-    ]
-
-    tests.forEach((test) => {
-        it(`should get atb ${test.output} from ${test.url}`, () => {
-            expect(atb.getAcceptedParamsFromURL(test.url)).toEqual(test.output)
+            expect((atb.getAcceptedParamsFromURL(test.url)).toString()).toEqual(test.output)
         })
     })
 })

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -214,6 +214,29 @@ describe('getNewATBFromURL()', () => {
     })
 })
 
+describe('getAcceptedParamsFromURL()', () => {
+    const tests = [
+        { url: 'https://duckduckgo.com/?natb=v123-4ab&cp=atbhc', output: 'cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4&cp=atbhc', output: 'cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4_b&cp=atbhc', output: 'cp=atbhc' },
+        { url: 'https://duckduckgo.com/?natb=v123-4__&cp=atbhc', output: 'cp=atbhc' },
+        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&cp=atbhc', output: 'cp=atbhc' },
+        { url: 'https://duckduckgo.com/?q=123&natb=v123-4__&foo=bar&cp=atbhc', output: 'cp=atbhc' },
+
+        { url: 'https://duckduckgo.com/about', output: '' },
+        { url: 'https://duckduckgo.com/?natb=v123-4a', output: '' },
+        { url: 'https://duckduckgo.com/?nnatb=v123-4ab', output: '' },
+        { url: 'https://duckduckgo.com/?natb=v123-4abc', output: '' },
+        { url: 'https://duckduckgo.com/?natb=v123-4ab&foo=bar', output: '' }
+    ]
+
+    tests.forEach((test) => {
+        it(`should get atb ${test.output} from ${test.url}`, () => {
+            expect(atb.getAcceptedParamsFromURL(test.url)).toEqual(test.output)
+        })
+    })
+})
+
 describe('complex install workflow cases', () => {
     let loadURLSpy
 


### PR DESCRIPTION
**Reviewer:** @andrey-p 

**Depends on:**  Internal Changes

## Description:
Adds ability to parse additional url params from success page


## Steps to test this PR:
1. Visit https://duckduckgo.com?natb=v123-1zz&cp=atbzz
2. Install extension
3. Ajax call to /exti/ should include `cp=atbzz` (See Kibana)

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications 
