### PR TITLE
Add prepopulated_id to the search provider

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -30,6 +30,7 @@
         "is_default": true,
         "keyword": "duckduckgo.com",
         "name": "DuckDuckGo",
+        "prepopulated_id": 92,
         "search_url": "https://duckduckgo.com/?q={searchTerms}",
         "suggest_url": "https://duckduckgo.com/ac/?q={searchTerms}&type=list"
       }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 
**CC:** @kdzwinel 

<!-- Optional fields

**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
This PR adds the prepopulated ID for DuckDuckGo to the search provider in Chrome settings. Doing this will tell the browser to use Chromium's built-in settings for DuckDuckGo. This will allow the extension to set our new tab page.

## Steps to test this PR:
1. Build the extension for Chrome
2. For now, you'll need a build of Chrome 75 - you can use Chrome Canary, Dev, or Beta. See https://www.chromium.org/getting-involved/dev-channel
3. Load the extension. Verify that new tabs open the DuckDuckGo new tab page.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
