### PR TITLE
Change d omnibox keyword to ddg

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -16,6 +16,7 @@
         },
         "default_popup": "html/popup.html"
     },
+    "omnibox": {"keyword": "ddg"},
     "options_page": "html/options.html",
     "background": {
             "scripts": [

--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -16,7 +16,6 @@
         },
         "default_popup": "html/popup.html"
     },
-    "omnibox": {"keyword": "d"},
     "options_page": "html/options.html",
     "background": {
             "scripts": [

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -21,7 +21,6 @@
         },
         "default_popup": "html/popup.html"
     },
-    "omnibox": {"keyword": "d"},
     "background": {
             "scripts": [
                 "public/js/background.js"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -21,6 +21,7 @@
         },
         "default_popup": "html/popup.html"
     },
+    "omnibox": {"keyword": "ddg"},
     "background": {
             "scripts": [
                 "public/js/background.js"


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

## Description:
Changes `d` omnibox keyword binding to `ddg`. Addresses https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/388.


## Steps to test this PR:
1. Build and install extension in Firefox and Chrome
2. Type d then space in omnibox / address bar. In Chrome the omnibox should no longer show 'DuckDuckGo Privacy Essentials' in the left, and in Firefox the first autocomplete suggestion should not be 'DuckDuckGo Privacy Essentials'.
3. Repeat 2 this time using ddg instead of d. This should make Chrome show 'DuckDuckGo Privacy Essentials' in the left of the omnibox, and make Firefox show 'DuckDuckGo Privacy Essentials' as the first autocomplete suggestion.


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
