### PR TITLE
fix isSameDomainRequest for chrome

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -197,7 +197,17 @@ function tryElementHide (requestData, tab) {
     }
 }
 
+/* Check to see if a request came from our current tab. This generally handles the
+ * case of pings that fire on document unload. We can get into a case where we count the
+ * ping to the new site we navigated to. 
+ *
+ * In Firefox we can check the request frameAncestors to see if our current
+ * tab url is one of the ancestors. 
+ * In Chrome we don't have access to a sub_frame ancestors. We can check that a request
+ * is coming from the main_frame and that it matches our current tab url
+ */
 function isSameDomainRequest (tab, req) {
+    // Firefox
     if (req.documentUrl) {
         if (req.frameAncestors && req.frameAncestors.length) {
             const ancestors = req.frameAncestors.reduce((lst, f) => {
@@ -208,6 +218,9 @@ function isSameDomainRequest (tab, req) {
         } else {
             return req.documentUrl === tab.url
         }
+    // Chrome
+    } else if (req.initiator && req.frameId === 0) {
+        return tab.url === `${req.initiator}/`
     } else {
         return true
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
I updated isSameDomainRequest to work for Chrome.

## Steps to test this PR:
1. Go to a site that fires a ping or other request on unload, https://facebook.com
2. In the same tab go to a site that you know doesn't have any trackers, https://duckduckgo.com
3. There shouldn't be any trackers listed in the popup for the new site. 
4. If you have the extension console open you should see that the ping was still blocked

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
