### PR TITLE
Fix broken site check

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -62,11 +62,9 @@ class Site {
 
         // If root domain in temp whitelist, return true
         return tdsStorage.brokenSiteList.some((brokenSiteDomain) => {
-                if (brokenSiteDomain) {
-                    return hostname.match(new RegExp(brokenSiteDomain + '$'))
-                } else {
-                    return false
-                }
+            if (brokenSiteDomain) {
+                return hostname.match(new RegExp(brokenSiteDomain + '$'))
+            }
         })
     }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
A blank line added to the broken site whitelist causes all sites to be marked as broken. We need to check that `brokenSiteDomain` exists before matching. 

## Steps to test this PR:
1. Go to a site on the broken list. It should be marked as broken, comment in the console, no trackers blocked. https://github.com/duckduckgo/content-blocking-whitelist/blob/master/trackers-whitelist-temporary.txt
2. Try some sites not in the list. Trackers should still be blocked.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
