### PR TITLE
use match for isSameDomainRequest in chrome

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -220,7 +220,7 @@ function isSameDomainRequest (tab, req) {
         }
     // Chrome
     } else if (req.initiator && req.frameId === 0) {
-        return tab.url === `${req.initiator}/`
+        return !!tab.url.match(req.initiator)
     } else {
         return true
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Fix isSameDomainRequest for Chrome. The request initiator is not the full URL so looking for exact matches fails in some cases. 

## Steps to test this PR:
1. go to bbc.com/news 
2. there should be trackers listed in the popup

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
