### PR TITLE
dump tracker domains option

### DIFF
--- a/test-blocking.js
+++ b/test-blocking.js
@@ -48,7 +48,7 @@ fs.createReadStream(program.in)
         }
 
         if (program.trackers) {
-            console.log(chalk.blue('Trackers domains'))
+            console.log(chalk.blue('Tracker domains'))
             console.log(trackerDomains)
         }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer: @jdorweiler  **

## Description:

Allows test blocking to dump tracker domains for visual inspection.

## Steps to test this PR:
1. Run with --trackers option
1. Observe trackers dumped to console once test is complete

## Automated tests:

n/a

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 