### PR TITLE
Disable unused pixels

### DIFF
--- a/shared/js/background/banner.es6.js
+++ b/shared/js/background/banner.es6.js
@@ -153,7 +153,7 @@ function handleOnDOMContentLoaded (details) {
     const activeExp = settings.getSetting('activeExperiment')
 
     if (utils.getBrowserName() !== 'chrome') {
-        return 
+        return
     }
 
     // Exclude unless in active experiment, and banner not disabled

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -271,7 +271,7 @@ let onStartup = () => {
 
     settings.ready().then(() => {
         experiment.setActiveExperiment()
-        
+
         httpsStorage.getLists(constants.httpsLists)
             .then(lists => https.setLists(lists))
             .catch(e => console.log(e))
@@ -283,7 +283,6 @@ let onStartup = () => {
         https.sendHttpsUpgradeTotals()
 
         Companies.buildFromStorage()
-
     })
 }
 

--- a/shared/js/background/experiments.es6.js
+++ b/shared/js/background/experiments.es6.js
@@ -45,7 +45,7 @@ class Experiment {
                 }
 
                 // We already have an active experiemnt. Bail here to avoid overriding
-                // any of the settings for this experiment. 
+                // any of the settings for this experiment.
                 if (currentExp && currentExp.active === true && this.activeExperiment.active === true) {
                     return
                 }
@@ -57,12 +57,11 @@ class Experiment {
                 }
 
                 settings.updateSetting('activeExperiment', this.activeExperiment)
-                
+
                 if (this.activeExperiment.name) {
                     if (this.activeExperiment.atbExperiments && this.activeExperiment.atbExperiments[this.atbVariant]) {
                         this.activeExperiment.settings = this.activeExperiment.atbExperiments[this.atbVariant].settings
                     }
-
 
                     if (this.activeExperiment.settings) {
                         this.applySettingsChanges()

--- a/shared/js/background/pixel.es6.js
+++ b/shared/js/background/pixel.es6.js
@@ -4,7 +4,6 @@
  * Learn more at https://duck.co/help/privacy/atb
  *
  */
-const utils = require('./utils.es6')
 const load = require('./load.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 const settings = require('./settings.es6')
@@ -26,8 +25,8 @@ function fire () {
 
     if (typeof pixelName !== 'string') return
 
-    // only allow broken site pixel on Firefox
-    if (utils.getBrowserName() === 'moz' && pixelName !== 'epbf') return
+    // Only allow broken site reports
+    if (pixelName !== 'epbf') return
     
     const url = getURL(pixelName)
 

--- a/shared/js/background/pixel.es6.js
+++ b/shared/js/background/pixel.es6.js
@@ -27,7 +27,7 @@ function fire () {
 
     // Only allow broken site reports
     if (pixelName !== 'epbf') return
-    
+
     const url = getURL(pixelName)
 
     if (!url) return

--- a/shared/js/background/pixel.es6.js
+++ b/shared/js/background/pixel.es6.js
@@ -4,7 +4,7 @@
  * Learn more at https://duck.co/help/privacy/atb
  *
  */
-
+const utils = require('./utils.es6')
 const load = require('./load.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 const settings = require('./settings.es6')
@@ -26,6 +26,9 @@ function fire () {
 
     if (typeof pixelName !== 'string') return
 
+    // only allow broken site pixel on Firefox
+    if (utils.getBrowserName() === 'moz' && pixelName !== 'epbf') return
+    
     const url = getURL(pixelName)
 
     if (!url) return

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -21,7 +21,7 @@ class TDSStorage {
             const etag = settings.getSetting(`${listCopy.name}-etag`) || ''
             const version = this.getVersionParam()
             const activeExperiment = settings.getSetting('activeExperiment')
-            
+
             let experiment = ''
             if (activeExperiment) {
                 experiment = settings.getSetting('experimentData')


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Disables pixels that we're not using anymore.

## Steps to test this PR:
1. Install extension
2. Open the extension network tab
3. Interact with the popup, you shouldn't see any pixel requests to improving.duckduckgo.com
4. The only allowed pixel is when submitting a broken site report from the whitelist toggle

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
