### PR TITLE
add setAdIframeTitle method to gpt surrogate

### DIFF
--- a/shared/data/surrogates.txt
+++ b/shared/data/surrogates.txt
@@ -205,7 +205,8 @@ googletagservices.com/gpt.js application/javascript
         disablePublisherConsole: noop,
         display: noop,
         enableServices: noop,
-        getVersion: noopReturnEmptyString
+        getVersion: noopReturnEmptyString,
+        setAdIframeTitle: noop
     }
     const commandQueue = (window.googletag && window.googletag.cmd.length) ? window.googletag.cmd : []
     gptObj.cmd.push = function(arg) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

## Description:
Add missing method `window.googletag.setAdIframeTitle` to gpt surrogate. Looks like this is causing a little breakage specifically on [walmart.com product pages](https://www.walmart.com/ip/2-pack-Neutrogena-Moisturizing-Body-Oil-Light-Sesame-Formula-16-fl-oz/754642451?selected=true).


## Steps to test this PR:
1. build extension
2. visit link above, check that there are no blank images or iframes on the page


## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
