### PR TITLE
Remove changes to the DNT header

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -229,19 +229,6 @@ chrome.webNavigation.onCommitted.addListener(details => {
     }
 })
 
-// Remove DNT header if set, to match other anti-fingerprinting
-// api results.
-chrome.webRequest.onBeforeSendHeaders.addListener(
-    function filterDNTHeader (e) {
-        if (e.requestHeaders) {
-            const requestHeaders = e.requestHeaders.filter(header => header.name.toLowerCase() !== 'dnt')
-            return {requestHeaders: requestHeaders}
-        }
-    },
-    {urls: ['<all_urls>']},
-    ['blocking', 'requestHeaders']
-)
-
 /**
  * ALARMS
  */


### PR DESCRIPTION
This removes the modifications to the DNT header, as Mozilla asked us not to modify it.