### PR TITLE
Enable fingerprint protection for all users

### DIFF
--- a/shared/data/experiments-out.js
+++ b/shared/data/experiments-out.js
@@ -15,20 +15,5 @@ module.exports = {
                 }
             }
         }
-    },
-    f: {
-        name: 'Fingerprint protection',
-        description: 'Testing basic fingerprint protection',
-        active: true,
-        atbExperiments: {
-            'k': {
-                description: 'Basic fingerprint protection experiment group',
-                settings: {
-                    experimentData: {
-                        fingerprint_protection: true
-                    }
-                }
-            }
-        }
     }
 }

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -210,35 +210,27 @@ const agentSpoofer = require('./classes/agentspoofer.es6')
 // Inject fingerprint protection into sites when
 // they are not whitelisted.
 chrome.webNavigation.onCommitted.addListener(details => {
-    const activeExperiment = settings.getSetting('activeExperiment')
-
-    if (activeExperiment) {
-        const experiment = settings.getSetting('experimentData')
-
-        if (experiment && experiment.fingerprint_protection) {
-            const whitelisted = settings.getSetting('whitelisted')
-            const tabURL = new URL(details.url) || {}
-            if (!whitelisted || !whitelisted[tabURL.hostname]) {
-                // Set variables, which are used in the fingerprint-protection script.
-                const variableScript = {
-                    'code': `
-                        try {
-                            var ddg_ext_ua='${agentSpoofer.getAgent()}'
-                        } catch(e) {}`,
-                    'runAt': 'document_start',
-                    'allFrames': true,
-                    'matchAboutBlank': true
-                }
-                chrome.tabs.executeScript(details.tabId, variableScript)
-                const scriptDetails = {
-                    'file': '/data/fingerprint-protection.js',
-                    'runAt': 'document_start',
-                    'allFrames': true,
-                    'matchAboutBlank': true
-                }
-                chrome.tabs.executeScript(details.tabId, scriptDetails)
-            }
+    const whitelisted = settings.getSetting('whitelisted')
+    const tabURL = new URL(details.url) || {}
+    if (!whitelisted || !whitelisted[tabURL.hostname]) {
+        // Set variables, which are used in the fingerprint-protection script.
+        const variableScript = {
+            'code': `
+                try {
+                    var ddg_ext_ua='${agentSpoofer.getAgent()}'
+                } catch(e) {}`,
+            'runAt': 'document_start',
+            'allFrames': true,
+            'matchAboutBlank': true
         }
+        chrome.tabs.executeScript(details.tabId, variableScript)
+        const scriptDetails = {
+            'file': '/data/fingerprint-protection.js',
+            'runAt': 'document_start',
+            'allFrames': true,
+            'matchAboutBlank': true
+        }
+        chrome.tabs.executeScript(details.tabId, scriptDetails)
     }
 })
 


### PR DESCRIPTION
Removes the fingerprint protection experiment gates. The experiment did not show any increase in breakage or reported issues, so I'd like to enable this feature for all users.