### PR TITLE
Improve css positioning in popup

### DIFF
--- a/shared/html/popup.html
+++ b/shared/html/popup.html
@@ -26,8 +26,12 @@
 <body class="body--neutral">
 
     <div id="popup-container"
-         class="sliding-subview sliding-subview--root sliding-subview--has-fixed-header">
-         <div class="site-info site-info--placeholder card"></div>
+        class="sliding-subview sliding-subview--root sliding-subview--has-fixed-header">
+        <div class="site-info site-info--placeholder card"></div>
+        <section id="search-form-container"></section>
+        <section id="hamburger-menu-container"></section>
+        <section id="site-info-container"></section>
+        <section id="top-blocked-container"></section>
     </div>
 
 <script src="../public/js/base.js" type="text/javascript"></script>

--- a/shared/js/ui/pages/popup.es6.js
+++ b/shared/js/ui/pages/popup.es6.js
@@ -37,28 +37,28 @@ Trackers.prototype = window.$.extend({},
             this.views.search = new SearchView({
                 pageView: this,
                 model: new SearchModel({searchText: ''}),
-                appendTo: this.$parent,
+                appendTo: window.$('#search-form-container'),
                 template: searchTemplate
             })
 
             this.views.hamburgerMenu = new HamburgerMenuView({
                 pageView: this,
                 model: new HamburgerMenuModel(),
-                appendTo: this.$parent,
+                appendTo: window.$('#hamburger-menu-container'),
                 template: hamburgerMenuTemplate
             })
 
             this.views.site = new SiteView({
                 pageView: this,
                 model: new SiteModel(),
-                appendTo: this.$parent,
+                appendTo: window.$('#site-info-container'),
                 template: siteTemplate
             })
 
             this.views.topblocked = new TopBlockedView({
                 pageView: this,
                 model: new TopBlockedModel({numCompanies: 3}),
-                appendTo: this.$parent,
+                appendTo: window.$('#top-blocked-container'),
                 template: topBlockedTemplate
             })
 

--- a/shared/js/ui/templates/search.es6.js
+++ b/shared/js/ui/templates/search.es6.js
@@ -2,13 +2,12 @@ const bel = require('bel')
 const hamburgerButton = require('./shared/hamburger-button.es6.js')
 
 module.exports = function () {
-    return bel`<section>
+    return bel`
     <form class="sliding-subview__header search-form js-search-form" name="x">
         <input type="text" autocomplete="off" placeholder="Search DuckDuckGo"
             name="q" class="search-form__input js-search-input"
             value="${this.model.searchText}" />
         <input class="search-form__go js-search-go" value="" type="submit" aria-label="Search" />
         ${hamburgerButton('js-search-hamburger-button')}
-    </form>
-</section>`
+    </form>`
 }

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -51,7 +51,7 @@ module.exports = function () {
                 ${toggleButton(!this.model.isWhitelisted, 'js-site-toggle pull-right')}
             </div>
         </li>
-        <li class="js-site-manage-whitelist-li site-info__li--manage-whitelist padded border--bottom">
+        <li class="js-site-manage-whitelist-li site-info__li--manage-whitelist padded">
             ${renderManageWhitelist(this.model)}
         </li>
         <li class="js-site-confirm-breakage-li site-info__li--confirm-breakage border--bottom padded is-hidden">

--- a/shared/js/ui/templates/site.es6.js
+++ b/shared/js/ui/templates/site.es6.js
@@ -9,7 +9,7 @@ module.exports = function () {
     const tosdrMsg = (this.model.tosdr && this.model.tosdr.message) ||
         constants.tosdrMessages.unknown
 
-    return bel`<section class="site-info site-info--main">
+    return bel`<div class="site-info site-info--main">
     <ul class="default-list">
         <li class="border--bottom site-info__rating-li main-rating js-hero-open">
             ${ratingHero(this.model, {
@@ -73,7 +73,7 @@ module.exports = function () {
             </div>
         </li>
     </ul>
-</section>`
+</div>`
 
     function setTransitionText (isSiteWhitelisted) {
         isSiteWhitelisted = isSiteWhitelisted || false

--- a/shared/js/ui/templates/top-blocked-truncated.es6.js
+++ b/shared/js/ui/templates/top-blocked-truncated.es6.js
@@ -3,7 +3,7 @@ const listItems = require('./top-blocked-truncated-list-items.es6.js')
 
 module.exports = function () {
     if (this.model.companyListMap && this.model.companyListMap.length > 0) {
-        return bel`<section class="top-blocked top-blocked--truncated">
+        return bel`<div class="top-blocked top-blocked--truncated">
     <div class="top-blocked__see-all js-top-blocked-see-all">
         <a href="javascript:void(0)" class="link-secondary">
             <span class="icon icon__arrow pull-right"></span>
@@ -13,6 +13,6 @@ module.exports = function () {
             </span>
         </a>
     </div>
-</section>`
+</div>`
     }
 }

--- a/shared/js/ui/templates/top-blocked.es6.js
+++ b/shared/js/ui/templates/top-blocked.es6.js
@@ -5,10 +5,10 @@ const noData = require('./shared/top-blocked-no-data.es6.js')
 
 module.exports = function () {
     if (!this.model) {
-        return bel`<section class="sliding-subview
+        return bel`<div class="sliding-subview
     sliding-subview--has-fixed-header top-blocked-header">
     ${header('All Trackers')}
-</section>`
+</div>`
     } else {
         return bel`<div class="js-top-blocked-content">
     ${renderPctPagesWithTrackers(this.model)}

--- a/shared/scss/_mixins.scss
+++ b/shared/scss/_mixins.scss
@@ -158,7 +158,7 @@
         box-sizing: border-box;
 
         &.sliding-subview--root {
-            position: fixed;
+            position: relative;
             top: 0;
             left: 0;
             transition: left 0.35s ease-in-out;

--- a/shared/scss/_vars.scss
+++ b/shared/scss/_vars.scss
@@ -41,10 +41,6 @@ $color--site-rating--f: $color--red;
 
 /* Popup */
 $popup__width: 300px;
-$popup__height: 497px;
-$popup__height--max: 550px;
-$popup__height--min--moz: 493px;
-$popup__height--moz: 550px;
 
 /* Hamburger Button & Menu */
 $hamburger-button__color: #afafaf;

--- a/shared/scss/base/base.scss
+++ b/shared/scss/base/base.scss
@@ -15,8 +15,6 @@
  */
 
 html, body {
-    height: 100%;
-    min-height: 95%;
 
     &.body--neutral {
         background: $color--white;

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -98,7 +98,8 @@ body {
         }
     }
 
-    .site-info--placeholder {
+    .text-line-after-icon {
+        margin-left: 12px;
     }
 
     .site-info {
@@ -106,10 +107,6 @@ body {
 
         .default-list {
            padding-bottom: 0;
-        }
-
-        .text-line-after-icon {
-           margin-left: 12px;
         }
 
         .text-line-after-icon.privacy-on-off-message {
@@ -347,7 +344,10 @@ body {
     }
 
     .top-blocked {
-        padding-bottom: 15px;
+        display: flex;
+        align-items: center;
+        height: 50px;
+        border-top: 1px solid rgba(0, 0, 0, 0.05);
 
         &.top-blocked--truncated {
             padding-top: 0;
@@ -425,7 +425,7 @@ body {
 
 /* Top blocked lists */
 .top-blocked__see-all {
-   padding-top: 14px;
+   width: 100%;
    padding-left: 20px;
    cursor: pointer;
 

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -5,16 +5,6 @@
 /* Popup */
 html, body {
     width: $popup__width;
-    height: $popup__height;
-
-    &.has-top-blocked--truncated,
-    &.has-top-blocked--truncated.is-browser--moz {
-        height: $popup__height--max;
-    }
-
-    &.is-browser--moz {
-        height: $popup__height--min--moz;
-    }
 }
 
 body {
@@ -109,14 +99,9 @@ body {
     }
 
     .site-info--placeholder {
-        height: 388px;
     }
 
     .site-info {
-        position: absolute;
-        top: 50px;
-        left: 0;
-        right: 0;
         margin-top: 0;
 
         .default-list {
@@ -351,7 +336,6 @@ body {
     .site-info--full-height {
         position: relative;
         margin-top: 0;
-        top: 0;
         height: 100%;
         overflow-y: auto;
     }
@@ -363,17 +347,10 @@ body {
     }
 
     .top-blocked {
-        position: absolute;
-        top: 440px;
-        left: 0;
-        right: 0;
-        margin-top: 10px;
         padding-bottom: 15px;
 
         &.top-blocked--truncated {
             padding-top: 0;
-            top: 423px;
-            bottom: 0;
         }
 
         .top-blocked__list {
@@ -450,7 +427,6 @@ body {
 .top-blocked__see-all {
    padding-top: 14px;
    padding-left: 20px;
-   margin: 65px 0 0 0;
    cursor: pointer;
 
    .link-secondary {

--- a/shared/scss/views/_hero.scss
+++ b/shared/scss/views/_hero.scss
@@ -1,5 +1,5 @@
 .hero {
-    padding: 0 15px 20px;
+    padding: 15px;
     text-align: center;
     position: relative;
     cursor: pointer;
@@ -8,7 +8,6 @@
 
 .hero__icon {
     @include icon_display();
-    margin-top: 12px;
 }
 
 .hero__title {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @MariagraziaAlastra 

## Description:
<!-- Explain what is being changed, why, etc -->
Previously the order of elements in the popup was not guaranteed because they were slotted one after the other on a first-come-first-served basis and the underlying logic had network and other async calls. In order to maintain visual hierarchy, we were relying on `position: absolute` to explicitly set their position. This was hard to maintain and fragile.

With this PR, I have created hardcoded containers in the markup and render items inside them, regardless of when they become available. This allowed me to remove the fixed and absolute positioning and just let elements follow the normal flow, so that I could also remove the fixed heights of the body and other elements.

This PR also runs a minor review on elements heights to make them all more uniform in light of future developments.

## Steps to test this PR:
Just make sure that the popup is looking right. Click around and make sure that panels slide in as expected and everything sits right where it should.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
