### PR TITLE
Add cname support for blocking trackers

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -6,6 +6,7 @@ const tabManager = require('./tab-manager.es6')
 const ATB = require('./atb.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 const settings = require('./settings.es6')
+const tdsStorage = require('./storage/tds.es6')
 
 var debugRequest = false
 
@@ -90,7 +91,10 @@ function handleRequest (requestData) {
          * If request is a tracker, cancel the request
          */
 
-        var tracker = trackers.getTrackerData(requestData.url, thisTab.site.url, requestData)
+        // First check if request is actually a CNAME cloaked tracker
+        let cnameURL = tdsStorage.resolveCname(requestData.url)
+
+        var tracker = trackers.getTrackerData(cnameURL, thisTab.site.url, requestData)
 
         // allow embedded twitter content if user enabled this setting
         if (tracker && tracker.fullTrackerDomain === 'platform.twitter.com' && settings.getSetting('embeddedTweetsEnabled') === true) {

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -91,10 +91,7 @@ function handleRequest (requestData) {
          * If request is a tracker, cancel the request
          */
 
-        // First check if request is actually a CNAME cloaked tracker
-        let cnameURL = tdsStorage.resolveCname(requestData.url)
-
-        var tracker = trackers.getTrackerData(cnameURL, thisTab.site.url, requestData)
+        var tracker = trackers.getTrackerData(requestData.url, thisTab.site.url, requestData)
 
         // allow embedded twitter content if user enabled this setting
         if (tracker && tracker.fullTrackerDomain === 'platform.twitter.com' && settings.getSetting('embeddedTweetsEnabled') === true) {

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -6,7 +6,6 @@ const tabManager = require('./tab-manager.es6')
 const ATB = require('./atb.es6')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 const settings = require('./settings.es6')
-const tdsStorage = require('./storage/tds.es6')
 
 var debugRequest = false
 

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -3,7 +3,6 @@ const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings.es6')
 const browserWrapper = require('./../$BROWSER-wrapper.es6')
-const tldts = require('tldts')
 
 class TDSStorage {
     constructor () {
@@ -144,6 +143,5 @@ class TDSStorage {
 
         return versionParam
     }
-
 }
 module.exports = new TDSStorage()

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -145,18 +145,5 @@ class TDSStorage {
         return versionParam
     }
 
-    resolveCname (url) {
-        const parsed = tldts.parse(url)
-        let finalURL = url
-        if (parsed && this.tds.cnames) {
-            let domain = parsed.domain
-            if (parsed.subdomain) {
-                domain = parsed.subdomain + '.' + domain
-            }
-            const finalDomain = this.tds.cnames[domain] || domain
-            finalURL = finalURL.replace(domain, finalDomain)
-        }
-        return finalURL
-    }
 }
 module.exports = new TDSStorage()

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -3,6 +3,7 @@ const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings.es6')
 const browserWrapper = require('./../$BROWSER-wrapper.es6')
+const tldts = require('tldts')
 
 class TDSStorage {
     constructor () {
@@ -10,7 +11,7 @@ class TDSStorage {
         this.dbc.version(1).stores({
             tdsStorage: 'name,data'
         })
-        this.tds = {entities: {}, trackers: {}, domains: {}}
+        this.tds = {entities: {}, trackers: {}, domains: {}, cnames: {}}
         this.surrogates = ''
         this.brokenSiteList = []
     }
@@ -142,6 +143,20 @@ class TDSStorage {
         if (versionParam) settings.updateSetting('lastTdsUpdate', now)
 
         return versionParam
+    }
+
+    resolveCname (url) {
+        const parsed = tldts.parse(url)
+        let finalURL = url
+        if (parsed && this.tds.cnames) {
+            let domain = parsed.domain
+            if (parsed.subdomain) {
+                domain = parsed.subdomain + '.' + domain
+            }
+            const finalDomain = this.tds.cnames[domain] || domain
+            finalURL = finalURL.replace(domain, finalDomain)
+        }
+        return finalURL
     }
 }
 module.exports = new TDSStorage()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
This updates the tracker blocking logic to check for cname entries. If a request for a first party is actually a CNAME to a third party tracker, block it as if it were not behind a CNAME.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
