### PR TITLE
Update privacy grade to 1.03

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,9 +1375,9 @@
             }
         },
         "@duckduckgo/privacy-grade": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/privacy-grade/-/privacy-grade-1.0.2.tgz",
-            "integrity": "sha512-VpG8tgNymFopotPZhL1YrusoX34XjlkE1L3T1BpMzX7QT4VsHC3ZogDRsdNVaz1UAULTw1mTdNkMooGV+HIMvA=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/privacy-grade/-/privacy-grade-1.0.3.tgz",
+            "integrity": "sha512-2HM03HQ6B4MVyEi1AFANQtAWHEVsKC8o72WKrMuHClxA190Phn5I6IPa5AFOdDPT7P15hg1O8KgkX1+OZFYzgA=="
         },
         "@types/node": {
             "version": "14.0.27",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "timekeeper": "^2.1.1"
     },
     "dependencies": {
-        "@duckduckgo/privacy-grade": "1.0.2",
+        "@duckduckgo/privacy-grade": "1.0.3",
         "abp-filter-parser": "git://github.com/duckduckgo/abp-filter-parser.git#0.2.0",
         "bel": "4.6.0",
         "chalk": "2.1.0",


### PR DESCRIPTION
Updates the privacy-grade dependency to 1.03, which includes the cname blocking logic.