### PR TITLE
Fix issue with processing User Agent Safe List

### DIFF
--- a/shared/js/background/classes/agentspoofer.es6.js
+++ b/shared/js/background/classes/agentspoofer.es6.js
@@ -101,7 +101,7 @@ class AgentSpoofer {
             return false
         }
         const domain = tldts.parse(request.url).domain
-        if (agentStorage.excludedDomains.length > 0 && agentStorage.excludedDomains.every(excluded => domain === excluded)) {
+        if (agentStorage.excludedDomains.length > 0 && agentStorage.excludedDomains.includes(domain)) {
             return false
         }
         return true


### PR DESCRIPTION
This fixes an issue where if the user agent safe list is longer than a single entry, it won't correctly apply the safe listing. 