### PR TITLE
Stop injecting anti-fingerprint protections into xml and json documents

### DIFF
--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -5,6 +5,23 @@
  */
 
 (function protect () {
+    // Exclude some content types from injection
+    const elem = document.head || document.documentElement
+    try {
+        const contentType = elem.ownerDocument.contentType
+        if (contentType === 'application/xml' ||
+            contentType === 'application/json' ||
+            contentType === 'text/xml' ||
+            contentType === 'text/json' ||
+            contentType === 'text/rss+xml' ||
+            contentType === 'application/rss+xml'
+        ) {
+            return
+        }
+    } catch (e) {
+        // if we can't find content type, go ahead with injection.
+    }
+
     // Property values to be set and their original values.
     const fingerprintPropertyValues = {
         'screen': {
@@ -277,24 +294,12 @@
     /**
      * Inject all the overwrites into the page.
      */
-    function inject (scriptToInject, removeAfterExec) {
+    function inject (scriptToInject, removeAfterExec, elemToInject) {
         // Inject into main page
         try {
             let e = document.createElement('script')
             e.textContent = scriptToInject
-            const elem = document.head || document.documentElement
-            try {
-                const contentType = elem.ownerDocument.contentType
-                if (contentType === 'application/xml' ||
-                    contentType === 'application/json' ||
-                    contentType === 'text/xml' ||
-                    contentType === 'text/json') {
-                    return
-                }
-            } catch (e) {
-                // if we can't find content type, go ahead with injection.
-            }
-            elem.appendChild(e)
+            elemToInject.appendChild(e)
 
             if (removeAfterExec) {
                 e.remove()
@@ -305,9 +310,9 @@
 
     window.addEventListener('resize', function () {
         const windowScript = setWindowDimensions()
-        inject(windowScript, true)
+        inject(windowScript, true, elem)
     })
 
     const injectionScript = buildInjectionScript()
-    inject(injectionScript)
+    inject(injectionScript, false, elem)
 })()

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -283,6 +283,17 @@
             let e = document.createElement('script')
             e.textContent = scriptToInject
             const elem = document.head || document.documentElement
+            try {
+                const contentType = elem.ownerDocument.contentType
+                if (contentType === 'application/xml' ||
+                    contentType === 'application/json' ||
+                    contentType === 'text/xml' ||
+                    contentType === 'text/json') {
+                    return
+                }
+            } catch (e) {
+                // if we can't find content type, go ahead with injection.
+            }
             elem.appendChild(e)
 
             if (removeAfterExec) {

--- a/shared/js/content-scripts/GPC.js
+++ b/shared/js/content-scripts/GPC.js
@@ -7,7 +7,10 @@
         if (contentType === 'application/xml' ||
             contentType === 'application/json' ||
             contentType === 'text/xml' ||
-            contentType === 'text/json') {
+            contentType === 'text/json' ||
+            contentType === 'text/rss+xml' ||
+            contentType === 'application/rss+xml'
+        ) {
             return
         }
     } catch (e) {

--- a/shared/js/content-scripts/GPC.js
+++ b/shared/js/content-scripts/GPC.js
@@ -1,6 +1,18 @@
 /* global globalPrivacyControlValue */
 // Set Global Privacy Control property on DOM
 (function setDOMSignal () {
+    try {
+        const contentType = document.documentElement.ownerDocument.contentType
+        // don't inject into xml or json pages
+        if (contentType === 'application/xml' ||
+            contentType === 'application/json' ||
+            contentType === 'text/xml' ||
+            contentType === 'text/json') {
+            return
+        }
+    } catch (e) {
+        // if we can't find content type, go ahead with injection
+    }
     const scriptString = `
         // Catch errors if signal is already set by user agent or other extension
         try {


### PR DESCRIPTION
This adds some content checks into the anti-fingerprinting script injection, and will not inject scripts if the content type is json or xml. 

Fixes issue #503 