### PR TITLE
Break-fix: Disable UserAgent spoofing & fix issue with Temp Storage FP protection

### DIFF
--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -290,14 +290,14 @@
         const script = `
             if (navigator.webkitTemporaryStorage) {
                 try {
-                    navigator.webkitTemporaryStorage.${randomFunctionName} = navigator.webkitTemporaryStorage.queryUsageAndQuota
+                    ${randomFunctionName} = navigator.webkitTemporaryStorage.queryUsageAndQuota
                     navigator.webkitTemporaryStorage.queryUsageAndQuota = function queryUsageAndQuota (callback, err) {
                         const modifiedCallback = function (usedBytes, grantedBytes) {
                             const maxBytesGranted = 4 * 1024 * 1024 * 1024
-                            grantedBytes = Math.min(grantedBytes, maxBytesGranted)
+                            const grantedBytes = Math.min(grantedBytes, maxBytesGranted)
                             callback(usedBytes, grantedBytes)
                         }
-                        navigator.webkitTemporaryStorage.${randomFunctionName}(modifiedCallback, err)
+                        ${randomFunctionName}.call(navigator.webkitTemporaryStorage, modifiedCallback, err)
                     }
                 }
                 catch(e) {}

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -292,7 +292,7 @@
         const script = `
             if (navigator.webkitTemporaryStorage) {
                 try {
-                    ${randomFunctionName} = navigator.webkitTemporaryStorage.queryUsageAndQuota
+                    const org = navigator.webkitTemporaryStorage.queryUsageAndQuota
                     navigator.webkitTemporaryStorage.queryUsageAndQuota = function queryUsageAndQuota (callback, err) {
                         const modifiedCallback = function (usedBytes, grantedBytes) {
                             const maxBytesGranted = 4 * 1024 * 1024 * 1024

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -300,7 +300,7 @@
                         navigator.webkitTemporaryStorage.${randomFunctionName}(modifiedCallback, err)
                     }
                 }
-                catch(e) {console.err(e)}
+                catch(e) {}
             }
         `
         return script

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -294,8 +294,8 @@
                     navigator.webkitTemporaryStorage.queryUsageAndQuota = function queryUsageAndQuota (callback, err) {
                         const modifiedCallback = function (usedBytes, grantedBytes) {
                             const maxBytesGranted = 4 * 1024 * 1024 * 1024
-                            const grantedBytes = Math.min(grantedBytes, maxBytesGranted)
-                            callback(usedBytes, grantedBytes)
+                            const spoofedGrantedBytes = Math.min(grantedBytes, maxBytesGranted)
+                            callback(usedBytes, spoofedGrantedBytes)
                         }
                         ${randomFunctionName}.call(navigator.webkitTemporaryStorage, modifiedCallback, err)
                     }

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -288,7 +288,6 @@
      * feature.
      */
     function modifyTemporaryStorage () {
-        const randomFunctionName = 'A' + Math.random().toString(36).substring(2) // random string of alphanumeric chars
         const script = `
             if (navigator.webkitTemporaryStorage) {
                 try {
@@ -299,7 +298,7 @@
                             const spoofedGrantedBytes = Math.min(grantedBytes, maxBytesGranted)
                             callback(usedBytes, spoofedGrantedBytes)
                         }
-                        ${randomFunctionName}.call(navigator.webkitTemporaryStorage, modifiedCallback, err)
+                        org.call(navigator.webkitTemporaryStorage, modifiedCallback, err)
                     }
                 }
                 catch(e) {}

--- a/shared/data/fingerprint-protection.js
+++ b/shared/data/fingerprint-protection.js
@@ -73,18 +73,20 @@
                 'targetValue': 8
             }
         },
+        /*
         'useragent': {
 //            'userAgent': {
 //                'object': 'navigator',
 //                'origValue': navigator.userAgent,
 //                'targetValue': `"${ddg_ext_ua}"` // Defined in chrome-events.es6.js and injected as a variable
 //            },
-            'appVersion': {
+              'appVersion': {
                 'object': 'navigator',
                 'origValue': navigator.appVersion,
                 'targetValue': `"${getAppVersionValue()}"`
             }
         },
+        */
         'options': {
             'doNotTrack': {
                 'object': 'navigator',

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -246,6 +246,10 @@ chrome.webNavigation.onCommitted.addListener(details => {
 })
 
 // Replace UserAgent header on third party requests.
+/* Disable User Agent Spoofing temporarily.
+ * Some chromium based browsers have started changing
+ * UA per site. Once this feature is re-worked to match
+ * that behaviour, it will be re-enabled.
 chrome.webRequest.onBeforeSendHeaders.addListener(
     function spoofUserAgentHeader (e) {
         let tab = tabManager.get({ tabId: e.tabId })
@@ -270,6 +274,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     {urls: ['<all_urls>']},
     ['blocking', 'requestHeaders']
 )
+*/
 
 /**
  * Global Privacy Control

--- a/shared/js/background/classes/agentspoofer.es6.js
+++ b/shared/js/background/classes/agentspoofer.es6.js
@@ -80,7 +80,7 @@ class AgentSpoofer {
             agent.versionMinor <= Number(this.parsedAgent.minor) + Number(browserMinorVariance))
         // Filter out any excluded agents
         if (agentStorage.excludedAgents.length > 0) {
-            agents = agents.filter(agent => !agentStorage.excludedAgents.every(excludePattern => excludePattern.test(agent.agentString)))
+            agents = agents.filter(agent => !agentStorage.excludedAgents.some(excludePattern => excludePattern.test(agent.agentString)))
         }
         // Don't include our current agent (so it should always rotate)
         agents = agents.filter(agent => agent.agentString !== this.spoofedAgent)

--- a/shared/js/background/storage/agents.es6.js
+++ b/shared/js/background/storage/agents.es6.js
@@ -24,21 +24,8 @@ class AgentStorage {
         this.excludedAgents = []
         // Information about which agents to keep in our data set.
         const realAgent = agentparser.lookup(navigator.userAgent)
-        this.family = this.getBrowserType(realAgent)
+        this.family = realAgent.family
         this.os = realAgent.os.family
-    }
-
-    /*
-     * Return the type of browser, such as Brave or Chrome
-     * @param {useragent.Agent} parsedAgent - the parsed agent object
-     */
-    getBrowserType (parsedAgent) {
-        // The node libraries I tested do not return "brave" as expected for brave user agent strings.
-        // so this corrects for that.
-        if (parsedAgent.source.toLowerCase().includes('brave')) {
-            return 'Brave'
-        }
-        return parsedAgent.family
     }
 
     /**
@@ -121,15 +108,14 @@ class AgentStorage {
                     continue
                 }
                 const parsedUA = agentparser.lookup(ua.agent)
-                const uaFamily = this.getBrowserType(parsedUA)
-                if (uaFamily === this.family &&
+                if (parsedUA.family === this.family &&
                     parsedUA.os.family === this.os) {
                     let frequency = ua.percentage
                     if (typeof frequency === 'string') {
                         frequency = Number(frequency.replace('%', ''))
                     }
                     this.agents.push({
-                        browser: uaFamily,
+                        browser: parsedUA.family,
                         platform: parsedUA.os.family,
                         frequency: frequency,
                         agentString: ua.agent,

--- a/shared/js/background/storage/agents.es6.js
+++ b/shared/js/background/storage/agents.es6.js
@@ -24,8 +24,21 @@ class AgentStorage {
         this.excludedAgents = []
         // Information about which agents to keep in our data set.
         const realAgent = agentparser.lookup(navigator.userAgent)
-        this.family = realAgent.family
+        this.family = this.getBrowserType(realAgent)
         this.os = realAgent.os.family
+    }
+
+    /*
+     * Return the type of browser, such as Brave or Chrome
+     * @param {useragent.Agent} parsedAgent - the parsed agent object
+     */
+    getBrowserType (parsedAgent) {
+        // The node libraries I tested do not return "brave" as expected for brave user agent strings.
+        // so this corrects for that.
+        if (parsedAgent.source.toLowerCase().includes('brave')) {
+            return 'Brave'
+        }
+        return parsedAgent.family
     }
 
     /**
@@ -108,14 +121,15 @@ class AgentStorage {
                     continue
                 }
                 const parsedUA = agentparser.lookup(ua.agent)
-                if (parsedUA.family === this.family &&
+                const uaFamily = this.getBrowserType(parsedUA)
+                if (uaFamily === this.family &&
                     parsedUA.os.family === this.os) {
                     let frequency = ua.percentage
                     if (typeof frequency === 'string') {
                         frequency = Number(frequency.replace('%', ''))
                     }
                     this.agents.push({
-                        browser: parsedUA.family,
+                        browser: uaFamily,
                         platform: parsedUA.os.family,
                         frequency: frequency,
                         agentString: ua.agent,


### PR DESCRIPTION
Brave generally doesn't include a special UA, so JS agent parsing libraries don't correctly identify Brave user agent strings. It looks like there was a logic error in how excluded regex patterns were being matched, which this should fix, so we can also ignore certain Brave strings are are DDG internal only.

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. Open the background page console in chrome, and reload the plugin several times. Ensure that no selected user agent strings include a brave user agent.
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
