### PR TITLE
Add trailing slash to modified referrer

### DIFF
--- a/shared/js/background/tracker-utils.js
+++ b/shared/js/background/tracker-utils.js
@@ -74,6 +74,7 @@ function truncateReferrer (referrer, target) {
     } else {
         modifiedReferrer = utils.extractLimitedDomainFromURL(referrer, {keepSubdomains: true})
     }
+    modifiedReferrer += '/'
     // If extractLimitedDomainFromURL fails (for instance, invalid referrer URL), it
     // returns undefined, (in practice, don't modify the referrer), so sometimes this value could be undefined.
     return modifiedReferrer

--- a/shared/js/background/tracker-utils.js
+++ b/shared/js/background/tracker-utils.js
@@ -74,7 +74,6 @@ function truncateReferrer (referrer, target) {
     } else {
         modifiedReferrer = utils.extractLimitedDomainFromURL(referrer, {keepSubdomains: true})
     }
-    modifiedReferrer += '/'
     // If extractLimitedDomainFromURL fails (for instance, invalid referrer URL), it
     // returns undefined, (in practice, don't modify the referrer), so sometimes this value could be undefined.
     return modifiedReferrer

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -36,7 +36,7 @@ function extractLimitedDomainFromURL (url, {keepSubdomains} = {}) {
             finalURL = 'www.' + tld.domain
         }
 
-        return `${parsedURL.protocol}//${finalURL}`
+        return `${parsedURL.protocol}//${finalURL}/`
     } catch (e) {
         // tried to parse invalid URL, such as an extension URL. In this case, don't modify anything
         return undefined

--- a/unit-test/background/tracker-utils-tests.js
+++ b/unit-test/background/tracker-utils-tests.js
@@ -180,37 +180,37 @@ describe('Tracker Utilities', () => {
             name: 'Simple truncation test',
             referrer: 'http://siteA.com/article/1',
             target: 'http://siteB.com',
-            expectedReferrer: 'http://sitea.com'
+            expectedReferrer: 'http://sitea.com/'
         },
         {
             name: 'target is a tracker, and referrer has a subdomain',
             referrer: 'http://subdomain.siteA.com/article/1',
             target: 'https://google-analytics.com/some/path',
-            expectedReferrer: 'http://sitea.com'
+            expectedReferrer: 'http://sitea.com/'
         },
         {
             name: 'target is not a tracker, referrer should keep subdomain',
             referrer: 'http://subdomain.siteA.com/article/1',
             target: 'http://siteB.com',
-            expectedReferrer: 'http://subdomain.sitea.com'
+            expectedReferrer: 'http://subdomain.sitea.com/'
         },
         {
             name: 'target is not a tracker, referrer should keep multi-level subdomain',
             referrer: 'http://a.b.subdomain.siteA.com/article/1',
             target: 'http://siteB.com',
-            expectedReferrer: 'http://a.b.subdomain.sitea.com'
+            expectedReferrer: 'http://a.b.subdomain.sitea.com/'
         },
         {
             name: 'target is a tracker, and referrer has a subdomain that is www only.',
             referrer: 'http://www.siteA.com/article/1',
             target: 'https://google-analytics.com/some/path',
-            expectedReferrer: 'http://www.sitea.com'
+            expectedReferrer: 'http://www.sitea.com/'
         },
         {
             name: 'target is not a tracker, and referrer has a subdomain that is www only.',
             referrer: 'http://www.siteA.com/article/1',
             target: 'http://siteB.com',
-            expectedReferrer: 'http://www.sitea.com'
+            expectedReferrer: 'http://www.sitea.com/'
         }
     ]
     it('Should modify referrer when referrer != target', () => {


### PR DESCRIPTION
Modifies the referrer header truncation function to include a trailing '/' when the referrer is modified to a domain. This is because some sites do security checking on referrer, and may not match without this trailing slash.