### PR TITLE
Reload site when site when added to unprotected list.

### DIFF
--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -44,7 +44,7 @@ Site.prototype = window.$.extend({},
 
             this.model.toggleWhitelist()
             const whitelisted = this.model.isWhitelisted
-            this._showWhitelistedStatusMessage(!whitelisted)
+            this._showWhitelistedStatusMessage(whitelisted)
 
             if (whitelisted) {
                 this._showBreakageConfirmation()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @dharb 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

The breakage toggle only reloads when protection is added back on, which is probably the inverse of what is expected. The alternative is we always reload in both cases.

This likely will reduce the number of people upset in breakage reports that the site is always broken and also fix retention etc.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
