### PR TITLE
Stop UA from attempting to rotate (disabled already)

### DIFF
--- a/shared/js/background/classes/agentspoofer.es6.js
+++ b/shared/js/background/classes/agentspoofer.es6.js
@@ -14,6 +14,7 @@ class AgentSpoofer {
 
     getAgent () {
         // TODO: Remove this when UA fixes occur
+        /* eslint-disable no-unreachable */
         return this.realAgent
         if (this.needsRotation) {
             this.rotateAgent()
@@ -26,6 +27,7 @@ class AgentSpoofer {
      */
     rotateAgent () {
         // TODO: remove this return when UA fixes occur
+        /* eslint-disable no-unreachable */
         return
         const oldAgent = this.spoofedAgent
         this.spoofedAgent = this.selectAgent()

--- a/shared/js/background/classes/agentspoofer.es6.js
+++ b/shared/js/background/classes/agentspoofer.es6.js
@@ -13,6 +13,8 @@ class AgentSpoofer {
     }
 
     getAgent () {
+        // TODO: Remove this when UA fixes occur
+        return this.realAgent
         if (this.needsRotation) {
             this.rotateAgent()
         }
@@ -23,6 +25,8 @@ class AgentSpoofer {
      * Select a new spoofed user agent to return.
      */
     rotateAgent () {
+        // TODO: remove this return when UA fixes occur
+        return
         const oldAgent = this.spoofedAgent
         this.spoofedAgent = this.selectAgent()
         console.log(`Rotated UserAgent. Old agent was: ${oldAgent}. New UserAgent: ${this.spoofedAgent}`)
@@ -33,6 +37,7 @@ class AgentSpoofer {
      *      browser & OS faimly should be the same
      *      Browser major version should be +/- 3 versions
      *      OS major version should remain the same
+     * TODO: The list to pick from is no longer updated correctly.
     **/
     selectAgent () {
         const agentList = this.filterAgents(agentStorage.agents)

--- a/unit-test/background/fingerprint.es6.js
+++ b/unit-test/background/fingerprint.es6.js
@@ -39,11 +39,14 @@ describe('User-Agent replacement', () => {
             }
         })
 
+        /* Disabled until UserAgent functionality is restored */
+        /*
         it('should rotate to a new agent', () => {
             const agent = agentSpoofer.getAgent()
             agentSpoofer.rotateAgent()
             expect(agent).not.toEqual(agentSpoofer.getAgent())
         })
+        */
 
         it('should send fake headers to third parties', () => {
             const request = {


### PR DESCRIPTION
Stop User Agent rotations from occurring. The UA spoofing is already disabled, this just stops support code from executing until all UA fixes are implemented.