### PR TITLE
Fix postinstall page test

### DIFF
--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -25,12 +25,9 @@ describe('install workflow', () => {
             // wait for post install page to open
             // if it never does, jasmine timeout will kick in
             while (!postInstallOpened) {
+                const urls = await Promise.all(browser.targets().map(target => target.url()))
+                postInstallOpened = urls.some(url => url.includes('duckduckgo.com/app?post=1'))
                 await wait.ms(100)
-                postInstallOpened = await browser.targets().some(async (target) => {
-                    const url = await target.url()
-
-                    return url.match(/duckduckgo\.com\/install\?post=1/)
-                })
             }
 
             expect(postInstallOpened).toBeTruthy()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Due to a bug the current test for the post-install page always passes. This PR solves that by fixing the async/await logic.

## Steps to test this PR:
- Run the first test in `integration-test/background/atb.js`
- [ ] check that it passes

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
