### PR TITLE
Add caching for exclusion list

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -389,12 +389,12 @@ chrome.runtime.onMessage.addListener((req, sender, res) => {
             const parsed = tldts.parse(tabUrl)
             action.tabRegisteredDomain = parsed.domain === null ? parsed.hostname : parsed.domain
 
+            if (req.documentUrl && trackerutils.isTracker(req.documentUrl) && sender.frameId !== 0) {
+                action.isTrackerFrame = true
+            }
+
             action.isThirdParty = !utils.isFirstParty(sender.url, sender.tab.url)
             action.shouldBlock = !cookieConfig.isExcluded(sender.url)
-
-            if (req.documentUrl && trackerutils.isTracker(req.documentUrl) && sender.frameId !== 0) {
-                action.isTrackerFrame = true && action.shouldBlock
-            }
 
             res(action)
         } else {

--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -389,12 +389,13 @@ chrome.runtime.onMessage.addListener((req, sender, res) => {
             const parsed = tldts.parse(tabUrl)
             action.tabRegisteredDomain = parsed.domain === null ? parsed.hostname : parsed.domain
 
-            if (req.documentUrl && trackerutils.isTracker(req.documentUrl) && sender.frameId !== 0) {
-                action.isTrackerFrame = true
-            }
-
             action.isThirdParty = !utils.isFirstParty(sender.url, sender.tab.url)
             action.shouldBlock = !cookieConfig.isExcluded(sender.url)
+
+            if (req.documentUrl && trackerutils.isTracker(req.documentUrl) && sender.frameId !== 0) {
+                action.isTrackerFrame = true && action.shouldBlock
+            }
+
             res(action)
         } else {
             res(action)

--- a/shared/js/background/storage/cookies.es6.js
+++ b/shared/js/background/storage/cookies.es6.js
@@ -87,7 +87,7 @@ class ExcludedCookieStorage {
         chrome.storage.local.get(listName, callback)
     }
 
-    async storeExclusionList (listname, data) {
+    storeExclusionList (listname, data) {
         chrome.storage.local.set({ [listname]: data }, () => {})
     }
 

--- a/shared/js/background/storage/cookies.es6.js
+++ b/shared/js/background/storage/cookies.es6.js
@@ -60,13 +60,13 @@ class ExcludedCookieStorage {
                     settings.updateSetting(`${listName}-etag`, '')
                     console.log(`Error updating cookie data:  ${e}. Attempting to load from local storage.`)
                     this.loadExclusionList(listName)
-                            .then(queryData => {
-                                this.processList(listName, queryData.listData)
-                            })
-                            .catch(e => {
-                                console.log(`Error loading Exclusion settings from storage: ${e}`)
-                                settings.updateSetting(`${listName}-etag`, '')
-                            })
+                        .then(queryData => {
+                            this.processList(listName, queryData.listData)
+                        })
+                        .catch(e => {
+                            console.log(`Error loading Exclusion settings from storage: ${e}`)
+                            settings.updateSetting(`${listName}-etag`, '')
+                        })
                 })
         }
     }
@@ -92,7 +92,7 @@ class ExcludedCookieStorage {
     loadExclusionList (listName) {
         console.log(`looking for listname ${listName}`)
         return this.exclusionDB.open()
-            .then(() => this.exclusionDB.table('exclusionStorage').get({ listName: listName}))
+            .then(() => this.exclusionDB.table('exclusionStorage').get({ listName: listName }))
     }
 
     async storeExclusionList (listname, data) {

--- a/shared/js/background/storage/cookies.es6.js
+++ b/shared/js/background/storage/cookies.es6.js
@@ -39,7 +39,6 @@ class ExcludedCookieStorage {
                 .then(response => {
                     if (response && response.status === 200) {
                         // New cookie data to process.
-                        console.log(response)
                         const data = JSON.parse(response.response)
                         this.storeExclusionList(listName, data)
                         this.processList(listName, data)

--- a/shared/js/background/storage/cookies.es6.js
+++ b/shared/js/background/storage/cookies.es6.js
@@ -2,6 +2,7 @@
 import 'regenerator-runtime/runtime'
 
 const load = require('./../load.es6')
+const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings.es6')
 
@@ -13,6 +14,10 @@ const settings = require('./../settings.es6')
  **/
 class ExcludedCookieStorage {
     constructor () {
+        this.exclusionDB = new Dexie('exclusionStorage')
+        this.exclusionDB.version(1).stores({
+            exclusionStorage: 'listName,listData'
+        })
         this.excludedDomains = []
         this.firstPartyCookiePolicy = {
             threshold: 864000, // 10 days
@@ -32,18 +37,37 @@ class ExcludedCookieStorage {
             const etag = settings.getSetting(`${listName}-etag`) || ''
             load.loadExtensionFile({ url: list.url, etag: etag, returnType: list.format, source, timeout: 60000 })
                 .then(response => {
-                    if (response && (response.status === 200 || response.status === 304)) {
+                    if (response && response.status === 200) {
                         // New cookie data to process.
+                        console.log(response)
                         const data = JSON.parse(response.response)
+                        this.storeExclusionList(listName, data)
                         this.processList(listName, data)
                         const newEtag = response.getResponseHeader('etag') || ''
                         settings.updateSetting(`${listName}-etag`, newEtag)
+                    } else if (response && response.status === 304) {
+                        this.loadExclusionList(listName)
+                            .then(queryData => {
+                                this.processList(listName, queryData.listData)
+                            })
+                            .catch(e => {
+                                console.log(`Error loading Exclusion settings from storage: ${e}`)
+                                settings.updateSetting(`${listName}-etag`, '')
+                            })
                     }
                 })
                 .catch(e => {
                     // Reset the etag
                     settings.updateSetting(`${listName}-etag`, '')
                     console.log(`Error updating cookie data:  ${e}. Attempting to load from local storage.`)
+                    this.loadExclusionList(listName)
+                            .then(queryData => {
+                                this.processList(listName, queryData.listData)
+                            })
+                            .catch(e => {
+                                console.log(`Error loading Exclusion settings from storage: ${e}`)
+                                settings.updateSetting(`${listName}-etag`, '')
+                            })
                 })
         }
     }
@@ -63,6 +87,20 @@ class ExcludedCookieStorage {
         }
         if (data.firstPartyTrackerCookiePolicy) {
             this.firstPartyCookiePolicy = data.firstPartyTrackerCookiePolicy
+        }
+    }
+
+    loadExclusionList (listName) {
+        console.log(`looking for listname ${listName}`)
+        return this.exclusionDB.open()
+            .then(() => this.exclusionDB.table('exclusionStorage').get({ listName: listName}))
+    }
+
+    async storeExclusionList (listname, data) {
+        try {
+            await this.exclusionDB.exclusionStorage.put({ listName: listname, listData: data })
+        } catch (e) {
+            console.log(`Error storing exclusion data locally: ${e}`)
         }
     }
 

--- a/shared/js/content-scripts/block-cookie.js
+++ b/shared/js/content-scripts/block-cookie.js
@@ -129,8 +129,8 @@
         checkThirdParty: true,
         documentUrl: window.location.href
     }, function (action) {
-        if (!action) {
-            // response is undefined if the background has not yet registered the message listener
+        if (!action || !action.shouldBlock || !action.isThirdParty) {
+            // action is undefined if the background has not yet registered the message listener
             return
         }
         if (window.top !== window && action.isTrackerFrame) {

--- a/shared/js/content-scripts/block-cookie.js
+++ b/shared/js/content-scripts/block-cookie.js
@@ -129,11 +129,11 @@
         checkThirdParty: true,
         documentUrl: window.location.href
     }, function (action) {
-        if (!action || !action.shouldBlock || !action.isThirdParty) {
+        if (!action) {
             // action is undefined if the background has not yet registered the message listener
             return
         }
-        if (window.top !== window && action.isTrackerFrame) {
+        if (window.top !== window && action.isTrackerFrame && action.shouldBlock && action.isThirdParty) {
             // overrides expiry policy with blocking - only in subframes
             inject(blockCookies)
         }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth @jonathanKingston @kdzwinel 

<!-- Optional fields
**CC:** @kdzwinel @jdorweiler 
**Depends on:** 
-->

## Description:
Cookie exclusion list was not being cached. If the list endpoint returned a 304 there would be no response and the list would fail to load. This PR adds caching based on the UserAgent list implementation.


## Steps to test this PR:
1. Load extension
2. Visit site with excluded cookie domain (e.g. google 3rd party login)
3. Login should work
4. Reload extension (to force reloading exclusion list)
5. Repeat steps 2-3
**Note:** Since this relies on getting a 304 response you may need to reload the extension in quick succession

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
