### PR TITLE
Fix error when no response is received from bg

### DIFF
--- a/shared/js/content-scripts/block-cookie.js
+++ b/shared/js/content-scripts/block-cookie.js
@@ -129,6 +129,10 @@
         checkThirdParty: true,
         documentUrl: window.location.href
     }, function (action) {
+        if (!action) {
+            // response is undefined if the background has not yet registered the message listener
+            return
+        }
         if (window.top !== window && action.isTrackerFrame) {
             // overrides expiry policy with blocking - only in subframes
             inject(blockCookies)
@@ -140,9 +144,12 @@
         }, document.location.origin)
     })
     chrome.runtime.onMessage.addListener((message) => {
-        window.postMessage({
-            source: MSG_SECRET,
-            ...message
-        })
+        // forward tracker messages to the embedded script
+        if (message && message.type === 'tracker') {
+            window.postMessage({
+                source: MSG_SECRET,
+                ...message
+            })
+        }
     })
 })()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
On extension startup it is possible that the content-script message handler in the background is not ready when we query from the content-script. In this case we get an `undefined` response. This PR handles this case to avoid showing an error in the console.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
