### PR TITLE
Fix cookie config load error when data is missing in storage

### DIFF
--- a/shared/js/background/storage/cookies.es6.js
+++ b/shared/js/background/storage/cookies.es6.js
@@ -41,7 +41,7 @@ class ExcludedCookieStorage {
                         settings.updateSetting(`${listName}-etag`, newEtag)
                     } else if (response && response.status === 304) {
                         this.loadExclusionList(listName, (results) => {
-                            if (chrome.runtime.lastError) {
+                            if (chrome.runtime.lastError || !results[listName]) {
                                 console.log(`Error loading Exclusion settings from storage: ${chrome.runtime.lastError}`)
                                 settings.updateSetting(`${listName}-etag`, '')
                             }
@@ -54,7 +54,7 @@ class ExcludedCookieStorage {
                     settings.updateSetting(`${listName}-etag`, '')
                     console.log(`Error updating cookie data:  ${e}. Attempting to load from local storage.`)
                     this.loadExclusionList(listName, (results) => {
-                        if (chrome.runtime.lastError) {
+                        if (chrome.runtime.lastError || !results[listName]) {
                             console.log(`Error loading Exclusion settings from storage: ${chrome.runtime.lastError}`)
                             settings.updateSetting(`${listName}-etag`, '')
                         }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fixes an issue after #582 if there is an update-to-date etag in settings, but the data is missing in `chrome.storage`.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
