### PR TITLE
Block CSP reports that contain a moz-extension URL

### DIFF
--- a/shared/js/background/chrome-events.es6.js
+++ b/shared/js/background/chrome-events.es6.js
@@ -13,6 +13,7 @@ const experiment = require('./experiments.es6')
 const settings = require('./settings.es6')
 const constants = require('../../data/constants')
 const onboarding = require('./onboarding.es6')
+const cspProtection = require('./csp-blocking.es6')
 const browser = utils.getBrowserName()
 
 const sha1 = require('../shared-utils/sha1')
@@ -716,6 +717,10 @@ chrome.webRequest.onErrorOccurred.addListener(e => {
         }
     }
 }, { urls: ['<all_urls>'] })
+
+if (browser === 'moz') {
+    cspProtection.init()
+}
 
 module.exports = {
     onStartup: onStartup

--- a/shared/js/background/csp-blocking.es6.js
+++ b/shared/js/background/csp-blocking.es6.js
@@ -1,0 +1,21 @@
+
+function init () {
+    chrome.webRequest.onBeforeRequest.addListener((details) => {
+        try {
+            // parse requestBody as an ASCII string
+            const report = String.fromCharCode.apply(null, new Uint8Array(details.requestBody.raw[0].bytes))
+            if (report.indexOf('moz-extension://') !== -1) {
+                return { cancel: true }
+            }
+        } catch (e) {
+            console.warn('Unable to parse CSP report contents', details.url)
+        }
+    }, {
+        urls: ['<all_urls>'],
+        types: ['csp_report']
+    }, ['blocking', 'requestBody'])
+}
+
+module.exports = {
+    init
+}

--- a/shared/js/background/csp-blocking.es6.js
+++ b/shared/js/background/csp-blocking.es6.js
@@ -1,4 +1,3 @@
-
 function init () {
     chrome.webRequest.onBeforeRequest.addListener((details) => {
         try {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Scripts injected by extensions can be blocked by CSPs in Firefox. If a CSP `report-uri` is specified, the browser will report this, including the `moz-extension://` url to the injected script. On Firefox this is a unique identifier which is persistent for a browser, including in private browsing windows.

This PR blocks CSP reports which contain a moz-extension:// URL, preventing this identifier from being leaked.

## Steps to test this PR:

 1. Grab privacy-test-pages with this PR: https://github.com/duckduckgo/privacy-test-pages/pull/35
 2. Visit `/security/csp-report/index.html`
 3. There should be no reported leakages. In the network console one of the csp-reports should be blocked.
<img width="717" alt="Screenshot 2021-04-14 at 14 01 16" src="https://user-images.githubusercontent.com/248111/114706949-eec46380-9d29-11eb-946c-b6a9151da7be.png">

## Automated tests:

As this is Firefox-only, our integration test setup cannot test for this issue.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
