### PR TITLE
Allow IPs to be added to unprotected site list

### DIFF
--- a/shared/js/ui/models/whitelist.es6.js
+++ b/shared/js/ui/models/whitelist.es6.js
@@ -46,9 +46,10 @@ Whitelist.prototype = window.$.extend({},
             // But first, strip the 'www.' part, otherwise getSubDomain will include it
             // and whitelisting won't work for that site
             url = url ? url.replace('www.', '') : ''
+            const parsedDomain = tldts.parse(url)
             const localDomain = url.match(/^localhost(:[0-9]+)?$/i) ? 'localhost' : null
-            const subDomain = tldts.getSubdomain(url)
-            const domain = tldts.getDomain(url) || localDomain
+            const subDomain = parsedDomain.subdomain
+            const domain = localDomain || (parsedDomain.isIp ? parsedDomain.hostname : parsedDomain.domain)
             if (domain) {
                 const domainToWhitelist = subDomain ? subDomain + '.' + domain : domain
                 console.log(`whitelist: add ${domainToWhitelist}`)

--- a/unit-test/ui/models/whitelist.es6.js
+++ b/unit-test/ui/models/whitelist.es6.js
@@ -29,6 +29,11 @@ const domainTestCases = [
         valid: false
     },
     {
+        url: '127.0.0.1',
+        whitelistedDomain: '127.0.0.1',
+        valid: true
+    },
+    {
         url: 'localhost',
         whitelistedDomain: 'localhost',
         valid: true


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

The domain parsing in the UI for adding sites to the unprotected site list was treating IPs as invalid inputs (see #571). This PR fixes that issue.


## Steps to test this PR:
 1. Open the popup and click 'unprotected sites'
 2. At the bottom of the page, choose 'Add unprotected site' and type an IP address (e.g. `1.1.1.1`) and click 'Add'
 3. The IP should be added to the list.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
