### PR TITLE
🔒 Require version npm 6 so that the lockfileVersion is always 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "name": "duckduckgo-privacy-extension",
     "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.0.0",
+        "npm": "~6.14.12"
     },
     "repository": "duckduckgo/duckduckgo-privacy-extension",
     "scripts": {


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 

## Description:
Let's make `lockfileVersion: 1` stick!

## Steps to test this PR:
Make sure that you can `npm i` on your machine and build the extension.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
