### PR TITLE
Site of null in isFeatureBroken

### DIFF
--- a/shared/js/content-scope/protections.js
+++ b/shared/js/content-scope/protections.js
@@ -62,6 +62,7 @@ export async function updateProtections (args) {
     if (!shouldRun()) {
         return
     }
+    if(initArgs === null) return;
     const resolvedProtections = await Promise.all(protections)
     resolvedProtections.forEach(({ update, protectionName }) => {
         if (!isFeatureBroken(initArgs, protectionName) && update) {


### PR DESCRIPTION
This is a bugfix for #636 
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
I added a check for null before running `isFeatureBroken`-calls which expects a non-null value.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
