### PR TITLE
Allow postinstall page to be disabled by managed storage

### DIFF
--- a/browsers/chrome/managed-schema.json
+++ b/browsers/chrome/managed-schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "hasSeenPostInstall": {
+            "title": "Has the post install screen been shown to the user",
+            "description": "If set to true then no postinstall tab will be opened on start.",
+            "type": "boolean"
+        }
+    }
+}

--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -70,5 +70,8 @@
         "/img/logo-small.svg",
         "/public/css/autofill.css",
         "/public/font/*"
-    ]
+    ],
+    "storage": {
+        "managed_schema": "managed-schema.json"
+    }
 }

--- a/managed-storage.md
+++ b/managed-storage.md
@@ -1,0 +1,24 @@
+# Managed Storage
+
+The extension supports pre-configuration of certain options in managed environments. See documentation for [Firefox](https://extensionworkshop.com/documentation/enterprise/adding-policy-support-to-your-extension/#distributing-your-policy) and [Chrome](https://www.chromium.org/administrators/) on how to configure extension policies.
+
+The follow options can be configured via policy:
+ * `hasSeenPostInstall` (boolean) - if true the post install page will not be shown when the extension is launched for the first time.
+
+## Example
+
+Following instructions from [here](https://extensionworkshop.com/documentation/enterprise/adding-policy-support-to-your-extension/), the following policy would disable the post install page in a Firefox install:
+
+```json
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "jid1-ZAdIEUB7XOzOJw@jetpack": {
+          "hasSeenPostInstall": true
+        }
+      }
+    }
+  }
+}
+```

--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -22,7 +22,11 @@ const getFromStorage = (key, cb) => {
 }
 const getFromManagedStorage = (keys, cb) => {
     chrome.storage.managed.get(keys, (result) => {
-        cb(result)
+        if (!browser.runtime.lastError) {
+            cb(result)
+        } else {
+            console.warn('Managed storage not available.', browser.runtime.lastError)
+        }
     })
 }
 

--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -20,6 +20,11 @@ const getFromStorage = (key, cb) => {
         cb(result[key])
     })
 }
+const getFromManagedStorage = (keys, cb) => {
+    chrome.storage.managed.get(keys, (result) => {
+        cb(result)
+    })
+}
 
 const getExtensionId = () => {
     return chrome.runtime.id
@@ -76,5 +81,6 @@ module.exports = {
     getDDGTabUrls: getDDGTabUrls,
     setUninstallURL: setUninstallURL,
     getExtensionId: getExtensionId,
-    changeTabURL
+    changeTabURL,
+    getFromManagedStorage
 }

--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -22,11 +22,10 @@ const getFromStorage = (key, cb) => {
 }
 const getFromManagedStorage = (keys, cb) => {
     chrome.storage.managed.get(keys, (result) => {
-        if (!browser.runtime.lastError) {
-            cb(result)
-        } else {
+        if (browser.runtime.lastError) {
             console.warn('Managed storage not available.', browser.runtime.lastError)
         }
+        cb(result || {})
     })
 }
 

--- a/shared/js/background/chrome-wrapper.es6.js
+++ b/shared/js/background/chrome-wrapper.es6.js
@@ -22,7 +22,7 @@ const getFromStorage = (key, cb) => {
 }
 const getFromManagedStorage = (keys, cb) => {
     chrome.storage.managed.get(keys, (result) => {
-        if (browser.runtime.lastError) {
+        if (chrome.runtime.lastError) {
             console.warn('Managed storage not available.', browser.runtime.lastError)
         }
         cb(result || {})

--- a/shared/js/background/settings.es6.js
+++ b/shared/js/background/settings.es6.js
@@ -2,6 +2,10 @@ const defaultSettings = require('../../data/defaultSettings')
 const browserWrapper = require('./$BROWSER-wrapper.es6')
 
 /**
+ * Settings whose defaults can by managed by the system administrator
+ */
+const MANAGED_SETTINGS = ['hasSeenPostInstall']
+/**
  * Public api
  * Usage:
  * You can use promise callbacks to check readyness before getting and updating
@@ -15,11 +19,11 @@ const _ready = init().then(() => {
 })
 
 function init () {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         buildSettingsFromDefaults()
-        buildSettingsFromLocalStorage().then(() => {
-            resolve()
-        })
+        buildSettingsFromManagedStorage()
+            .then(buildSettingsFromLocalStorage)
+            .then(() => resolve())
     })
 }
 
@@ -32,6 +36,15 @@ function buildSettingsFromLocalStorage () {
         browserWrapper.getFromStorage(['settings'], function (results) {
             // copy over saved settings from storage
             if (!results) resolve()
+            settings = browserWrapper.mergeSavedSettings(settings, results)
+            resolve()
+        })
+    })
+}
+
+function buildSettingsFromManagedStorage () {
+    return new Promise((resolve) => {
+        browserWrapper.getFromManagedStorage(MANAGED_SETTINGS, (results) => {
             settings = browserWrapper.mergeSavedSettings(settings, results)
             resolve()
         })


### PR DESCRIPTION
## Description:

Allows some settings to be pre-configured by system administrators via extension managed storage. Initially this adds support for the `hasSeenPostInstall` which can be used to prevent the post install page being shown on new installs.

Following instructions from [here](https://extensionworkshop.com/documentation/enterprise/adding-policy-support-to-your-extension/), the following policy would disable the post install page:
```json
{
  "policies": {
    "3rdparty": {
      "Extensions": {
        "jid1-ZAdIEUB7XOzOJw@jetpack": {
          "hasSeenPostInstall": true
        }
      }
    }
  }
}
```

Fixes #567 and #519


## Steps to test this PR:

For Firefox:
 1. Put the above JSON into a file call `policies.json` and put it into the appropriate location for Firefox on your OS (e.g. on mac in (`Firefox.app/Contents/Resources/distribution`).
 2. Open Firefox on a new profile, open one tab to https://duckduckgo.com, then install the extension.
 3. Verify that no post install page is opened.