### PR TITLE
Ignore phaser text calculation to canvas randomisation

### DIFF
--- a/shared/js/content-scope/canvas.js
+++ b/shared/js/content-scope/canvas.js
@@ -24,12 +24,20 @@ export function modifyPixelData (imageData, domainKey, sessionKey) {
     // Create an array of only pixels that have data in them
     const d = imageData.data
     for (let i = 0; i < d.length; i += 4) {
-        // Ignore non blank pixels there is high chance compression ignores them
-        const sum = d[i] + d[i + 1] + d[i + 2] + d[i + 3]
-        if (sum !== 0) {
-            checkSum += sum
-            arr.push(i)
+        // Blank Blue and Green color
+        if (d[i + 1] === 0 && d[i + 2] === 0) {
+            // Ignore non blank pixels there is high chance compression ignores them
+            if (d[i] === 0 && d[i + 3] === 0) {
+                continue
+            }
+            // Ignore phaser background
+            if (d[i] === 255 && d[i + 3] === 255) {
+                continue
+            }
         }
+        // Add to the checksum the R,G,B,A values
+        checkSum += d[i] + d[i + 1] + d[i + 2] + d[i + 3]
+        arr.push(i)
     }
 
     const canvasKey = getDataKeySync(sessionKey, domainKey, checkSum)


### PR DESCRIPTION
Fixes #610

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

See #610.

I've ignored for now only 255,0,0,255 pixels and 0,0,0,0 which are a canvas default.
I would normally assign these variables but we are in a very hot path here.

## Steps to test this PR:

1. Visit: https://labs.phaser.io/edit.html?src=src/scenes/ui%20scene.js&v=3.53.1
2. See the score is in the wrong position (this might not be in a consistent place due to the random pixels)

After the fix is applied, the score text should be in the top left.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
