### PR TITLE
Add preferences button to firefox

### DIFF
--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -57,6 +57,9 @@
         "run_at": "document_idle"
       }
     ],
+    "options_ui": {
+        "page": "html/options.html"
+    },
     "permissions": [
         "contextMenus",
         "webRequest",


### PR DESCRIPTION
This change adds the preference button in about:addons and also embeds it in the extensions site:
<img width="1126" alt="screen shot 2018-04-29 at 4 21 57 pm" src="https://user-images.githubusercontent.com/5529410/39411129-7c14c23a-4bc9-11e8-8b85-618299b98bd0.png">
<img width="1015" alt="screen shot 2018-04-29 at 4 22 04 pm" src="https://user-images.githubusercontent.com/5529410/39411130-7c359fc8-4bc9-11e8-8690-ec4d58f69704.png">