### PR TITLE
Prevent polyfill side-effects from 1p cookie protection

### DIFF
--- a/shared/js/content-scope/cookie-protection.js
+++ b/shared/js/content-scope/cookie-protection.js
@@ -26,6 +26,9 @@ function applyCookieExpiryPolicy () {
     const loadPolicy = new Promise((resolve) => {
         loadedPolicyResolve = resolve
     })
+    // Create the then callback now - this ensures that Promise.prototype.then changes won't break
+    // this call.
+    const loadPolicyThen = loadPolicy.then.bind(loadPolicy)
     defineProperty(document, 'cookie', {
         configurable: true,
         set: (value) => {
@@ -45,7 +48,7 @@ function applyCookieExpiryPolicy () {
                 }, new Set())
 
                 // wait for config before doing same-site tests
-                loadPolicy.then(({ shouldBlock, tabRegisteredDomain, policy, isTrackerFrame }) => {
+                loadPolicyThen(({ shouldBlock, tabRegisteredDomain, policy, isTrackerFrame }) => {
                     if (!tabRegisteredDomain || !shouldBlock) {
                         // no site domain for this site to test against, abort
                         debug && console.log('[ddg-cookie-policy] policy disabled on this page')


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When we load a content-scope script on a page, after the first tick any global could be polluted or changed by other scripts in the page. This can break some of our protection implementations.

In the case of #680, the page loaded a polyfill which changed `Promise` and `Promise.prototype.then`. This then caused an issue when we subsequently called the polyfilled `Promise.then` with a native `Promise` instance.

The PR fixes this specific case by creating the `then` function during the script's first tick, where we are sure (are we?) that we have the native `Promise.prototype.then`.

## Steps to test this PR:
See #680 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
