### PR TITLE
Remove remote styling & fix comment issue on some sites

### DIFF
--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -5,6 +5,7 @@
     let siteInit = function () {}
     let fbIsEnabled = false
     let initData = {}
+    let runInit = false
     const parseCalls = []
     const popupName = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 12)
 
@@ -30,7 +31,7 @@
             window.FB = undefined
 
             window.fbAsyncInit = function () {
-                if (initData) {
+                if (runInit && initData) {
                     window.FB.init(initData)
                 }
                 siteInit()
@@ -40,6 +41,9 @@
             }
 
             const fbScript = document.createElement('script')
+            fbScript.setAttribute('crossorigin', 'anonymous')
+            fbScript.setAttribute('async', '')
+            fbScript.setAttribute('defer', '')
             fbScript.src = originalFBURL
             fbScript.onload = function () {
                 for (const node of parseCalls) {
@@ -48,6 +52,10 @@
             }
             document.head.appendChild(fbScript)
             fbIsEnabled = true
+        } else {
+            if (initData) {
+                window.FB.init(initData)
+            }
         }
     }
 
@@ -92,6 +100,7 @@
             init: function (obj) {
                 if (obj) {
                     initData = obj
+                    runInit = true
                     messageAddon({
                         'appID': obj.appId
                     })

--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -26,6 +26,19 @@
         dispatchEvent(event)
     }
 
+    /**
+     * When setting up the Facebook SDK, the site may define a function called window.fbAsyncInit.
+     * Once the SDK loads, it searches for and calls window.fbAsyncInit. However, some sites may
+     * not use this, and just call FB.init directly at some point (after ensuring that the script has loaded).
+     *
+     * Our surrogate (defined below in window.FB) captures calls made to init by page scripts. If at a
+     * later point we load the real sdk here, we then re-call init with whatever arguments the page passed in
+     * originally. The runInit param should be true when a page has called init directly.
+     * Because we put it in asyncInit, the flow will be something like:
+     *
+     * FB SDK loads -> SDK calls window.fbAsyncInit -> Our function calls window.FB.init (maybe) ->
+     * our function calls original fbAsyncInit (if it existed)
+     */
     function enableFacebookSDK () {
         if (!fbIsEnabled) {
             window.FB = undefined

--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -390,10 +390,7 @@
         // collects the style from the original element & any specified in config for the element
         // type and returns a CSS string.
         getStyle () {
-            let styleString = this.clickAction.style
-            if (styleString[styleString.length - 1] !== ';') {
-                styleString += ';'
-            }
+            let styleString = 'border: none;'
 
             if (this.clickAction.styleDataAttributes) {
                 // Copy elements from the original div into style attributes as directed by config
@@ -494,8 +491,8 @@
                     // If we allow everything when this element is clicked,
                     // notify surrogate to enable SDK and replace original element.
                     if (this.clickAction.type === 'allowFull') {
-                        window.dispatchEvent(new CustomEvent(`Load${this.entity}SDK`))
                         parent.replaceChild(originalElement, replacementElement)
+                        window.dispatchEvent(new CustomEvent(`Load${this.entity}SDK`))
                         return
                     }
                     // Create a container for the new FB element


### PR DESCRIPTION
This removes the usage of the style data in remote config, and also fixes an issue where some comment sections don't load after enabling (due to a FB update)