### PR TITLE
Release: 2021.6.2

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2021.5.10",
+    "version": "2021.6.2",
     "icons": {
         "16": "img/icon_16.png",
         "48": "img/icon_48.png",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
               "strict_min_version": "57.0"
         }
     },
-    "version": "2021.5.10",
+    "version": "2021.6.2",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",


### PR DESCRIPTION
## Release: 2021.6.2

- PR: Prevent polyfill side-effects from 1p cookie protection
- Add getAll linker object to ga surrogate
- PR: Wrap floc code in try
- GPC DOM API not injected into frames
- Storage test intermittent failures
- Privacy Grade tests failing
- Update logo in extensions
- PR: Same domain trackers are sometimes undefined if they haven't been see… #659
- PR: Add preferences button to firefox
- PR: Update chrome store description
- PR: Remove selenium tests
- PR: Change chrome.extension.getURL to chrome.runtime.getURL
- PR: Add Canvas unit test
- PR: Ignore phaser text calculation to canvas randomisation
- PR: Update autofill version
- PR: Add www. back into safelisting
- Site Breakage: reuters.com (2021-05-13)
- PR #673: Full Click to load release
- PR: Allow postinstall page to be disabled by managed storage
- PR: Update autofill version and bundling
- PR: Handle www. differently only for broken sites
- PR: Remove remote styling & fix comment issue on some sites