### PR TITLE
DRAFT: Attempt 2 to fix ctl integration tests

### DIFF
--- a/integration-test/background/click-to-load-integration-tests.js
+++ b/integration-test/background/click-to-load-integration-tests.js
@@ -39,11 +39,12 @@ describe('Test Click To Load', () => {
         await page.waitForTimeout(4000)
         const fbRequestData = await page.evaluate(() => {
             return {
-                requests: document.getElementById('facebook_call_count').innerHTML
+                requests: document.getElementById('facebook_call_count').innerHTML,
+                expectedCalls: document.getElementById('facebook_iFrames').innerHTML
             }
         })
 
-        expect(Number(fbRequestData.requests)).toEqual(0)
+        expect(Number(fbRequestData.requests)).toBeLessThanOrEqual(Number(fbRequestData.expectedCalls))
 
         try {
             await page.close()
@@ -62,17 +63,23 @@ describe('Test Click To Load', () => {
         // give it little time just to be sure (facebook widgets can take time to load)
         await page.waitForTimeout(4000)
 
-        // click image element to trigger click to load
-        page.click('div > div > div > button')
-
-        await page.waitForTimeout(5000) // FB elements can take a while to load...
-
-        const fbRequestData = await page.evaluate(() => {
+        const fbRequestDataBeforeClick = await page.evaluate(() => {
             return {
                 requests: document.getElementById('facebook_call_count').innerHTML
             }
         })
 
-        expect(Number(fbRequestData.requests)).toBeGreaterThanOrEqual(1)
+        // click image element to trigger click to load
+        page.click('div > div > div > button')
+
+        await page.waitForTimeout(5000) // FB elements can take a while to load...
+
+        const fbRequestDataAfterClick = await page.evaluate(() => {
+            return {
+                requests: document.getElementById('facebook_call_count').innerHTML
+            }
+        })
+
+        expect(Number(fbRequestDataAfterClick.requests)).toBeGreaterThan(Number(fbRequestDataBeforeClick.requests))
     })
 })

--- a/integration-test/background/click-to-load-integration-tests.js
+++ b/integration-test/background/click-to-load-integration-tests.js
@@ -72,7 +72,7 @@ describe('Test Click To Load', () => {
         // click image element to trigger click to load
         page.click('div > div > div > button')
 
-        await page.waitForTimeout(5000) // FB elements can take a while to load...
+        await page.waitForTimeout(6000) // FB elements can take a while to load...
 
         const fbRequestDataAfterClick = await page.evaluate(() => {
             return {


### PR DESCRIPTION
This updates how the Click to Load integration tests determine whether Facebook requests are loading. Instead of assuming "0" requests will be successful, it looks at requests that are expected (iFrame requests are generally sent regardless, and blocked by the extension).

It should now consistently pass if things are working right with CTL.