### PR TITLE
Make cookie properties writable

### DIFF
--- a/shared/js/content-scope/cookie-protection.js
+++ b/shared/js/content-scope/cookie-protection.js
@@ -4,7 +4,8 @@ import { defineProperty } from './utils'
 function blockCookies () {
     // disable setting cookies
     defineProperty(document, 'cookie', {
-        configurable: false,
+        enumerable: true,
+        writable: true,
         set: function (value) { },
         get: () => ''
     })
@@ -30,7 +31,9 @@ function applyCookieExpiryPolicy () {
     // this call.
     const loadPolicyThen = loadPolicy.then.bind(loadPolicy)
     defineProperty(document, 'cookie', {
+        enumerable: true,
         configurable: true,
+        writable: true,
         set: (value) => {
             // call the native document.cookie implementation. This will set the cookie immediately
             // if the value is valid. We will override this set later if the policy dictates that


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kdzwinel 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:


This change fixes the issue with hangouts writing to the `document.cookie` with an assignment operator. This restores the functionality to pre content script resilience where we using __defineGetter__ and setter.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
