### PR TITLE
Update autofill to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3183,8 +3183,8 @@
             }
         },
         "@duckduckgo/autofill": {
-            "version": "git+https://github.com/duckduckgo/duckduckgo-autofill.git#3f8b4d63731d0f4417dca569de69acc39a67f641",
-            "from": "git+https://github.com/duckduckgo/duckduckgo-autofill.git#3f8b4d63731d0f4417dca569de69acc39a67f641"
+            "version": "git+https://github.com/duckduckgo/duckduckgo-autofill.git#2d6e7a397d602653d1f1eb024d236ebb7974e30e",
+            "from": "git+https://github.com/duckduckgo/duckduckgo-autofill.git#3.0.1"
         },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "timekeeper": "^2.1.1"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "https://github.com/duckduckgo/duckduckgo-autofill.git#3.0.0",
+        "@duckduckgo/autofill": "https://github.com/duckduckgo/duckduckgo-autofill.git#3.0.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "1.0.3",
         "bel": "6.0.0",


### PR DESCRIPTION
## Description:
Update autofill to 3.0.1:

- Fix breakages on other platforms 🔧
- Remove autofill from signup page 🦆