### PR TITLE
Fixes for PRNG

### DIFF
--- a/shared/js/content-scope/utils.js
+++ b/shared/js/content-scope/utils.js
@@ -66,7 +66,8 @@ export function shouldExemptMethod (type) {
 
 // Iterate through the key, passing an item index and a byte to be modified
 export function iterateDataKey (key, callback) {
-    let item = key.charCodeAt(0)
+    // Seed the PRNG with 32-bits of entropy from the key
+    let item = parseInt(key.substring(0, 8))
     for (const i in key) {
         let byte = key.charCodeAt(i)
         for (let j = 8; j >= 0; j--) {

--- a/shared/js/content-scope/utils.js
+++ b/shared/js/content-scope/utils.js
@@ -7,9 +7,14 @@ export function getDataKeySync (sessionKey, domainKey, inputData) {
     return sjcl.codec.hex.fromBits(hmac.encrypt(inputData))
 }
 
-// linear feedback shift register to find a random approximation
-export function nextRandom (v) {
-    return Math.abs((v >> 1) | (((v << 62) ^ (v << 61)) & (~(~0 << 63) << 62)))
+// 32-bit XOR shift. Approximates randomness with high performance.
+// https://stackoverflow.com/questions/65661856/how-to-do-an-8-bit-16-bit-and-32-bit-linear-feedback-shift-register-prng-in-ja
+export function nextRandom(x) {
+    x |= x == 0; // if x == 0, set x = 1 instead
+    x ^= (x & 0x0007ffff) << 13;
+    x ^= x >> 17;
+    x ^= (x & 0x07ffffff) << 5;
+    return x & 0xffffffff;
 }
 
 const exemptionLists = {}


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
* Change 64-bit LFSR PRNG to a 32-bit XOR-shift PRNG due to JS integer width limitations.
* Seed PRNG with 32-bits of entropy.

Partially addresses discussion in #736.


## Steps to test this PR:
1. Collect perturbed indexes from a `AudioBuffer`s of a constant size (eg, length=64) using multiple different `audioKeys` (eg, by reloading the extension to receive a new session key). Conduct this data with and without the patch applied.
2. Ensure that more than 16 sets of indexes are collected in the patched version. (This process is probabilistic and therefore will likely require more than 16 iterations to collect.)
3. Observe improvements in the perturbation ratio as described in #736. Observe that the sample code for extracting the PRNG seed no longer works in the patched version.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
