### PR TITLE
Allow dashes in ddg subdomain regex

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -19,7 +19,7 @@ let dev = false
 const ATB = (() => {
     // regex to match ddg urls to add atb params to.
     // Matching subdomains, searches, and newsletter page
-    const regExpAboutPage = /^https?:\/\/(\w+\.)?duckduckgo\.com\/(\?.*|about#newsletter)/
+    const regExpAboutPage = /^https?:\/\/([\w-]+\.)?duckduckgo\.com\/(\?.*|about#newsletter)/
     const ddgAtbURL = 'https://duckduckgo.com/atb.js?'
 
     return {

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -72,7 +72,8 @@ describe('atb.redirectURL()', () => {
         { url: 'https://beta.duckduckgo.com/share/spice/forecast/1347/forecast.css', rewrite: false },
         { url: 'http://beta.duckduckgo.com/?q=something', rewrite: true },
         { url: 'https://beta.duckduckgo.com/?q=something', rewrite: true },
-        { url: 'https://beta.duckduckgo.com/?q=something&atb=v70-1', rewrite: false }
+        { url: 'https://beta.duckduckgo.com/?q=something&atb=v70-1', rewrite: false },
+        { url: 'https://dev-testing.duckduckgo.com/?q=something', rewrite: true }
     ]
 
     beforeEach(() => {


### PR DESCRIPTION
**Reviewer: TBD**

## Description:
Adds support for DDG subdomains that include dashes in ATB accepted URL regex.
- e.g https://dev-machine.duckduckgo.com


## Steps to test this PR:
- Build Chrome/FF dev build
- Install extension
- Visit a DDG subdomain that includes a dash (`-`)
    -  [ ] Ensure the `atb=` param is appended to the URL

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
