### PR TITLE
Support new configurable features in debugger panel

### DIFF
--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -28,6 +28,14 @@
       padding: 10px;
     }
 
+    #protections {
+      padding-top: 0px;
+    }
+
+    #protections > button {
+      margin: 2px;
+    }
+
     .block {
       background-color: #DE5833;
     }
@@ -137,6 +145,8 @@
       <option value="next">Next</option>
       <option value="beta">Beta</option>
     </select>
+  </div>
+  <div class="header" id="protections">
   </div>
   <div id="table-filter">
     Display options:


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

#728 changed the set of features that can be toggled on a global and per-site basis. This PR updates the debugger panel to dynamically pull in the set of configurable features from the config, so it will stay up-to-date to future changes to features.

While we can present feature toggles for all features, the following don't yet support site-specific exceptions:
 * `contentBlocking` - currently broken
 * `trackingCookies3p` - only supports 3rd party exceptions
 * `clickToPlay` - only supports global disable
 * `gpc` - only works for JS API, header is still sent.

These should be fixed by #749 . 

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
