### PR TITLE
Fix spacing in feedback.html

### DIFF
--- a/shared/scss/base/_forms.scss
+++ b/shared/scss/base/_forms.scss
@@ -15,6 +15,7 @@
 
 .frm__label__chk {
     margin-top: 0.1em;
+    margin-right: .5em;
     display: inline-block;
     vertical-align: top;
 }


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 

## Description:
A tiny spacing issue in feedback.html:

![CleanShot 2021-07-22 at 15 35 31@2x](https://user-images.githubusercontent.com/1828326/126647942-b413f461-08fe-402e-966b-bd515a073f65.jpg)

## Steps to test this PR:
- In the popup, click on the cog
- Click on Share Feedback
- The checkbox should have the appropriate spacing