### PR TITLE
Disable click to load tests due to perma failures

### DIFF
--- a/integration-test/background/click-to-load-integration-tests.js
+++ b/integration-test/background/click-to-load-integration-tests.js
@@ -4,7 +4,8 @@ const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/click
 let browser
 let bgPage
 
-describe('Test Click To Load', () => {
+// DISABLED due to perma failing
+xdescribe('Test Click To Load', () => {
     beforeAll(async () => {
         ({ browser, bgPage } = await harness.setup())
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:


These tests are essentially being ignored already as we manually check every time a test fails and merge if these are the reason of failure. This is causing overhead to a merge and in reality we should be fixing the test.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
