### PR TITLE
[WIP] Update email protection in settings

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -44,22 +44,24 @@ const fetchAlias = () => {
 }
 
 const MENU_ITEM_ID = 'ddg-autofill-context-menu-item'
-// Create the contextual menu hidden by default
-chrome.contextMenus.create({
-    id: MENU_ITEM_ID,
-    title: 'Use Duck Address',
-    contexts: ['editable'],
-    visible: false,
-    onclick: (info, tab) => {
-        const userData = getSetting('userData')
-        if (userData.nextAlias) {
-            chrome.tabs.sendMessage(tab.id, {
-                type: 'contextualAutofill',
-                alias: userData.nextAlias
-            })
+const createAutofillContextMenuItem = () => {
+    // Create the contextual menu hidden by default
+    chrome.contextMenus.create({
+        id: MENU_ITEM_ID,
+        title: 'Use Duck Address',
+        contexts: ['editable'],
+        visible: false,
+        onclick: (info, tab) => {
+            const userData = getSetting('userData')
+            if (userData.nextAlias) {
+                chrome.tabs.sendMessage(tab.id, {
+                    type: 'contextualAutofill',
+                    alias: userData.nextAlias
+                })
+            }
         }
-    }
-})
+    })
+}
 
 const showContextMenuAction = () => chrome.contextMenus.update(MENU_ITEM_ID, { visible: true })
 
@@ -97,6 +99,7 @@ const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
 module.exports = {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
+    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -59,6 +59,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
             })
         })
     }
+    createAutofillContextMenuItem()
 })
 
 /**
@@ -304,6 +305,7 @@ const browserWrapper = require('./wrapper.es6')
 const {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
+    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,

--- a/shared/js/ui/models/user-data.es6.js
+++ b/shared/js/ui/models/user-data.es6.js
@@ -13,7 +13,7 @@ UserData.prototype = window.$.extend({},
 
         logout () {
             this.fetch({ logout: true })
-                .then(() => this.set('loggingOut', true))
+                .then(() => this.set('userName', null))
         },
 
         setUserDataFromSettings: function () {

--- a/shared/js/ui/templates/user-data.es6.js
+++ b/shared/js/ui/templates/user-data.es6.js
@@ -2,26 +2,26 @@ const bel = require('bel')
 const { formatAddress } = require('../../background/email-utils.es6')
 
 module.exports = function () {
-    // We don't render anything if the user is not set
-    if (!this.model.userName) return bel`<div></div>`
-
     return bel`<section class="options-content__user-data divider-bottom">
-        <h2 class="menu-title">Email Autofill</h2>
+        <h2 class="menu-title">Email Protection</h2>
         ${renderUserDataContent(this.model)}
     </section>`
 }
 
 function renderUserDataContent (model) {
-    return model.loggingOut
+    return (!model.userName)
         ? bel`<div>
-                <p class="menu-paragraph">Disabled successfully.</p>
+                <p class="menu-paragraph">Off</p>
+                <p class="options-info">
+                    <a href="https://duckduckgo.com/email/enable-autofill">Add Duck Address</a>
+                </p>
             </div>`
         : bel`<div>
                 <p class="menu-paragraph">
-                    Enabled for <strong class="js-userdata-container">${formatAddress(model.userName)}</strong>
+                    <span class="js-userdata-container">${formatAddress(model.userName)}</span>
                 </p>
                 <p class="options-info js-userdata-logout">
-                    <a href="#">Disable</a>
+                    <a href="#">Remove from browser</a>
                 </p>
             </div>`
 }


### PR DESCRIPTION
**Reviewer:** 

## Description:
Updates the settings to show info on the email protection beta.


## Steps to test this PR:
- Go to settings
- If you're on Chrome, check that there's no error in the console
- Regardless of your email state, there should be an Email Protection section
  - If Email Protection is enabled, you can disable it
  - If it's not enabled, you should have a link to the web app login