### PR TITLE
Prevent error in settings page on Chrome

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -44,22 +44,24 @@ const fetchAlias = () => {
 }
 
 const MENU_ITEM_ID = 'ddg-autofill-context-menu-item'
-// Create the contextual menu hidden by default
-chrome.contextMenus.create({
-    id: MENU_ITEM_ID,
-    title: 'Use Duck Address',
-    contexts: ['editable'],
-    visible: false,
-    onclick: (info, tab) => {
-        const userData = getSetting('userData')
-        if (userData.nextAlias) {
-            chrome.tabs.sendMessage(tab.id, {
-                type: 'contextualAutofill',
-                alias: userData.nextAlias
-            })
+const createAutofillContextMenuItem = () => {
+    // Create the contextual menu hidden by default
+    chrome.contextMenus.create({
+        id: MENU_ITEM_ID,
+        title: 'Use Duck Address',
+        contexts: ['editable'],
+        visible: false,
+        onclick: (info, tab) => {
+            const userData = getSetting('userData')
+            if (userData.nextAlias) {
+                chrome.tabs.sendMessage(tab.id, {
+                    type: 'contextualAutofill',
+                    alias: userData.nextAlias
+                })
+            }
         }
-    }
-})
+    })
+}
 
 const showContextMenuAction = () => chrome.contextMenus.update(MENU_ITEM_ID, { visible: true })
 
@@ -97,6 +99,7 @@ const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
 module.exports = {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
+    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -59,6 +59,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
             })
         })
     }
+    createAutofillContextMenuItem()
 })
 
 /**
@@ -304,6 +305,7 @@ const browserWrapper = require('./wrapper.es6')
 const {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
+    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 

## Description:
In the current version, there is an error in the console when visiting the settings page. For some reason, the background page tries to create a new context menu item with the same id. This change moves the creation of the context menu item to the `onInstalled` event, thus fixing the issue. This is not happening in Firefox.


## Steps to test this PR:
1. On Chrome, go to settings
2. There should be no error in the console