### PR TITLE
Add config submodule as preloaded config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/chrome
 build/test
 test/background.js
 shared/js/content-scope/sjcl.js
+shared/data/etags.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "shared/tracker-surrogates"]
 	path = shared/tracker-surrogates
 	url = https://github.com/duckduckgo/tracker-surrogates.git
+[submodule "shared/privacy-configuration"]
+	path = shared/privacy-configuration
+	url = https://github.com/duckduckgo/privacy-configuration.git

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ web-resources:
 	mkdir -p build/$(browser)/$(type)/web_accessible_resources
 	cp shared/data/web_accessible_resources/* build/$(browser)/$(type)/web_accessible_resources/
 	cp shared/tracker-surrogates/surrogates/*.js build/$(browser)/$(type)/web_accessible_resources/
+	mkdir -p build/$(browser)/$(type)/data
 	node scripts/generateListOfSurrogates.js -i build/$(browser)/$(type)/web_accessible_resources/ >> build/$(browser)/$(type)/data/surrogates.txt
 
 moveout: $(ITEMS)

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "license": "Apache-2.0",
     "repository": "duckduckgo/duckduckgo-privacy-extension",
     "scripts": {
-        "postinstall": "git submodule update --init --recursive && npm run copy-sjcl && export PATH='$PATH:$PWD/node_modules/chromedriver/bin'",
+        "postinstall": "git submodule update --init --recursive && npm run generate-etags && npm run copy-sjcl && export PATH='$PATH:$PWD/node_modules/chromedriver/bin'",
         "copy-sjcl": "cd node_modules/sjcl/ && ./configure --compress=none --without-all --with-hmac --with-codecHex && make && cp sjcl.js ../../shared/js/content-scope/",
+        "generate-etags": "node scripts/generateEtags.js > shared/data/etags.json",
         "build": "echo 'Try npm run release-firefox or npm run release-chrome instead' && exit 0",
         "dev": "echo 'Try npm run dev-firefox or npm run dev-chrome instead' && exit 0",
         "release": "grunt build && node scripts/httpsWhitelist.js",

--- a/scripts/generateEtags.js
+++ b/scripts/generateEtags.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+const crypto = require('crypto');
+const data = fs.readFileSync('shared/privacy-configuration/generated/extension-config.json', 'utf8')
+const hash = crypto.createHash('md5').update(data).digest('hex');
+const outputHash = `W/"${hash}"`;
+const outputConfig = {
+    'config-etag': outputHash
+};
+console.log(JSON.stringify(outputConfig))

--- a/shared/js/background/settings.es6.js
+++ b/shared/js/background/settings.es6.js
@@ -1,4 +1,5 @@
 const defaultSettings = require('../../data/defaultSettings')
+const etags = require('../../data/etags.json')
 const browserWrapper = require('./wrapper.es6')
 
 /**
@@ -53,7 +54,7 @@ function buildSettingsFromManagedStorage () {
 
 function buildSettingsFromDefaults () {
     // initial settings are a copy of default settings
-    settings = Object.assign({}, defaultSettings)
+    settings = Object.assign({}, defaultSettings, etags)
 }
 
 function syncSettingTolocalStorage () {

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -3,6 +3,7 @@ const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings.es6')
 const browserWrapper = require('./../wrapper.es6')
+const extensionConfig = require('./../../../privacy-configuration/generated/extension-config.json')
 
 class TDSStorage {
     constructor () {
@@ -12,88 +13,9 @@ class TDSStorage {
         })
         this.tds = { entities: {}, trackers: {}, domains: {}, cnames: {} }
         this.surrogates = ''
-        this.config = {
-            features: {
-                contentBlocking: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                trackerAllowlist: {
-                    state: 'enabled'
-                },
-                trackingCookies1p: {
-                    state: 'enabled',
-                    settings: {
-                        firstPartyTrackerCookiePolicy: {
-                            threshold: 86400,
-                            maxAge: 86400
-                        }
-                    },
-                    exceptions: []
-                },
-                trackingCookies3p: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                clickToPlay: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingCanvas: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingAudio: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingTemporaryStorage: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                referrer: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingBattery: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingScreenSize: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                fingerprintingHardware: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                floc: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                gpc: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                autofill: {
-                    state: 'enabled',
-                    exceptions: []
-                },
-                userAgentRotation: {
-                    state: 'disabled',
-                    settings: {
-                        agentExcludePatterns: [
-                            {
-                                agent: 'Brave Chrome',
-                                reason: 'Uncommon UA'
-                            }
-                        ]
-                    },
-                    exceptions: []
-                }
-            },
-            unprotectedTemporary: []
-        }
+        this.ClickToLoadConfig = {}
+        this.config = extensionConfig
+        this.storeInLocalDB('config', extensionConfig)
 
         this.removeLegacyLists()
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kdzwinel 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

This replaces this hard coded config that is already outdated and will be forgotten about.

It also adds in a pre-generated etags config file which prevents the extension needing to load the file output from the server if it matches the bundled version saving us start up time and server costs.

## Steps to test this PR:

Checking the e-tag works:
1. Load the extension with web ext
2. Debug the extension in about:debugging#/runtime/this-firefox
3. Open the inspector
4. Clear the extension storage in the inspector
5. Reload the extension
6. Ensure that the network tab load for the `extension-config.json` is a 304

Ensure there are no "TDS: data update failed" in the console.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
