### PR TITLE
Correctly calculate partyness for about:blank frames

### DIFF
--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -637,7 +637,7 @@ function getArgumentsObject (tabId, sender, documentUrl) {
         return null
     }
     // Clone site so we don't retain any site changes
-    const site = Object.assign({}, tab?.site || {})
+    const site = Object.assign({}, tab.site || {})
     const referrer = tab?.referrer || ''
 
     const firstPartyCookiePolicy = utils.getFeatureSettings('trackingCookies1p').firstPartyTrackerCookiePolicy || {
@@ -656,7 +656,7 @@ function getArgumentsObject (tabId, sender, documentUrl) {
         site.brokenFeatures = site.brokenFeatures.concat(utils.getBrokenFeaturesAboutBlank(tab.url))
     }
 
-    if (tab?.site.isFeatureEnabled('trackingCookies3p') || tab?.site.isFeatureEnabled('trackingCookies1p')) {
+    if (tab.site.isFeatureEnabled('trackingCookies3p') || tab.site.isFeatureEnabled('trackingCookies1p')) {
         // determine the register domain of the sending tab
         const tabUrl = tab ? tab.url : sender.tab.url
         const parsed = tldts.parse(tabUrl)

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -656,6 +656,7 @@ function getArgumentsObject (tabId, sender, documentUrl) {
         site.brokenFeatures = site.brokenFeatures.concat(utils.getBrokenFeaturesAboutBlank(tab.url))
     }
 
+    // Extra contextual data required for 1p and 3p cookie protection - only send if at least one is enabled here
     if (tab.site.isFeatureEnabled('trackingCookies3p') || tab.site.isFeatureEnabled('trackingCookies1p')) {
         // determine the register domain of the sending tab
         const parsed = tldts.parse(tab.url)

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -658,15 +658,14 @@ function getArgumentsObject (tabId, sender, documentUrl) {
 
     if (tab.site.isFeatureEnabled('trackingCookies3p') || tab.site.isFeatureEnabled('trackingCookies1p')) {
         // determine the register domain of the sending tab
-        const tabUrl = tab ? tab.url : sender.tab.url
-        const parsed = tldts.parse(tabUrl)
+        const parsed = tldts.parse(tab.url)
         cookie.tabRegisteredDomain = parsed.domain === null ? parsed.hostname : parsed.domain
 
         if (documentUrl && trackerutils.isTracker(documentUrl) && sender.frameId !== 0) {
             cookie.isTrackerFrame = true
         }
 
-        cookie.isThirdParty = !trackerutils.isFirstPartyByEntity(documentUrl, tabUrl)
+        cookie.isThirdParty = !trackerutils.isFirstPartyByEntity(documentUrl, tab.url)
         cookie.shouldBlock = !utils.isCookieExcluded(documentUrl)
     }
     return {

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -656,7 +656,7 @@ function getArgumentsObject (tabId, sender, documentUrl) {
         site.brokenFeatures = site.brokenFeatures.concat(utils.getBrokenFeaturesAboutBlank(tab.url))
     }
 
-    if (tab?.site.isFeatureEnabled('trackingCookies3p')) {
+    if (tab?.site.isFeatureEnabled('trackingCookies3p') || tab?.site.isFeatureEnabled('trackingCookies1p')) {
         // determine the register domain of the sending tab
         const tabUrl = tab ? tab.url : sender.tab.url
         const parsed = tldts.parse(tabUrl)
@@ -666,8 +666,8 @@ function getArgumentsObject (tabId, sender, documentUrl) {
             cookie.isTrackerFrame = true
         }
 
-        cookie.isThirdParty = !trackerutils.isFirstPartyByEntity(sender.url, sender.tab.url)
-        cookie.shouldBlock = !utils.isCookieExcluded(sender.url)
+        cookie.isThirdParty = !trackerutils.isFirstPartyByEntity(documentUrl, tabUrl)
+        cookie.shouldBlock = !utils.isCookieExcluded(documentUrl)
     }
     return {
         debug: devtools.isActive(tabId),


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

For third-party cookie blocking we block the cookie getter/setter for iframes where the iframe origin is a tracker domain, which is owned by a different entity to the top-level frame domain.

In order to do this partyness check, we need the document url of the iframe, and the URL of the tab the frame is in. For the former we were using `sender.url`, which in Firefox can be `about:blank` in some circumstances. When that case happens, the check would always return that `about:blank` was third-party to whatever the tab URL was. Because the check for whether the frame document URL was a tracker used the `documentUrl` parameter sent by the content script (which would not be `about:blank`), it was possible to block cookies in a iframe from a tracker domain when it was embedded on a page of the same origin.

This PR fixes the issue by using `documentUrl` for the third party check, which should always correctly reflect the iframe document's URL.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
