### PR TITLE
Resolve extension startup errors

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -69,9 +69,11 @@ class Site {
      */
     setListStatusFromGlobal () {
         const globalLists = ['allowlisted', 'allowlistOptIn', 'denylisted']
-        globalLists.forEach((name) => {
-            const list = settings.getSetting(name) || {}
-            this.setListValue(name, list[this.domain])
+        settings.ready().then(() => {
+            globalLists.forEach((name) => {
+                const list = settings.getSetting(name) || {}
+                this.setListValue(name, list[this.domain])
+            })
         })
     }
 

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -629,7 +629,7 @@ chrome.runtime.onMessage.addListener((req, sender, res) => {
 let sessionKey = getHash()
 
 function getArgumentsObject (tabId, sender, documentUrl) {
-    const tab = tabManager.get({ tabId })
+    const tab = tabManager.createOrUpdateTab(tabId, sender.tab)
     if (!tab) {
         return null
     }

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -669,10 +669,11 @@ function getArgumentsObject (tabId, sender, documentUrl) {
         cookie.isThirdParty = !trackerutils.isFirstPartyByEntity(documentUrl, tab.url)
         cookie.shouldBlock = !utils.isCookieExcluded(documentUrl)
     }
+    const globalPrivacyControlValue = settings.isReady && settings.getSetting('GPC')
     return {
         debug: devtools.isActive(tabId),
         cookie,
-        globalPrivacyControlValue: settings.getSetting('GPC'),
+        globalPrivacyControlValue,
         stringExemptionLists: utils.getBrokenScriptLists(),
         sessionKey,
         site,

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -1,7 +1,6 @@
 const tldts = require('tldts')
 
 const utils = require('./utils.es6')
-const trackers = require('./trackers.es6')
 const trackerutils = require('./tracker-utils')
 const https = require('./https.es6')
 const Companies = require('./companies.es6')
@@ -93,7 +92,7 @@ function handleRequest (requestData) {
          * If request is a tracker, cancel the request
          */
 
-        let tracker = trackers.getTrackerData(requestData.url, thisTab.site.url, requestData)
+        let tracker = trackerutils.getTrackerData(requestData.url, thisTab.site.url, requestData)
         /**
          * Click to Load Blocking
          * If it isn't in the tracker list, check the clickToLoad block list

--- a/shared/js/background/settings.es6.js
+++ b/shared/js/background/settings.es6.js
@@ -139,9 +139,10 @@ function logSettings () {
 }
 
 module.exports = {
-    getSetting: getSetting,
-    updateSetting: updateSetting,
-    removeSetting: removeSetting,
-    logSettings: logSettings,
-    ready: ready
+    isReady,
+    getSetting,
+    updateSetting,
+    removeSetting,
+    logSettings,
+    ready
 }

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -73,7 +73,7 @@ class TabManager {
     createOrUpdateTab (id, info) {
         if (!tabManager.get({ tabId: id })) {
             info.id = id
-            tabManager.create(info)
+            return tabManager.create(info)
         } else {
             const tab = tabManager.get({ tabId: id })
             if (tab && info.status) {
@@ -107,6 +107,7 @@ class TabManager {
                     if (tab.statusCode === 200) tab.endStopwatch()
                 }
             }
+            return tab;
         }
     }
 

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -107,7 +107,7 @@ class TabManager {
                     if (tab.statusCode === 200) tab.endStopwatch()
                 }
             }
-            return tab;
+            return tab
         }
     }
 

--- a/shared/js/background/tracker-utils.js
+++ b/shared/js/background/tracker-utils.js
@@ -5,8 +5,22 @@ const tldts = require('tldts')
 const tdsStorage = require('./storage/tds.es6')
 const settings = require('./settings.es6')
 
+function hasTrackerListLoaded () {
+    return !!trackers.trackerList
+}
+
+function getTrackerData (...args) {
+    if (!hasTrackerListLoaded()) {
+        return null
+    }
+    return trackers.getTrackerData(...args)
+}
+
 // Determine if two URL's belong to the same entity.
 function isSameEntity (url1, url2) {
+    if (!hasTrackerListLoaded()) {
+        return false
+    }
     try {
         const domain1 = tldts.parse(url1).domain
         const domain2 = tldts.parse(url2).domain
@@ -24,6 +38,9 @@ function isSameEntity (url1, url2) {
 
 // return true if URL is in our tracker list
 function isTracker (url) {
+    if (!hasTrackerListLoaded()) {
+        return false
+    }
     const data = {
         urlToCheckSplit: utils.extractHostFromURL(url).split('.')
     }
@@ -181,6 +198,9 @@ function truncateReferrer (referrer, target) {
  * @returns {boolean}
  */
 function isFirstPartyByEntity (trackerUrl, siteUrl) {
+    if (!hasTrackerListLoaded()) {
+        return false
+    }
     const cnameResolution = trackers.resolveCname(trackerUrl)
     trackerUrl = cnameResolution.finalURL
 
@@ -197,14 +217,15 @@ function isFirstPartyByEntity (trackerUrl, siteUrl) {
 }
 
 module.exports = {
-    isSameEntity: isSameEntity,
-    isTracker: isTracker,
-    truncateReferrer: truncateReferrer,
-    getSocialTracker: getSocialTracker,
-    socialTrackerIsAllowedByUser: socialTrackerIsAllowedByUser,
-    shouldBlockSocialNetwork: shouldBlockSocialNetwork,
-    getDomainsToExludeByNetwork: getDomainsToExludeByNetwork,
-    getXraySurrogate: getXraySurrogate,
-    allowSocialLogin: allowSocialLogin,
-    isFirstPartyByEntity: isFirstPartyByEntity
+    getTrackerData,
+    isSameEntity,
+    isTracker,
+    truncateReferrer,
+    getSocialTracker,
+    socialTrackerIsAllowedByUser,
+    shouldBlockSocialNetwork,
+    getDomainsToExludeByNetwork,
+    getXraySurrogate,
+    allowSocialLogin,
+    isFirstPartyByEntity
 }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fixes issue with tracker methods that check the list without knowing if the list has loaded.

Errors such as:

- TypeError: Cannot read property 'duckduckgo.com' of undefined
- tried to detect trackers before rules were loaded

This makes all tracker checks **fail open** which I think is essentially what we are doing currently whilst also breaking other code.

This also handles missing tab data for `getArgumentsObject` calls by creating a tab given the sender info. This only happens on extension startup time:
![image](https://user-images.githubusercontent.com/338988/129201372-3b731f12-3ceb-4689-9e65-58c85eb38d10.png)


This also handles getSettings calls not returning as they've not loaded yet:
![image](https://user-images.githubusercontent.com/338988/129201348-d145a4e0-4040-41a0-b5f7-bfbc5ef78c23.png)


## Steps to test this PR:

1. Load the extension
2. Check the extension console for these messages

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
