### PR TITLE
Bump version

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2021.8.13-35685",
+    "version": "2021.8.13.36133",
     "icons": {
         "16": "img/icon_16.png",
         "48": "img/icon_48.png",

--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2021.8.12-68238",
+    "version": "2021.8.13-35685",
     "icons": {
         "16": "img/icon_16.png",
         "48": "img/icon_48.png",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
             "strict_min_version": "57.0"
         }
     },
-    "version": "2021.8.13-35685",
+    "version": "2021.8.13.36133",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
             "strict_min_version": "57.0"
         }
     },
-    "version": "2021.8.12-68238",
+    "version": "2021.8.13-35685",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",

--- a/scripts/bumpVersion.js
+++ b/scripts/bumpVersion.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const time = new Date();
 
 const seconds = (time.getUTCHours() * 60 * 60) + (time.getUTCMinutes() * 60) + time.getUTCSeconds();
-const newVersion = `${time.getUTCFullYear()}.${time.getUTCMonth()+1}.${time.getUTCDate()}-${seconds}`
+const newVersion = `${time.getUTCFullYear()}.${time.getUTCMonth()+1}.${time.getUTCDate()}.${seconds}`
 
 for (let browser of ['chrome', 'firefox']) {
     const manifest = fs.readFileSync(`browsers/${browser}/manifest.json`, 'utf8')


### PR DESCRIPTION
@jonathanKingston Just FYI, I have tweaked the bumpVersion script to use all dots in the version, because dashes are not allowed (failed validation when uploading to Mozilla).