### PR TITLE
Sync session key via session storage

### DIFF
--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -9,6 +9,7 @@ const https = require('./https.es6')
 const tds = require('./storage/tds.es6')
 const startup = require('./startup.es6')
 const browserWrapper = require('./wrapper.es6')
+const utils = require('./utils.es6')
 
 self.dbg = {
     settings,
@@ -16,7 +17,8 @@ self.dbg = {
     tabManager,
     atb,
     https,
-    tds
+    tds,
+    utils
 }
 
 // mark this as a dev build

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -468,6 +468,7 @@ browserWrapper.createAlarm('rotateUserAgent', { periodInMinutes: 24 * 60 })
 browserWrapper.createAlarm('rotateSessionKey', { periodInMinutes: 24 * 60 })
 
 browser.alarms.onAlarm.addListener(async alarmEvent => {
+    // Warning: Awaiting in this function doesn't actually wait for the promise to resolve before unblocking the main thread.
     if (alarmEvent.name === 'updateHTTPSLists') {
         await settings.ready()
         try {
@@ -490,7 +491,7 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
     } else if (alarmEvent.name === 'clearExpiredHTTPSServiceCache') {
         httpsService.clearExpiredCache()
     } else if (alarmEvent.name === 'rotateSessionKey') {
-        utils.resetSessionKey()
+        await utils.resetSessionKey()
     } else if (alarmEvent.name === REFETCH_ALIAS_ALARM) {
         fetchAlias()
     }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -9,7 +9,7 @@ import sha1 from '../shared-utils/sha1'
 const browserInfo = parseUserAgentString()
 
 /**
- * Produce a random float, same output as Math.random()
+ * Produce a random float, matches the output of Math.random() but much more cryptographically psudo-random.
  * @returns {number}
  */
 function getRandomFloat () {

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -1,11 +1,34 @@
 import browser from 'webextension-polyfill'
-import { getExtensionVersion } from './wrapper.es6'
+import { getExtensionVersion, getFromSessionStorage, setToSessionStorage } from './wrapper.es6'
 import tdsStorage from './storage/tds.es6'
 import settings from './settings.es6'
 import load from './load.es6'
 import * as tldts from 'tldts'
 import parseUserAgentString from '../shared-utils/parse-user-agent-string.es6'
+import sha1 from '../shared-utils/sha1'
 const browserInfo = parseUserAgentString()
+
+/**
+ * Produce a random float, same output as Math.random()
+ * @returns {number}
+ */
+function getRandomFloat () {
+    return crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32
+}
+
+export async function getSessionKey () {
+    let sessionKey = await getFromSessionStorage('sessionKey')
+    if (!sessionKey) {
+        sessionKey = await resetSessionKey()
+    }
+    return sessionKey
+}
+
+export async function resetSessionKey () {
+    const sessionKey = sha1(getRandomFloat().toString())
+    await setToSessionStorage('sessionKey', sessionKey)
+    return sessionKey
+}
 
 export async function sendTabMessage (id, message, details) {
     try {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kzar 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

https://app.asana.com/0/312629933896096/1201066533025796/f

Changes to synced storage for the session key sent to the content script (used for psudo-randomisation)

## Steps to test this PR:

1.  Open [several canvas draw pages](https://good.third-party.site/features/canvas-draw.html)
2. Click 'draw pattern'
3. Ensure the output is the same across the same page.
4. Open a different first party domain: https://bad.third-party.site/features/canvas-draw.html
5. Click 'draw pattern'
6. Ensure the output is different to the previous hashes.

Open the extension debugger and run _dbg.utils.resetSessionKey()_ and verify the tabs have different hashes; this simulates session key expiry via the alarm.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
