### PR TITLE
Resolve reinstall caching previous bundled config values

### DIFF
--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -31,6 +31,8 @@ function getHash () {
 }
 
 chrome.runtime.onInstalled.addListener(function (details) {
+    tdsStorage.initOnInstall()
+
     if (details.reason.match(/install/)) {
         settings.ready()
             .then(() => {

--- a/shared/js/background/settings.es6.js
+++ b/shared/js/background/settings.es6.js
@@ -1,5 +1,4 @@
 const defaultSettings = require('../../data/defaultSettings')
-const etags = require('../../data/etags.json')
 const browserWrapper = require('./wrapper.es6')
 
 /**
@@ -88,7 +87,7 @@ function buildSettingsFromManagedStorage () {
 
 function buildSettingsFromDefaults () {
     // initial settings are a copy of default settings
-    settings = Object.assign({}, defaultSettings, etags)
+    settings = Object.assign({}, defaultSettings)
 }
 
 function syncSettingTolocalStorage () {

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -16,14 +16,15 @@ class TDSStorage {
         this.surrogates = ''
         this.ClickToLoadConfig = {}
         this.config = {}
-        // If initOnInstall is not called before getList, just resolve.
-        this._installing = Promise.resolve(false)
+        this.isInstalling = false
 
         this.removeLegacyLists()
     }
 
-    initOnInstall () {
-        this._installing = this._internalInitOnInstall()
+    async initOnInstall () {
+        this.isInstalling = true
+        this._installingPromise = await this._internalInitOnInstall()
+        this.isInstalling = false
     }
 
     async _internalInitOnInstall () {
@@ -44,7 +45,9 @@ class TDSStorage {
 
     async getList (list) {
         // If initOnInstall was called, await the updating from the local bundles before fetching
-        await this._installing
+        if (this.installing) {
+            await this._installingPromise
+        }
         const listCopy = JSON.parse(JSON.stringify(list))
         const etag = settings.getSetting(`${listCopy.name}-etag`) || ''
         const version = this.getVersionParam()

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -4,6 +4,7 @@ const constants = require('../../../data/constants')
 const settings = require('./../settings.es6')
 const browserWrapper = require('./../wrapper.es6')
 const extensionConfig = require('./../../../privacy-configuration/generated/extension-config.json')
+const etags = require('../../../data/etags.json')
 
 class TDSStorage {
     constructor () {
@@ -14,17 +15,36 @@ class TDSStorage {
         this.tds = { entities: {}, trackers: {}, domains: {}, cnames: {} }
         this.surrogates = ''
         this.ClickToLoadConfig = {}
-        this.config = extensionConfig
-        this.storeInLocalDB('config', extensionConfig)
+        this.config = {}
+        // If initOnInstall is not called before getList, just resolve.
+        this._installing = Promise.resolve(false)
 
         this.removeLegacyLists()
+    }
+
+    initOnInstall () {
+        this._installing = this._internalInitOnInstall()
+    }
+
+    async _internalInitOnInstall () {
+        await settings.ready()
+        const etagKey = 'config-etag'
+        const etagValue = settings.getSetting(etagKey)
+        // If there's an existing value ignore the bundled values
+        if (!etagValue) {
+            settings.updateSetting(etagKey, etags[etagKey])
+            this.config = extensionConfig
+            await this.storeInLocalDB('config', extensionConfig)
+        }
     }
 
     getLists () {
         return Promise.all(constants.tdsLists.map(list => this.getList(list)))
     }
 
-    getList (list) {
+    async getList (list) {
+        // If initOnInstall was called, await the updating from the local bundles before fetching
+        await this._installing
         const listCopy = JSON.parse(JSON.stringify(list))
         const etag = settings.getSetting(`${listCopy.name}-etag`) || ''
         const version = this.getVersionParam()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Manual testing is the only way I've found to resolve this issue mentioned in: https://app.asana.com/0/1200223097357040/1201035302493499/f


## Steps to test this PR:

For this ensure you're on an old copy of the extension copy in privacy-configuration module (you can checkout an old commit and then run `npm run generate-etags`)

1. Load the extension with web-ext
2. Inspect the storage to see if there's what is stored in the indexedDB
3. Check network requests to see if a 304 occurred
4. Update the code (web ext should trigger an update)
5. Check the storage again to verify it's still the remote copy

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
