### PR TITLE
Reinstate autofill from context menu on Firefox

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -45,24 +45,22 @@ const fetchAlias = () => {
 }
 
 const MENU_ITEM_ID = 'ddg-autofill-context-menu-item'
-const createAutofillContextMenuItem = () => {
-    // Create the contextual menu hidden by default
-    browser.contextMenus.create({
-        id: MENU_ITEM_ID,
-        title: 'Use Duck Address',
-        contexts: ['editable'],
-        visible: false
-    })
-    browser.contextMenus.onClicked.addListener((info, tab) => {
-        const userData = getSetting('userData')
-        if (userData.nextAlias) {
-            browser.tabs.sendMessage(tab.id, {
-                type: 'contextualAutofill',
-                alias: userData.nextAlias
-            })
-        }
-    })
-}
+// Create the contextual menu hidden by default
+browser.contextMenus.create({
+    id: MENU_ITEM_ID,
+    title: 'Use Duck Address',
+    contexts: ['editable'],
+    visible: false
+})
+browser.contextMenus.onClicked.addListener((info, tab) => {
+    const userData = getSetting('userData')
+    if (userData.nextAlias) {
+        browser.tabs.sendMessage(tab.id, {
+            type: 'contextualAutofill',
+            alias: userData.nextAlias
+        })
+    }
+})
 
 const showContextMenuAction = () => browser.contextMenus.update(MENU_ITEM_ID, { visible: true })
 
@@ -100,7 +98,6 @@ const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
 module.exports = {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
-    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -61,7 +61,6 @@ browser.runtime.onInstalled.addListener(function (details) {
             })
         })
     }
-    createAutofillContextMenuItem()
 })
 
 /**
@@ -302,7 +301,6 @@ const browserWrapper = require('./wrapper.es6')
 const {
     REFETCH_ALIAS_ALARM,
     fetchAlias,
-    createAutofillContextMenuItem,
     showContextMenuAction,
     hideContextMenuAction,
     getAddresses,


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 

## Description:
In https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/767 we moved the context menu creation on `onInstalled` to avoid an error in Chrome when visiting the settings page. Apparently, that was a Chrome bug and no longer happening, but the change broke context menu autofill on Firefox (see https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/876).

## Steps to test this PR:
- On Firefox, install and enable autofill
- On any input field, open the context menu
- You should see the Dax autofill menu item
- On Chrome, open the settings page
- You should see no error in the console
