### PR TITLE
Improve release automation with Asana magic

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -20,6 +20,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
+
+      - name: Restore npm artifact from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install dependencies
         run: |
           npm i -g web-ext
@@ -41,12 +50,6 @@ jobs:
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
         - name: Build
           run: |
             npm run bundle-config

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -10,25 +10,75 @@ on:
 jobs:
   release_pr:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target: [ release-chrome, release-firefox ]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-    - name: Install dependencies
-      run: |
-        npm i -g web-ext
-        npm run install-ci
-    - name: Fetch config and update version
-      run: |
-        npm run bundle-config
-        node scripts/bumpVersion.js ${{ github.event.inputs.version }}
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
-      with:
-        commit-message: ${{ github.event.inputs.version }}
-        branch: "release-${{ github.event.inputs.version }}"
-        title: "Prepare release ${{ github.event.inputs.version }}"
-        body: ''
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Install dependencies
+        run: |
+          npm i -g web-ext
+          npm ci
+      - name: Fetch config and update version
+        run: |
+          npm run bundle-config
+          node scripts/bumpVersion.js ${{ github.event.inputs.version }}
+      - name: Commit config and version updates
+        uses: stefanzweifel/git-auto-commit-action@8c3ed373fb7e451dbb9706bf99ad63124e33f614
+        with:
+          commit_message: ${{ github.event.inputs.version }}
+          branch: develop
+          title: "Prepare release ${{ github.event.inputs.version }}"
+
+      - name: Generate changelog
+        id: changelog
+        uses: metcalfc/changelog-generator@c3f61b2a3db543ceee83c759ac8e48419a1a2211
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+        - name: Install dependencies
+          run: |
+            npm ci
+            npm i -g web-ext
+        - name: Build
+          run: |
+            npm run bundle-config
+            npm run ${{ matrix.target }}
+            echo "VERSION=$(jq -r .version ./browsers/firefox/manifest.json)" >> $GITHUB_ENV
+        - name: Package Firefox Release
+          if: matrix.target == 'release-firefox'
+          run: |
+            cd build/firefox/release && web-ext build
+            echo "BUILT_WITH=Built with node $(node --version) and npm $(npm --version)" >> $GITHUB_ENV
+
+        - name: Create release draft
+          uses: softprops/action-gh-release@9729932bfb75c05ad1f6e3a729294e05abaa7001
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            draft: true
+            prerelease: true
+            body: ${{ steps.changelog.outputs.changelog }}\n\n${{ env.BUILT_WITH }}
+            files: |
+              ./build/firefox/release/web-ext-artifacts/*.zip
+              ./build/chrome/release/*.zip
+
+        - name: Asana Workflow
+            env:
+              ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+              VERSION: ${{ github.event.release.tag_name }}
+              RELEASE_URL: ${{ github.event.release.html_url }}
+            run: |
+              npm install
+              node scripts/asana-release.js

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm i -g web-ext
-          npm ci
+          npm run install-ci
       - name: Fetch config and update version
         run: |
           npm run bundle-config
@@ -47,10 +47,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-        - name: Install dependencies
-          run: |
-            npm ci
-            npm i -g web-ext
         - name: Build
           run: |
             npm run bundle-config
@@ -79,6 +75,5 @@ jobs:
               ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
               VERSION: ${{ github.event.release.tag_name }}
               RELEASE_URL: ${{ github.event.release.html_url }}
-            run: |
-              npm install
+            run:
               node scripts/asana-release.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "@rollup/plugin-commonjs": "^21.0.1",
                 "@rollup/plugin-node-resolve": "^13.0.6",
                 "@rollup/plugin-replace": "^3.0.0",
+                "asana": "^0.18.6",
                 "babelify": "10.0.0",
                 "brfs": "^2.0.2",
                 "duckduckgo-colors": "0.0.1",
@@ -2878,6 +2879,25 @@
                 "node": ">=8"
             }
         },
+        "node_modules/asana": {
+            "version": "0.18.6",
+            "resolved": "https://registry.npmjs.org/asana/-/asana-0.18.6.tgz",
+            "integrity": "sha512-ETvmihkeDz80z2GRGoQZXFUqIxuid9zRMcAiNsh604JPyzgPDyfOuba8Jvjxxedfz3WABENbkjBHMYCQ369k8A==",
+            "dev": true,
+            "dependencies": {
+                "bluebird": "^3.7.2",
+                "browser-request": "^0.3.2",
+                "lodash": "^4.17.20",
+                "readline": "^1.3.0",
+                "request": "^2.88.2"
+            }
+        },
+        "node_modules/asana/node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "node_modules/asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3383,6 +3403,15 @@
             "bin": {
                 "browser-pack": "bin/cmd.js"
             }
+        },
+        "node_modules/browser-request": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+            "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+            "dev": true,
+            "engines": [
+                "node"
+            ]
         },
         "node_modules/browser-resolve": {
             "version": "2.0.0",
@@ -12501,6 +12530,12 @@
                 "util-deprecate": "~1.0.1"
             }
         },
+        "node_modules/readline": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+            "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+            "dev": true
+        },
         "node_modules/regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -17902,6 +17937,27 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
+        "asana": {
+            "version": "0.18.6",
+            "resolved": "https://registry.npmjs.org/asana/-/asana-0.18.6.tgz",
+            "integrity": "sha512-ETvmihkeDz80z2GRGoQZXFUqIxuid9zRMcAiNsh604JPyzgPDyfOuba8Jvjxxedfz3WABENbkjBHMYCQ369k8A==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.7.2",
+                "browser-request": "^0.3.2",
+                "lodash": "^4.17.20",
+                "readline": "^1.3.0",
+                "request": "^2.88.2"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "3.7.2",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+                    "dev": true
+                }
+            }
+        },
         "asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -18313,6 +18369,12 @@
                 "through2": "^2.0.0",
                 "umd": "^3.0.0"
             }
+        },
+        "browser-request": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+            "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+            "dev": true
         },
         "browser-resolve": {
             "version": "2.0.0",
@@ -25426,6 +25488,12 @@
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
             }
+        },
+        "readline": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+            "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+            "dev": true
         },
         "regenerate": {
             "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
         "@rollup/plugin-replace": "^3.0.0",
+        "asana": "^0.18.6",
         "babelify": "10.0.0",
         "brfs": "^2.0.2",
         "duckduckgo-colors": "0.0.1",

--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -2,6 +2,7 @@
 /* eslint-disable camelcase */
 const fs = require('fs')
 const Asana = require('asana')
+const path = require('path')
 
 const ASANA_ACCESS_TOKEN = process.env.ASANA_ACCESS_TOKEN
 const version = process.env.VERSION

--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -1,0 +1,110 @@
+/* eslint-disable no-undef */
+/* eslint-disable camelcase */
+const fs = require('fs')
+const Asana = require('asana')
+
+const ASANA_ACCESS_TOKEN = process.env.ASANA_ACCESS_TOKEN
+const version = process.env.VERSION
+const releaseUrl = process.env.RELEASE_URL
+const chromeFilePath = fs.readdirSync('../build/chrome/release/').find(fn => fn.endsWith('.zip'))
+const firefoxFilePath = fs.readdirSync('../build/firefox/release/web-ext-artifacts').find(fn => fn.endsWith('.zip'))
+
+const templateTaskGid = '1201192367380462'
+const projectGid = '312629933896096'
+const releaseSectionGid = '1138897367672278'
+
+let asana
+
+const setupAsana = () => {
+    asana = Asana.Client.create({
+        defaultHeaders: {
+            'Asana-Enable': 'new_user_task_lists'
+        }
+    }).useAccessToken(ASANA_ACCESS_TOKEN)
+}
+
+const duplicateTemplateTask = (templateTaskGid) => {
+    const duplicateOption = {
+        include: ['notes', 'assignee', 'subtasks', 'projects'],
+        name: `Extension Release ${version}`,
+        opt_fields: 'html_notes'
+    }
+
+    return asana.tasks.duplicateTask(templateTaskGid, duplicateOption)
+}
+
+const getTaskList = (tasks) => tasks.map((t) =>
+    `<li><a data-asana-gid="${t.gid}" /> — ${
+        t.assignee ? `<a data-asana-gid="${t.assignee.gid}" />` : '…'
+    }</li>`).join('')
+
+// get list of assignees to add to the release task
+const getAssigneeGids = (releaseTasks) =>
+    releaseTasks.reduce(
+        (assignees, task) => {
+            if (task.assignee) assignees.add(task.assignee.gid)
+
+            return assignees
+        },
+        new Set() // using a Set so they're unique
+    )
+
+const run = async () => {
+    setupAsana()
+
+    console.info('Asana on. Duplicating template task...')
+
+    const { new_task } = await duplicateTemplateTask(templateTaskGid)
+
+    const { html_notes: notes } = await asana.tasks.getTask(new_task.gid, { opt_fields: 'html_notes' })
+
+    // get list of tasks in release section
+    const { data: releaseTasks } = await asana.tasks.getTasksForSection(
+        releaseSectionGid,
+        {
+            completed_since: 'now', // only fetch incomplete tasks
+            opt_fields: 'gid,assignee,name'
+        }
+    )
+
+    // create html list with <a>task</a> - @assignee
+    const releaseNotes = `<ul>${getTaskList(releaseTasks)}</ul>`
+
+    const updatedNotes =
+        notes.replace('[[release_url]]', `<a href="${releaseUrl}">${releaseUrl}</a>`)
+            .replace('[[notes]]', releaseNotes)
+
+    console.info('Updating task and moving to Release section...')
+
+    await asana.tasks.updateTask(new_task.gid, { html_notes: updatedNotes })
+
+    await asana.tasks.addProjectForTask(new_task.gid, {
+        project: projectGid,
+        insert_before: releaseTasks[0].gid
+    })
+
+    console.info('Uploading files...')
+
+    const uploadFile = (err, data) => {
+        if (err) throw err
+
+        asana.attachments.createAttachmentForTask(new_task, { file: data })
+    }
+
+    fs.readFile(chromeFilePath, uploadFile)
+    fs.readFile(firefoxFilePath, uploadFile)
+
+    console.info('Adding followers...')
+
+    await asana.tasks.addFollowersForTask(
+        new_task.gid,
+        { followers: [...getAssigneeGids(releaseTasks)] }
+    )
+
+    console.info('All done. Enjoy! 🎉')
+}
+
+run().catch((e) => {
+    console.error(e)
+    process.exit(1)
+})


### PR DESCRIPTION
**Reviewers:** @jonathanKingston @MariagraziaAlastra @sammacbeth 
**Asana:** https://app.asana.com/0/0/1200750505563921/1201183123265449/f

## Description:
Automate the Asana paperwork!

- Run the workflow, with manual input of version (as the current stage.yml)
- Run the script and commit the changes
- Generate a new Release draft (prerelease: true)
- Use the list of commits from the previous tag to the current to populate the release notes
- Build zip files and upload them to the release ← We already have most of this logic in publish.yml
- Asana Script:
  - Get list of tasks in the Extension release project under the Release section
  - Duplicate the release template, paste in the list of tasks in the appropriate section
  - Upload the zip files to Asana

## Steps to test this PR:
Give it a first pass, then we'll merge and try to cut test releases to see how it works. You can see what the Asana script spits out in https://app.asana.com/0/312629933896096/1201202709634481/f.