### PR TITLE
Click to Play code improvements

### DIFF
--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -161,7 +161,7 @@
             padding-bottom: 10px;
         `,
         buttonTextContainer: `
-            display: flex; 
+            display: flex;
             flex-direction: row;
             align-items: center;
         `,
@@ -177,7 +177,7 @@
             margin: auto;
             display: flex;
             flex-direction: column;
-            
+
             font-family: DuckDuckGoPrivacyEssentials;
             line-height: 1;
         `,
@@ -442,6 +442,8 @@
 
         /*
          * Creates an iFrame for this facebook content.
+         *
+         * @returns {Element}
          */
         createFBIFrame () {
             const frame = document.createElement('iframe')
@@ -481,7 +483,7 @@
             return this.fadeElement(element, 10, true)
         }
 
-        clickFunction (originalElement, replacementElement, shouldFade = true) {
+        clickFunction (originalElement, replacementElement) {
             let clicked = false
             const handleClick = function handleClick (e) {
                 // Ensure that the click is created by a user event & prevent double clicks from adding more animations
@@ -591,11 +593,9 @@
     }
 
     /**
-     * Creates a safe element to replace the original tracking element.
+     * Creates a safe element and replaces the original tracking element with it.
      * @param {Object} widgetData - a single entry from elementData
      * @param {Element} originalElement - the element on the page we are replacing
-     *
-     * @returns {Element} a new element that can be inserted on the page in place of the original.
      */
     function createReplacementWidget (entity, widgetData, originalElement) {
         // Construct the widget based on data in the original element

--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -567,15 +567,23 @@
     function init (extensionResponseData) {
         for (const entity of Object.keys(extensionResponseData)) {
             entities.push(entity)
-            entityData[entity] = {
-                shouldShowLoginModal: true,
-                modalIcon: extensionResponseData[entity].informationalModal.icon,
-                modalTitle: extensionResponseData[entity].informationalModal.messageTitle,
-                modalText: extensionResponseData[entity].informationalModal.messageBody,
-                modalAcceptText: extensionResponseData[entity].informationalModal.confirmButtonText,
-                modalRejectText: extensionResponseData[entity].informationalModal.rejectButtonText,
-                simpleVersion: extensionResponseData[entity].simpleVersion
+            const { informationalModal, simpleVersion } = extensionResponseData[entity]
+            const shouldShowLoginModal = !!informationalModal
+
+            const currentEntityData = {
+                shouldShowLoginModal,
+                simpleVersion
             }
+
+            if (shouldShowLoginModal) {
+                currentEntityData.modalIcon = informationalModal.icon
+                currentEntityData.modalTitle = informationalModal.messageTitle
+                currentEntityData.modalText = informationalModal.messageBody
+                currentEntityData.modalAcceptText = informationalModal.confirmButtonText
+                currentEntityData.modalRejectText = informationalModal.rejectButtonText
+            }
+
+            entityData[entity] = currentEntityData
         }
         replaceClickToLoadElements(extensionResponseData)
     }

--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -715,6 +715,7 @@
         linkElement.style.cssText = styles.generalLink + styles[mode].linkFont
         linkElement.ariaLabel = 'Read about this privacy protection'
         linkElement.href = 'https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/'
+        linkElement.target = '_blank'
         linkElement.textContent = 'Learn More'
         return linkElement
     }


### PR DESCRIPTION
**Reviewer**: @jonathanKingston
**Cc**: @Charlie-belmer, @ladamski

## Description:

This is a grab-bag of  Click to Play code improvements that I've split-out from my current project work. I've explained each change in the commit descriptions (please don't squash the commits!), but I'll also summarise here:

1. Some superficial changes, including fixing comments and clearing trailing whitespace.
2. Changed the CTP placeholder code to reduce ways the website's styles could screw them up. Most importantly I start putting as much of the placeholder inside a shadowRoot as possible.
3. Properly handled entries in `social_ctp_configuration.json` which don't include the `informationalModal` key. Currently the code completely fails, but instead we should just consider that `shouldShowLoginModal` is false and not attempt to set up the modal.
4. Open the documentation in a new tab/window when the user clicks the "Learn more" button inside a placeholder. Currently the documentation opens in the same page, which seems like a bad user experience.

## Steps to test this PR:
1. Ensure the Facebook Click to Load functionality still works OK on the test page https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
