### PR TITLE
Features missing from config should be disabled.

### DIFF
--- a/shared/js/background/classes/site.es6.js
+++ b/shared/js/background/classes/site.es6.js
@@ -38,7 +38,7 @@ class Site {
          * The other allowlisting code is different and probably should be changed to match.
          */
         this.isBroken = utils.isBroken(domainWWW) // broken sites reported to github repo
-        this.brokenFeatures = utils.getBrokenFeatures(domainWWW) // site issues reported to github repo
+        this.enabledFeatures = utils.getEnabledFeatures(domainWWW) // site issues reported to github repo
         this.didIncrementCompaniesData = false
 
         this.tosdr = privacyPractices.getTosdr(domain)
@@ -102,7 +102,7 @@ class Site {
         if (this.denylisted) {
             return true
         }
-        return this.isProtectionEnabled() && !this.brokenFeatures.includes(featureName)
+        return this.isProtectionEnabled() && this.enabledFeatures.includes(featureName)
     }
 
     addTracker (t) {

--- a/shared/js/background/devtools.es6.js
+++ b/shared/js/background/devtools.es6.js
@@ -76,7 +76,7 @@ function connected (port) {
             const { tabId } = m
             const feature = m.action.slice(6)
             const tab = tabManager.get({ tabId })
-            const enabled = !tab.site?.brokenFeatures.includes(feature)
+            const enabled = tab.site?.enabledFeatures.includes(feature)
             const excludedSites = tdsStorage.config.features[feature].exceptions
             const tabDomain = tldts.getDomain(tab.site.domain)
             if (enabled) {

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -384,7 +384,8 @@ function getArgumentsObject (tabId, sender, documentUrl) {
     }
     // Special case for iframes that are blank we check if it's also enabled
     if (sender.url === 'about:blank') {
-        site.brokenFeatures = site.brokenFeatures.concat(utils.getBrokenFeaturesAboutBlank(tab.url))
+        const aboutBlankEnabled = utils.getEnabledFeaturesAboutBlank(tab.url)
+        site.enabledFeatures = site.enabledFeatures.filter(feature => aboutBlankEnabled.includes(feature))
     }
 
     // Extra contextual data required for 1p and 3p cookie protection - only send if at least one is enabled here

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -176,34 +176,28 @@ export function removeBroken (domain) {
     }
 }
 
-export function getBrokenFeaturesAboutBlank (url) {
+export function getEnabledFeaturesAboutBlank (url) {
     if (!tdsStorage.config.features) return
-    const brokenFeatures = []
+    const enabledFeatures = []
     for (const feature in tdsStorage.config.features) {
         const featureSettings = getFeatureSettings(feature)
 
-        if (featureSettings.aboutBlankEnabled === 'disabled') {
-            brokenFeatures.push(feature)
-        }
-        if (brokenListIndex(url, featureSettings.aboutBlankSites || []) !== -1) {
-            brokenFeatures.push(feature)
+        if (featureSettings.aboutBlankEnabled !== 'disabled' && brokenListIndex(url, featureSettings.aboutBlankSites || []) === -1) {
+            enabledFeatures.push(feature)
         }
     }
-    return brokenFeatures
+    return enabledFeatures
 }
 
-export function getBrokenFeatures (url) {
+export function getEnabledFeatures (url) {
     if (!tdsStorage.config.features) return
-    const brokenFeatures = []
+    const enabledFeatures = []
     for (const feature in tdsStorage.config.features) {
-        if (!isFeatureEnabled(feature)) {
-            brokenFeatures.push(feature)
-        }
-        if (brokenListIndex(url, tdsStorage.config.features[feature].exceptions || []) !== -1) {
-            brokenFeatures.push(feature)
+        if (isFeatureEnabled(feature) && brokenListIndex(url, tdsStorage.config.features[feature].exceptions || []) === -1) {
+            enabledFeatures.push(feature)
         }
     }
-    return brokenFeatures
+    return enabledFeatures
 }
 
 export function brokenListIndex (url, list) {
@@ -218,15 +212,6 @@ export function brokenListIndex (url, list) {
         }
         return false
     })
-}
-
-export function isFeatureBrokenForURL (url, feature) {
-    const exceptionList = tdsStorage.config.features[feature]?.exceptions
-    if (!exceptionList || exceptionList.length === 0) {
-        return false
-    }
-
-    return brokenListIndex(url, exceptionList) !== -1
 }
 
 // We inject this into content scripts

--- a/shared/js/content-scope/utils.js
+++ b/shared/js/content-scope/utils.js
@@ -96,7 +96,7 @@ export function iterateDataKey (key, callback) {
 }
 
 export function isFeatureBroken (args, feature) {
-    return args.site.brokenFeatures.includes(feature)
+    return !args.site.enabledFeatures.includes(feature)
 }
 
 /**

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -73,7 +73,7 @@ const actionHandlers = {
         protectionButton.innerText = `Protection: ${tab.site?.allowlisted || tab.site?.isBroken ? 'OFF' : 'ON'}`
         loadConfigurableFeatures.then((features) => {
             features.forEach((feature) => {
-                document.getElementById(feature).innerText = `${feature}: ${tab.site?.brokenFeatures.includes(feature) ? 'OFF' : 'ON'}`
+                document.getElementById(feature).innerText = `${feature}: ${tab.site?.enabledFeatures.includes(feature) ? 'ON' : 'OFF'}`
             })
         })
     },

--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -247,7 +247,7 @@ Site.prototype = window.$.extend({},
             this.isAllowlisted = allowListValue
             this.isDenylisted = denyListValue
 
-            this.isBroken = this.tab.site.isBroken || this.tab.site.brokenFeatures.includes('contentBlocking')
+            this.isBroken = this.tab.site.isBroken || !this.tab.site.enabledFeatures.includes('contentBlocking')
             this.displayBrokenUI = this.isBroken
 
             if (denyListValue) {


### PR DESCRIPTION
**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When feature key is missing from the config we should disable the feature. This already got us in trouble once and we partially addressed it with https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/938 .

## Steps to test this PR:
1. Go to chrome-extension://hacmkdifffpphkffddioobolnmelljoa/html/list-editor.html in the extension
2. Change config to 

```json
{
  "readme": "https://github.com/duckduckgo/privacy-configuration",
  "version": 1636990486124,
  "features": {},
  "unprotectedTemporary": [
  ]
}
```

3. Make sure that all features, both content world (e.g. fingerprinting, 1p cookie expiry date thing) and background-page (e.g. GPC headers, content blocking) are disabled.

## Automated tests:
- [ ] Unit tests - unit test that checks this will be a follow up in https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/937
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
