### PR TITLE
Fix the fonts in our Click to Play placeholders

### DIFF
--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -938,15 +938,22 @@
         const contentBlock = document.createElement('div')
         contentBlock.style.cssText = styles.wrapperDiv
 
-        // Put everyting inside the shadowRoot of the wrapper element to reduce
-        // the chances of the website's stylesheets messing up the placeholder's
-        // appearance.
+        // Put our custom font-faces inside the wrapper element, since
+        // @font-face does not work inside a shadowRoot.
+        // See https://github.com/mdn/interactive-examples/issues/887.
+        const fontFaceStyleElement = document.createElement('style')
+        fontFaceStyleElement.textContent = styles.fontStyle
+        contentBlock.appendChild(fontFaceStyleElement)
+
+        // Put everyting else inside the shadowRoot of the wrapper element to
+        // reduce the chances of the website's stylesheets messing up the
+        // placeholder's appearance.
         const shadowRoot = contentBlock.attachShadow({ mode: 'closed' })
 
         // Style element includes our font & overwrites page styles
         const styleElement = document.createElement('style')
         const wrapperClass = 'DuckDuckGoSocialContainer'
-        styleElement.textContent = styles.fontStyle + `
+        styleElement.textContent = `
             .${wrapperClass} a {
                 ${styles[widget.getMode()].linkFont}
                 font-weight: bold;


### PR DESCRIPTION
**Reviewer:** @jonathanKingston
**CC:** @Charlie-belmer, @kdzwinel, @ladamski 

## Description:
@kdzwinel noticed the fonts are broken in our Click to Play placeholders. It turns out, my [recent change](https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/4e39246d28e7ca606256f65444792ecea0a686b3) to put the placeholder's content inside a `shadowRoot` broke them. I didn't realise that `@font-face` is broken inside of `shadowRoot` on Chrome. ([See related discussion](https://github.com/mdn/interactive-examples/issues/887).)

With this change, we keep the `@font-face` stuff outside of our `shadowRoot`, but leave everything else inside.


## Steps to test this PR:
1. Browse to https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/ and ensure the font used by our placeholders looks correct:
![click-to-play-font](https://user-images.githubusercontent.com/155710/142009909-ffcd1fd5-50f4-4ff8-9117-34e0562f7d6d.png)

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
