### PR TITLE
Increase minimum supported Firefox version to 65

### DIFF
--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -3,7 +3,7 @@
     "applications": {
         "gecko": {
             "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
-            "strict_min_version": "57.0"
+            "strict_min_version": "65.0"
         }
     },
     "version": "2021.9.30",


### PR DESCRIPTION
It turns out that the extension is broken for Firefox versions below
65. For example, we use APIs like `Element.srcElement`[1],
`Element.attachShadow`[2], `globalThis`[3] and pass the
"visible" option to `browser.contextMenus.create`[4]. Rather than to
workaround those issues (and likely more), let's just drop support for
those old versions of Firefox.

1 - https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement#browser_compatibility
2 - https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#browser_compatibility
3 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility
4 - https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/create#browser_compatibility

**Reviewer:** @jonathanKingston 

## Description:
If we decide to go ahead with dropping support for Firefox < 65 here's a patch.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
