### PR TITLE
Don't display Click to Play placeholders for first-party domains

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -65,6 +65,13 @@ export async function initClickToLoad (unused, sender) {
     const tab = tabManager.get({ tabId: sender.tab.id })
     const config = { ...tdsStorage.ClickToLoadConfig }
 
+    // Remove first-party entries.
+    const siteUrlSplit = tab.site.domain.split('.')
+    const websiteOwner = trackers.findWebsiteOwner({ siteUrlSplit })
+    if (websiteOwner) {
+        delete config[websiteOwner]
+    }
+
     // Determine whether to show one time messages or simplified messages
     for (const [entity] of Object.entries(config)) {
         const clickToLoadClicks = settings.getSetting('clickToLoadClicks') || {}


### PR DESCRIPTION
Click to Play is intended to protect the user from tracking via
embedded third-party content. The placeholder elements should never be
displayed for first-party embedded content.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

**CC:** @Charlie-belmer, @ladamski, @kdzwinel 

## Steps to test this PR:
1. Ensure Facebook Click to Load still works correctly: https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
