### PR TITLE
Check excludedDomains before blocking/redirecting Click to Play requests

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -102,6 +102,15 @@ function handleRequest (requestData) {
             if (tracker && socialTracker && trackerutils.shouldBlockSocialNetwork(socialTracker.entity, thisTab.site.url)) {
                 if (!trackerutils.isSameEntity(requestData.url, thisTab.site.url) && // first party
                     !thisTab.site.clickToLoad.includes(socialTracker.entity)) {
+                    // Ensure this website isn't in the excluded domains list.
+                    if (socialTracker.data && socialTracker.data.excludedDomains) {
+                        for (const { domain: excludedDomain } of socialTracker.data.excludedDomains) {
+                            if (excludedDomain === thisTab.site.domain) {
+                                return
+                            }
+                        }
+                    }
+
                     // TDS doesn't block social sites by default, so update the action & redirect for click to load.
                     tracker.action = 'block'
                     if (socialTracker.redirectUrl) {


### PR DESCRIPTION
So far, the excludedDomains option in the Click to Play configuration
stops the Click to Play placeholders from being shown, but not the
corresponding requests from being blocked or redirected. Let's correct
that here.

**Reviewer:** @jonathanKingston 

**CC:** @Charlie-belmer, @ladamski, @kdzwinel 

## Steps to test this PR:
1. Check that Click to Play is still working OK for Facebook https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
