### PR TITLE
Implement YouTube Click to Load

### DIFF
--- a/integration-test/background/click-to-load-youtube.js
+++ b/integration-test/background/click-to-load-youtube.js
@@ -1,0 +1,308 @@
+const harness = require('../helpers/harness')
+const { logPageRequests } = require('../helpers/requests')
+const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
+
+const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/youtube-click-to-load/'
+const testConfig = {
+    'dbg.tds.tds.trackers.youtube\\.com': {
+        owner: {
+            name: 'Google LLC',
+            displayName: 'YouTube',
+            privacyPolicy: 'https://policies.google.com/privacy?hl=en',
+            url: 'http://google.com'
+        },
+        default: 'ignore'
+    },
+    'dbg.tds.tds.trackers.youtube-nocookie\\.com': {
+        owner: {
+            name: 'Google LLC',
+            displayName: 'YouTube',
+            privacyPolicy: 'https://policies.google.com/privacy?hl=en',
+            url: 'http://google.com'
+        },
+        default: 'ignore'
+    },
+    'dbg.tds.ClickToLoadConfig.Google LLC': {
+        domains: [
+            'youtube.com',
+            'youtube-nocookie.com'
+        ],
+        excludedSubdomains: [],
+        excludedDomains: [{
+            domain: 'duckduckgo.com',
+            reason: 'Existing privacy protections for YouTube videos'
+        }],
+        elementData: {
+            'YouTube embedded video': {
+                selectors: [
+                    'iframe[src*=\'://youtube.com/embed\']',
+                    'iframe[src*=\'://youtube-nocookie.com/embed\']',
+                    'iframe[src*=\'://www.youtube.com/embed\']',
+                    'iframe[src*=\'://www.youtube-nocookie.com/embed\']'
+                ],
+                replaceSettings: {
+                    type: 'youtube-video',
+                    buttonText: 'Unblock Video',
+                    infoTitle: 'DuckDuckGo blocked this YouTube Video',
+                    infoText: 'We blocked YouTube from tracking you when the page loaded. If you unblock this Video, YouTube will know your activity.',
+                    simpleInfoText: 'We blocked YouTube from tracking you when the page loaded. If you unblock this Video, YouTube will know your activity.'
+                },
+                clickAction: {
+                    type: 'youtube-video'
+                }
+            },
+            'YouTube embedded subscription button': {
+                selectors: [
+                    'iframe[src*=\'://youtube.com/subscribe_embed\']',
+                    'iframe[src*=\'://youtube-nocookie.com/subscribe_embed\']',
+                    'iframe[src*=\'://www.youtube.com/subscribe_embed\']',
+                    'iframe[src*=\'://www.youtube-nocookie.com/subscribe_embed\']'
+                ],
+                replaceSettings: {
+                    type: 'blank'
+                }
+            }
+        },
+        informationalModal: {},
+        surrogates: [
+            {
+                rule: '(www.)?youtube(-nocookie)?.com/iframe_api',
+                surrogate: 'youtube-iframe-api.js'
+            }
+        ]
+    }
+}
+
+const youTubeStandardDomains = new Set(['youtu.be', 'youtube.com', 'www.youtube.com'])
+const youTubeNocookieDomains = new Set(['youtube-nocookie.com', 'www.youtube-nocookie.com'])
+
+let browser
+let bgPage
+let teardown
+
+function summariseYouTubeRequests (requests) {
+    const youTubeIframeApi = { checked: false, alwaysRedirected: true }
+    const youTubeStandard = { blocked: 0, allowed: 0, total: 0 }
+    const youTubeNocookie = { blocked: 0, allowed: 0, total: 0 }
+
+    for (const request of requests) {
+        if (request.url.href === 'https://www.youtube.com/iframe_api') {
+            youTubeIframeApi.alwaysRedirected = (
+                youTubeIframeApi.alwaysRedirected &&
+                request.status === 'redirected' &&
+                request.redirectUrl &&
+                request.redirectUrl.protocol === 'chrome-extension:' &&
+                request.redirectUrl.pathname.endsWith('/youtube-iframe-api.js')
+            )
+            youTubeIframeApi.checked = true
+            continue
+        }
+
+        let stats
+
+        if (youTubeStandardDomains.has(request.url.hostname)) {
+            stats = youTubeStandard
+        } else if (youTubeNocookieDomains.has(request.url.hostname)) {
+            stats = youTubeNocookie
+        } else {
+            continue
+        }
+
+        stats.total += 1
+
+        if (request.status === 'blocked') {
+            stats.blocked += 1
+        } else {
+            // Consider anything not blocked as allowed, so that block tests
+            // don't miss redirected requests or failed requests.
+            stats.allowed += 1
+        }
+    }
+
+    return { youTubeIframeApi, youTubeStandard, youTubeNocookie }
+}
+
+describe('Test YouTube Click To Load', () => {
+    beforeAll(async () => {
+        ({ browser, bgPage, teardown } = await harness.setup())
+
+        // Wait for the extension to load its configuration files.
+        await bgPage.waitForFunction(
+            () => (
+                window.dbg &&
+                window.dbg.tds &&
+                !window.dbg.tds.isInstalling &&
+                window.dbg.tds.ClickToLoadConfig &&
+                window.dbg.tds.tds.trackers &&
+                window.dbg.tds.tds &&
+                window.dbg.tds.tds.domains &&
+                window.dbg.tds.tds.domains['youtube.com'] === 'Google LLC'
+            ),
+            { polling: 10 }
+        )
+
+        // Overwrite the parts of the configuration needed for our tests.
+        await loadTestConfig(bgPage, testConfig)
+    })
+
+    afterAll(async () => {
+        // Restore the original configuration.
+        await unloadTestConfig(bgPage, testConfig)
+
+        try {
+            await teardown()
+        } catch (e) {}
+    })
+
+    it('CTL: YouTube request blocking/redirecting', async () => {
+        // Open the test page and start logging network requests.
+        const page = await browser.newPage()
+        const pageRequests = []
+        logPageRequests(page, pageRequests)
+
+        // Initially there should be a bunch of requests. The iframe_api should
+        // be redirected to our surrogate but otherwise YouTube requests should
+        // be blocked.
+        await page.goto(testSite, { waitUntil: 'networkidle2' })
+        {
+            const {
+                youTubeIframeApi, youTubeStandard, youTubeNocookie
+            } = summariseYouTubeRequests(pageRequests)
+
+            expect(youTubeIframeApi.checked).toBeTrue()
+            expect(youTubeIframeApi.alwaysRedirected).toBeTrue()
+            expect(youTubeStandard.total).toBeGreaterThan(5)
+            expect(youTubeStandard.blocked).toEqual(youTubeStandard.total)
+            expect(youTubeStandard.allowed).toEqual(0)
+            expect(youTubeNocookie.blocked).toEqual(youTubeNocookie.total)
+            expect(youTubeNocookie.allowed).toEqual(0)
+        }
+
+        // Once the user clicks to load a video, the iframe_api should be loaded
+        // and the video should be unblocked.
+        pageRequests.length = 0
+        const button = await page.evaluateHandle(
+            'document.querySelector("div:nth-child(2) > div")' +
+            '.shadowRoot.querySelector("button")'
+        )
+        await button.click()
+        await page.waitForNetworkIdle({ idleTime: 1000 })
+        {
+            const {
+                youTubeIframeApi, youTubeStandard, youTubeNocookie
+            } = summariseYouTubeRequests(pageRequests)
+
+            expect(youTubeIframeApi.checked).toBeTrue()
+            expect(youTubeIframeApi.alwaysRedirected).toBeFalse()
+            expect(youTubeStandard.blocked).toEqual(0)
+            expect(youTubeNocookie.blocked).toEqual(0)
+            expect(youTubeNocookie.allowed).toBeGreaterThanOrEqual(1)
+        }
+
+        // When the page is reloaded, requests should be blocked again.
+        pageRequests.length = 0
+        await page.reload({ waitUntil: 'networkidle2' })
+        {
+            const {
+                youTubeIframeApi, youTubeStandard, youTubeNocookie
+            } = summariseYouTubeRequests(pageRequests)
+
+            expect(youTubeIframeApi.checked).toBeTrue()
+            expect(youTubeIframeApi.alwaysRedirected).toBeTrue()
+            expect(youTubeStandard.total).toBeGreaterThan(5)
+            expect(youTubeStandard.blocked).toEqual(youTubeStandard.total)
+            expect(youTubeStandard.allowed).toEqual(0)
+            expect(youTubeNocookie.blocked).toEqual(youTubeNocookie.total)
+            expect(youTubeNocookie.allowed).toEqual(0)
+        }
+
+        // The header button should also unblock YouTube.
+        pageRequests.length = 0
+        const headerButton = await page.evaluateHandle(
+            'document.querySelector("#short-container > div")' +
+            '.shadowRoot.querySelector("#DuckDuckGoPrivacyEssentialsCTLElementTitleTextButton")'
+        )
+        await headerButton.click()
+        await page.waitForNetworkIdle({ idleTime: 1000 })
+        {
+            const {
+                youTubeIframeApi, youTubeStandard, youTubeNocookie
+            } = summariseYouTubeRequests(pageRequests)
+
+            expect(youTubeIframeApi.checked).toBeTrue()
+            expect(youTubeIframeApi.alwaysRedirected).toBeFalse()
+            expect(youTubeStandard.blocked).toEqual(0)
+            expect(youTubeNocookie.blocked).toEqual(0)
+            expect(youTubeNocookie.allowed).toBeGreaterThanOrEqual(1)
+        }
+
+        page.close()
+    })
+
+    it('CTL: YouTube interacting with iframe API', async () => {
+        const page = await browser.newPage()
+        await page.goto(testSite, { waitUntil: 'networkidle2' })
+
+        // Test the Iframe API controls and events function correctly, even when
+        // used with an existing video.
+        {
+            const waitForExpectedBorder = expectedBorder =>
+                page.waitForFunction(expectedBorder => (
+                    document.getElementById('existing-video')
+                        .style.border.split(' ').pop() === expectedBorder
+                ),
+                { polling: 10 }, expectedBorder)
+
+            await waitForExpectedBorder('')
+
+            const button = await page.evaluateHandle(
+                'document.querySelector("div:nth-child(7) > div")' +
+                '.shadowRoot.querySelector("button")'
+            )
+            await button.click()
+            await waitForExpectedBorder('orange')
+
+            await page.click('#play-existing-video')
+            await waitForExpectedBorder('green')
+
+            await page.click('#pause-existing-video')
+            await waitForExpectedBorder('red')
+        }
+
+        // Test the Iframe API controls a 360 video correctly.
+        {
+            const waitForExpectedRoll = (expectedRoll, clickFlip) =>
+                page.waitForFunction((expectedRoll, clickFlip) => {
+                    if (clickFlip) {
+                        document.getElementById('spherical-video-flip').click()
+                    }
+                    return document.getElementById('spherical-video-roll')
+                        .value === expectedRoll
+                },
+                { polling: 10 }, expectedRoll, clickFlip)
+
+            await waitForExpectedRoll('')
+
+            const button = await page.evaluateHandle(
+                'document.querySelector("div:nth-child(8) > div")' +
+                '.shadowRoot.querySelector("button")'
+            )
+            // Sometimes Chrome shows a media dialog that seems to cause our
+            // click to not register. Focusing the button first seems to help.
+            await button.focus()
+            await button.click()
+            await waitForExpectedRoll('0.0000')
+
+            // Play video and keep clicking roll button until it flips. The
+            // video doesn't flip until its finished loading, so this way we
+            // avoid unnecessary waiting and flaky failures.
+            await page.click('#spherical-video')
+            await waitForExpectedRoll('180.0000', true)
+
+            await page.click('#spherical-video-flip')
+            await waitForExpectedRoll('0.0000')
+        }
+
+        page.close()
+    })
+})

--- a/integration-test/helpers/requests.js
+++ b/integration-test/helpers/requests.js
@@ -1,0 +1,71 @@
+/* @typedef {object} LoggedRequestDetails
+ * @property {string} url
+ *   The request's URL.
+ * @property {bool} blocked
+ *   False if the request was successful, true if it was blocked or failed.
+ */
+
+/**
+ * Start logging requests for the given Puppeteer Page.
+ * @param {Page} page
+ *   The Puppeteer page to log requests for.
+ * @param {LoggedRequestDetails[]} requests
+ *   Array of request details, appended to as requests happen.
+ *   Note: The requests array is mutated by this function.
+ */
+function logPageRequests (page, requests) {
+    const requestDetailsByRequestId = new Map()
+
+    page._client.on('Network.requestWillBeSent', ({
+        requestId, request: { url, method }, redirectResponse, type
+    }) => {
+        const requestDetails = { url, method, type }
+
+        if (redirectResponse &&
+            redirectResponse.statusText === 'Internal Redirect' &&
+            redirectResponse.headers && redirectResponse.headers.Location &&
+            redirectResponse.headers['Non-Authoritative-Reason'] === 'WebRequest API') {
+            requestDetails.url = redirectResponse.url
+            requestDetails.redirectUrl = new URL(redirectResponse.headers.Location)
+        }
+        requestDetails.url = new URL(requestDetails.url)
+
+        requestDetailsByRequestId.set(requestId, requestDetails)
+    })
+
+    page._client.on('Network.loadingFinished', ({ requestId }) => {
+        if (!requestDetailsByRequestId.has(requestId)) {
+            return
+        }
+
+        const details = requestDetailsByRequestId.get(requestId)
+        requestDetailsByRequestId.delete(requestId)
+
+        details.status = details.redirectUrl ? 'redirected' : 'allowed'
+        requests.push(details)
+    })
+
+    page._client.on('Network.loadingFailed', ({
+        requestId, blockedReason, errorText
+    }) => {
+        if (!requestDetailsByRequestId.has(requestId)) {
+            return
+        }
+
+        const details = requestDetailsByRequestId.get(requestId)
+        requestDetailsByRequestId.delete(requestId)
+
+        if (blockedReason === 'other' &&
+            errorText === 'net::ERR_BLOCKED_BY_CLIENT') {
+            details.status = 'blocked'
+        } else {
+            details.status = 'failed'
+            details.reason = errorText
+        }
+        requests.push(details)
+    })
+}
+
+module.exports = {
+    logPageRequests
+}

--- a/integration-test/helpers/testConfig.js
+++ b/integration-test/helpers/testConfig.js
@@ -1,0 +1,90 @@
+function parsePath (path) {
+    const pathParts = []
+
+    // Split path by '.' but take escaping into account.
+    let currentPart = ''
+    let escaped = false
+    for (const char of path) {
+        if (escaped) {
+            currentPart += char
+            escaped = false
+            continue
+        }
+
+        if (char === '\\') {
+            escaped = true
+            continue
+        }
+
+        if (char === '.') {
+            pathParts.push(currentPart)
+            currentPart = ''
+            continue
+        }
+
+        currentPart += char
+    }
+
+    // Find the target Object from that path.
+    let currentObject = window
+    for (const path of pathParts) {
+        currentObject = currentObject[path]
+    }
+
+    return [currentObject, currentPart]
+}
+
+/**
+ * Override some part of the extension config temporarily for an integration
+ * test.
+ * Note: Avoid overriding same configuration multiple times. Also ensure
+ *       unloadTestConfig() is called after your tests are done.
+ * @param {Page} bgPage
+ *   The extension's background page.
+ * @param {Object} testConfig
+ *   Your test configuration.
+ *    - the keys are a string containing the configuration's "path", for example
+ *      "dbg.tds.tds.trackers.duckduckgo\\.com".
+ *    - the values should be your test configuration to set for that path, for
+ *      the above example an Object containing the tracker entry.
+ *   Note:
+ *    - Paths containing '.' can  be escaped with a backslash.
+ *    - Don't include the 'window.' prefix in paths.
+ *    - There's no need to escape whitespace in paths.
+ */
+async function loadTestConfig (bgPage, testConfig) {
+    await bgPage.evaluate((testConfig, parsePathString) => {
+        window.configBackup = window.configBackup || {}
+        // eslint-disable-next-line no-eval
+        eval(parsePathString)
+
+        for (const path of Object.keys(testConfig)) {
+            const [target, lastPathPart] = parsePath(path)
+            window.configBackup[path] = target[lastPathPart]
+            target[lastPathPart] = testConfig[path]
+        }
+    }, testConfig, parsePath.toString())
+}
+
+/**
+ * Undoes the configuration changes made by loadTestConfig.
+ * @param {Page} bgPage
+ *   The extension's background page.
+ */
+async function unloadTestConfig (bgPage) {
+    await bgPage.evaluate(parsePathString => {
+        const { configBackup } = window || {}
+        // eslint-disable-next-line no-eval
+        eval(parsePathString)
+
+        for (const path of Object.keys(configBackup)) {
+            const [target, lastPathPart] = parsePath(path)
+            target[lastPathPart] = configBackup[path]
+        }
+    }, parsePath.toString())
+}
+
+module.exports = {
+    loadTestConfig,
+    unloadTestConfig
+}

--- a/shared/data/web_accessible_resources/youtube-iframe-api.js
+++ b/shared/data/web_accessible_resources/youtube-iframe-api.js
@@ -1,0 +1,310 @@
+(() => {
+    'use strict'
+
+    if (typeof YT !== 'undefined') {
+        return
+    }
+
+    const googleEntityName = 'Google LLC'
+
+    // See https://developers.google.com/youtube/iframe_api_reference
+    const iframeAPIURL = 'https://www.youtube.com/iframe_api'
+    const defaultHeight = 640
+    const defaultWidth = 390
+
+    // The website's `onYouTubeIframeAPIReady` listener (if any).
+    let realOnYouTubeIframeAPIReady
+
+    // Reference to the "real" `YT.Player` constructor.
+    let RealYTPlayer = null
+
+    // Loading state of the YouTube Iframe API.
+    let youTubeIframeAPILoaded = false
+    let youTubeIframeAPILoadingPromise = null
+
+    // Mappings between mock `YT.Player` Objects, their element in the page and
+    // any event listeners they might have.
+    const mockPlayerByVideoElement = new WeakMap()
+    const onReadyListenerByVideoElement = new WeakMap()
+    const onStateChangeListenerByVideoElement = new WeakMap()
+
+    // Mappings between the "real" video elements and their placeholder
+    // elements.
+    const videoElementsByID = new Map()
+    const videoElementByPlaceholderElement = new WeakMap()
+    const placeholderElementByVideoElement = new WeakMap()
+
+    /**
+     * Mock of the `YT.Player` constructor.
+     */
+    function Player (target, config = { }, ...rest) {
+        if (youTubeIframeAPILoaded) {
+            return new RealYTPlayer(target, config, ...rest)
+        }
+
+        const { height, width, videoId, playerVars = { }, events } = config
+
+        if (!(target instanceof Element)) {
+            target = document.getElementById(target)
+        }
+
+        // Normalise target to always be the video element instead of the
+        // placeholder element (if either even exists at this point).
+        if (videoElementByPlaceholderElement.has(target)) {
+            target = videoElementByPlaceholderElement.get(target)
+        }
+
+        if (!target) {
+            throw new Error('Target not found')
+        }
+
+        // Set up the video element if the target isn't an existing video.
+        if (!placeholderElementByVideoElement.has(target)) {
+            const url = new URL(window.YTConfig.host)
+            url.pathname = '/embed/'
+
+            // For videos (not playlists) append the video ID to the path.
+            // See https://developers.google.com/youtube/player_parameters
+            if (!playerVars.list) {
+                url.pathname += encodeURIComponent(videoId)
+            }
+
+            for (const [key, value] of Object.entries(playerVars)) {
+                url.searchParams.set(key, value)
+            }
+
+            // Ensure that JavaScript control of the video is enabled. This is
+            // necessary for the onReady event to fire for the video.
+            url.searchParams.set('enablejsapi', '1')
+
+            const videoIframe = document.createElement('iframe')
+            videoIframe.height = parseInt(height, 10) || defaultHeight
+            videoIframe.width = parseInt(width, 10) || defaultWidth
+            videoIframe.src = url.href
+
+            if (target.id) {
+                videoIframe.id = target.id
+            }
+
+            target.replaceWith(videoIframe)
+            target = videoIframe
+
+            target.dispatchEvent(new CustomEvent('ddg-ctp-replace-element'))
+        }
+
+        if (events) {
+            if (events.onReady) {
+                onReadyListenerByVideoElement.set(target, events.onReady)
+            }
+            if (events.onStateChange) {
+                onStateChangeListenerByVideoElement.set(target, events.onStateChange)
+            }
+        }
+
+        mockPlayerByVideoElement.set(target, this)
+        this.playerInfo = {}
+        return this
+    }
+
+    // Stub out the YouTube Iframe API.
+    window.YTConfig = {
+        host: 'https://www.youtube.com'
+    }
+    window.YT = {
+        loading: 1,
+        loaded: 1,
+        Player,
+        PlayerState: {
+            UNSTARTED: -1,
+            ENDED: 0,
+            PLAYING: 1,
+            PAUSED: 2,
+            BUFFERING: 3,
+            CUED: 5
+        },
+        setConfig (config) {
+            for (const key of Object.keys(config)) {
+                window.YTConfig[key] = config[key]
+            }
+        },
+        get () { },
+        ready () { },
+        scan () { },
+        subscribe () { },
+        unsubscribe () { }
+    }
+
+    /**
+     * Load the YouTube Iframe API, replacing the stub.
+     * @return {Promise}
+     *   Promise which resolves after the API has finished loading.
+     */
+    function ensureYouTubeIframeAPILoaded () {
+        if (youTubeIframeAPILoaded) {
+            return Promise.resolve()
+        }
+        if (youTubeIframeAPILoadingPromise) {
+            return youTubeIframeAPILoadingPromise
+        }
+
+        const loadingPromise = new Promise((resolve, reject) => {
+            // The YouTube Iframe API calls the `onYouTubeIframeAPIReady`
+            // function to signal that it is ready for use by the website.
+            window.onYouTubeIframeAPIReady = resolve
+        }).then(() => {
+            window.onYouTubeIframeAPIReady = realOnYouTubeIframeAPIReady
+            RealYTPlayer = window.YT.Player
+            youTubeIframeAPILoaded = true
+            youTubeIframeAPILoadingPromise = null
+        })
+
+        // Delete the stub `YT` Object, since its presence will prevent the
+        // YouTube Iframe API from loading.
+        // Note: There's a chance that website will attempt to reference the
+        //       `YT` Object inbetween now and when the script has loaded. This
+        //       is unfortunate but unavoidable.
+        delete window.YT
+
+        // Load the YouTube Iframe API.
+        const script = document.createElement('script')
+        script.src = iframeAPIURL
+        document.body.appendChild(script)
+
+        youTubeIframeAPILoadingPromise = loadingPromise
+        return loadingPromise
+    }
+
+    function onClickToPlayReady () {
+        // Signal to the website that the YouTube Iframe API is ready for use,
+        // even though it probably is not. That triggers the website to attempt
+        // to create any videos that it wants to, which we can then block and
+        // replace with placeholders.
+        realOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady
+        if (typeof realOnYouTubeIframeAPIReady === 'function') {
+            realOnYouTubeIframeAPIReady()
+        }
+    }
+
+    function onElementAnnounced (name) {
+        return ({
+            target,
+            detail: {
+                entity, widgetID: videoID,
+                replaceSettings: { type: replaceType }
+            }
+        }) => {
+            if (entity !== googleEntityName || replaceType !== 'youtube-video') {
+                return
+            }
+
+            let entry = videoElementsByID.get(videoID)
+            if (entry) {
+                entry[name] = target
+                videoElementByPlaceholderElement.set(entry.placeholder, entry.video)
+                placeholderElementByVideoElement.set(entry.video, entry.placeholder)
+                videoElementsByID.delete(videoID)
+            } else {
+                entry = { [name]: target }
+                videoElementsByID.set(videoID, entry)
+            }
+        }
+    }
+
+    async function onPlaceholderClicked ({
+        target,
+        detail: {
+            entity,
+            replaceSettings: { type: replaceType }
+        }
+    }) {
+        if (entity !== googleEntityName || replaceType !== 'youtube-video') {
+            return
+        }
+
+        await ensureYouTubeIframeAPILoaded()
+
+        const mockPlayer = mockPlayerByVideoElement.get(target)
+        if (!mockPlayer) {
+            return
+        }
+
+        const onReadyListener = onReadyListenerByVideoElement.get(target)
+        const onStateChangeListener = onStateChangeListenerByVideoElement.get(target)
+
+        const config = { events: { } }
+        if (onStateChangeListener) {
+            config.events.onStateChange = onStateChangeListener
+        }
+
+        let realPlayer // eslint-disable-line prefer-const
+
+        config.events.onReady = (...args) => {
+            // Make a best attempt at turning the mock `YT.Player` instance into
+            // something that behaves the same as the "real" one. Necessary
+            // since the website will likely still have a reference to the mock.
+
+            // The methods of `YT.Player` instances are stored directly on the
+            // instance, instead of in `YT.Player.__proto__` as would be
+            // expected. Copy those over onto the mock, taking care to rebind
+            // them so that they behave the same when called.
+            //   Instead of copying over raw values, replace them with a
+            // getter and setter which act on the value. That way any raw values
+            // should stay consistent between a mock and "real" `YT.Player`
+            // instance.
+            const properties = Object.getOwnPropertyDescriptors(realPlayer)
+            for (const [property, descriptor] of Object.entries(properties)) {
+                if (Object.prototype.hasOwnProperty.call(descriptor, 'value') &&
+                    typeof descriptor.value !== 'function' &&
+                    !descriptor.get && !descriptor.set) {
+                    // Plain value, replace with getter + setter.
+                    delete descriptor.writable
+                    delete descriptor.value
+                    descriptor.get = () => realPlayer[property]
+                    descriptor.set = (newValue) => { realPlayer[property] = newValue }
+                } else {
+                    // Method or getter + setter. Rebind to apply to the "real"
+                    // instance.
+                    for (const key of ['get', 'set', 'value']) {
+                        const value = descriptor[key]
+                        if (typeof value === 'function') {
+                            descriptor[key] = value.bind(realPlayer)
+                        }
+                    }
+                }
+            }
+            delete this.playerInfo
+            Object.defineProperties(mockPlayer, properties)
+
+            // Set the "real" player instance as the prototype of the mock. That
+            // way, checks like `instanceof` are more likely to behave as
+            // expected.
+            mockPlayer.__proto__ = realPlayer // eslint-disable-line no-proto
+
+            if (onReadyListener) {
+                onReadyListener(...args)
+            }
+        }
+
+        realPlayer = new RealYTPlayer(target, config)
+
+        onReadyListenerByVideoElement.delete(target)
+        onStateChangeListenerByVideoElement.delete(target)
+    }
+
+    window.addEventListener(
+        'ddg-ctp-ready', onClickToPlayReady,
+        { once: true }
+    )
+    window.addEventListener(
+        'ddg-ctp-tracking-element', onElementAnnounced('video'),
+        { capture: true }
+    )
+    window.addEventListener(
+        'ddg-ctp-placeholder-element', onElementAnnounced('placeholder'),
+        { capture: true }
+    )
+    window.addEventListener(
+        'ddg-ctp-placeholder-clicked', onPlaceholderClicked,
+        { capture: true }
+    )
+})()

--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -8,6 +8,7 @@ const load = require('./load.es6')
 const atb = require('./atb.es6')
 const https = require('./https.es6')
 const tds = require('./storage/tds.es6')
+const messageHandlers = require('./message-handlers')
 
 window.dbg = {
     settings,
@@ -22,3 +23,4 @@ window.dbg = {
 // metrics from being thrown off
 load.setDevMode()
 atb.setDevMode()
+messageHandlers._setDevMode()

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -325,7 +325,7 @@ browser.runtime.onMessage.addListener((req, sender) => {
         }
     }
 
-    if (req.messageType in messageHandlers) {
+    if (req.messageType && req.messageType[0] !== '_' && req.messageType in messageHandlers) {
         return Promise.resolve(messageHandlers[req.messageType](req.options, sender))
     }
     if (req.messageType === 'registeredContentScript' || req.registeredTempAutofillContentScript) {

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -12,6 +12,19 @@ const browserName = utils.getBrowserName()
 const devtools = require('./devtools.es6')
 const browserWrapper = require('./wrapper.es6')
 
+let dev = false
+
+// Exported functions are used as message handlers for messages with a
+// matching type. That is except for functions with the '_' prefix.
+
+export function _setDevMode () {
+    dev = true
+}
+
+export function getDevMode () {
+    return dev
+}
+
 export function resetTrackersData () {
     return Companies.resetData()
 }


### PR DESCRIPTION
Add privacy protection from embedded YouTube videos and
playlists. Block third-party YouTube requests and display a
placeholder for the corresponding element that allows users to
unblock the content again. Where possible, also upgrade embedded
videos to use youtube-nocookie.com.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

**CC:** @ladamski, @kdzwinel, @Charlie-belmer, @sammacbeth  

## Steps to test this PR:
1. Add the following entry to your `social_ctp_configuration.json` file: https://gist.github.com/kzar/89bc3b8971daef09334da5a0799589c0
2. Navigate to the YouTube test page and follow the instructions: https://privacy-test-pages.glitch.me/privacy-protections/youtube-click-to-load/

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
