### PR TITLE
Remove unused pixel tracking

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -1,6 +1,6 @@
 /**
  *
- * This is part of our tool for anonymous engagement metrics
+ * This is part of our tool for anonymous broken site reports
  * Learn more at https://duck.co/help/privacy/atb
  *
  */
@@ -17,22 +17,15 @@ const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es
  * @param {...*} args - any number of extra data
  *
  */
-function fire () {
+export function fire () {
     if (!arguments.length) return
 
     let args = Array.prototype.slice.call(arguments)
-    const pixelName = args[0]
-
-    if (typeof pixelName !== 'string') return
-
-    // Only allow broken site reports
-    if (pixelName !== 'epbf') return
-
+    const pixelName = 'epbf'
     const url = getURL(pixelName)
 
     if (!url) return
 
-    args = args.slice(1)
     args = args.concat(getAdditionalParams())
     const paramString = concatParams(args)
 
@@ -45,7 +38,7 @@ function fire () {
  * Return URL for the pixel request
  *
  */
-function getURL (pixelName) {
+export function getURL (pixelName) {
     if (!pixelName) return
 
     const url = 'https://improving.duckduckgo.com/t/'
@@ -79,7 +72,7 @@ function getAdditionalParams () {
  * @param {array} args - data we need to append
  *
  */
-function concatParams (args) {
+export function concatParams (args) {
     args = args || []
 
     let paramString = ''
@@ -104,10 +97,4 @@ function concatParams (args) {
     resultString = `${paramString}?${randomNum}${objParamString}`
 
     return resultString
-}
-
-module.exports = {
-    fire: fire,
-    getURL: getURL,
-    concatParams: concatParams
 }

--- a/shared/js/background/classes/https-redirects.es6.js
+++ b/shared/js/background/classes/https-redirects.es6.js
@@ -1,6 +1,4 @@
 const utils = require('../utils.es6')
-const pixel = require('../pixel.es6')
-const constants = require('../../../data/constants')
 
 const MAINFRAME_RESET_MS = 3000
 const REQUEST_REDIRECT_LIMIT = 7
@@ -87,13 +85,6 @@ class HttpsRedirects {
 
         // remember this hostname as previously failed, don't try to upgrade it
         if (!canRedirect) {
-            if (request.type === 'main_frame') {
-                const encodedHostname = encodeURIComponent(hostname)
-                const errCode = constants.httpsErrorCodes.downgrade_redirect_loop
-                // Fire pixel on https upgrade failures to allow bad data to be removed from lists
-                pixel.fire('ehd', { url: encodedHostname, error: errCode })
-            }
-
             this.failedUpgradeHosts[hostname] = true
             console.log(`HTTPS: not upgrading, redirect loop protection kicked in for url: ${request.url}`)
         }

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -166,7 +166,6 @@ if (browserName === 'chrome') {
 
 const redirect = require('./redirect.es6')
 const tabManager = require('./tab-manager.es6')
-const pixel = require('./pixel.es6')
 const https = require('./https.es6')
 
 const requestListenerTypes = utils.getUpdatedRequestListenerTypes()
@@ -632,7 +631,7 @@ const onStartup = async () => {
     }
 }
 
-// Fire pixel on https upgrade failures to allow bad data to be removed from lists
+// Count https upgrade failures to allow bad data to be removed from lists
 browser.webRequest.onErrorOccurred.addListener(e => {
     if (!(e.type === 'main_frame')) return
 
@@ -650,11 +649,6 @@ browser.webRequest.onErrorOccurred.addListener(e => {
 
         if (errCode) {
             https.incrementUpgradeCount('failedUpgrades')
-            const url = new URL(e.url)
-            pixel.fire('ehd', {
-                url: `${encodeURIComponent(url.hostname)}`,
-                error: errCode
-            })
         }
     }
 }, { urls: ['<all_urls>'] })

--- a/shared/js/background/https.es6.js
+++ b/shared/js/background/https.es6.js
@@ -1,7 +1,6 @@
 const settings = require('./settings.es6')
 const utils = require('./utils.es6')
 const BloomFilter = require('@duckduckgo/jsbloom').filter
-const pixel = require('./pixel.es6')
 const httpsService = require('./https-service.es6')
 const tabManager = require('./tab-manager.es6')
 const browserWrapper = require('./wrapper.es6')
@@ -257,7 +256,6 @@ class HTTPS {
             // clear the counts
             settings.updateSetting('totalUpgrades', 0)
             settings.updateSetting('failedUpgrades', 0)
-            pixel.fire('ehs', { total: upgrades, failures: failed })
         }
     }
 

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -7,7 +7,7 @@ const trackerutils = require('./tracker-utils')
 const trackers = require('./trackers.es6')
 const constants = require('../../data/constants')
 const Companies = require('./companies.es6')
-const pixel = require('./pixel.es6')
+const brokenSiteReport = require('./broken-site-report')
 const browserName = utils.getBrowserName()
 const devtools = require('./devtools.es6')
 const browserWrapper = require('./wrapper.es6')
@@ -33,11 +33,8 @@ export function getBrowser () {
     return browserName
 }
 
-export function firePixel (fireArgs) {
-    if (fireArgs.constructor !== Array) {
-        fireArgs = [fireArgs]
-    }
-    return pixel.fire.apply(null, fireArgs)
+export function submitBrokenSiteReport (brokenSiteArgs) {
+    return brokenSiteReport.fire.apply(null, brokenSiteArgs)
 }
 
 export function getTab (tabId) {

--- a/shared/js/ui/base/model.es6.js
+++ b/shared/js/ui/base/model.es6.js
@@ -101,8 +101,8 @@ BaseModel.prototype = $.extend({},
             return browserUIWrapper.sendMessage(messageType, options)
         },
 
-        firePixel (pixelData) {
-            return browserUIWrapper.sendMessage('firePixel', pixelData)
+        submitBrokenSiteReport (brokenSiteData) {
+            return browserUIWrapper.sendMessage('submitBrokenSiteReport', brokenSiteData)
         },
 
         /**

--- a/shared/js/ui/models/site.es6.js
+++ b/shared/js/ui/models/site.es6.js
@@ -278,17 +278,9 @@ Site.prototype = window.$.extend({},
                     this.setList('denylisted', this.tab.site.domain, false)
                     this.initAllowlisted(!this.isAllowlisted)
 
-                    // fire ept.on pixel if just turned privacy protection on,
-                    // fire ept.off pixel if just turned privacy protection off.
                     if (this.isAllowlisted && this.allowlistOptIn) {
-                    // If user reported broken site and opted to share data on site,
-                    // attach domain and path to ept.on pixel if they turn privacy protection back on.
-                        const siteUrl = this.tab.url.split('?')[0].split('#')[0]
                         this.set('allowlistOptIn', false)
-                        this.firePixel(['ept', 'on', { siteUrl: encodeURIComponent(siteUrl) }])
                         this.setList('allowlistOptIn', this.tab.site.domain, false)
-                    } else {
-                        this.firePixel(['ept', 'off'])
                     }
 
                     this.setList('allowlisted', this.tab.site.domain, this.isAllowlisted)

--- a/shared/js/ui/models/submit-breakage-form.es6.js
+++ b/shared/js/ui/models/submit-breakage-form.es6.js
@@ -7,7 +7,7 @@ module.exports = function (category) {
     // remove params and fragments from url to avoid including sensitive data
     const siteUrl = this.tab.url.split('?')[0].split('#')[0]
     const trackerObjects = this.tab.trackersBlocked
-    const pixelParams = ['epbf',
+    const brokenSiteParams = [
         { category: category },
         { siteUrl: encodeURIComponent(siteUrl) },
         { upgradedHttps: upgradedHttps.toString() },
@@ -25,8 +25,8 @@ module.exports = function (category) {
             }
         })
     }
-    pixelParams.push({ blockedTrackers: blockedTrackers }, { surrogates: surrogates })
-    this.firePixel(pixelParams)
+    brokenSiteParams.push({ blockedTrackers: blockedTrackers }, { surrogates: surrogates })
+    this.submitBrokenSiteReport(brokenSiteParams)
 
     // remember that user opted into sharing site breakage data
     // for this domain, so that we can attach domain when they

--- a/shared/js/ui/views/search.es6.js
+++ b/shared/js/ui/views/search.es6.js
@@ -60,14 +60,12 @@ Search.prototype = window.$.extend({},
         _handleSubmit: function (e) {
             e.preventDefault()
             console.log(`Search submit for ${this.$input.val()}`)
-            this.model.firePixel('epq')
             this.model.doSearch(this.$input.val())
             window.close()
         },
 
         _handleBurgerClick: function (e) {
             e.preventDefault()
-            this.model.firePixel('eph')
             this.model.send('burgerClick')
         }
     }

--- a/shared/js/ui/views/site.es6.js
+++ b/shared/js/ui/views/site.es6.js
@@ -24,7 +24,6 @@ function Site (ops) {
                 (this.model.tab.status === 'complete' || this.model.domain === 'new tab')) {
             // render template for the first time here
             Parent.call(this, ops)
-            this.model.firePixel('ep')
             this._setup()
         } else {
             // the timeout helps buffer the re-render cycle during heavy
@@ -180,7 +179,6 @@ Site.prototype = window.$.extend({},
 
         _showPageTrackers: function (e) {
             if (this.$body.hasClass('is-disabled')) return
-            this.model.firePixel('epn')
             this.views.slidingSubview = new TrackerNetworksView({
                 template: trackerNetworksTemplate
             })
@@ -188,7 +186,6 @@ Site.prototype = window.$.extend({},
 
         _showPrivacyPractices: function (e) {
             if (this.model.disabled) return
-            this.model.firePixel('epp')
 
             this.views.privacyPractices = new PrivacyPracticesView({
                 template: privacyPracticesTemplate,
@@ -198,7 +195,6 @@ Site.prototype = window.$.extend({},
 
         _showGradeScorecard: function (e) {
             if (this.model.disabled) return
-            this.model.firePixel('epc')
 
             this.views.gradeScorecard = new GradeScorecardView({
                 template: gradeScorecardTemplate,

--- a/shared/js/ui/views/top-blocked-truncated.es6.js
+++ b/shared/js/ui/views/top-blocked-truncated.es6.js
@@ -23,7 +23,6 @@ TruncatedTopBlocked.prototype = window.$.extend({},
     {
 
         _seeAllClick: function () {
-            this.model.firePixel('eps')
             this.views.slidingSubview = new TopBlockedFullView({
                 template: topBlockedFullTemplate,
                 numItems: 10

--- a/unit-test/background/broken-site-report.js
+++ b/unit-test/background/broken-site-report.js
@@ -1,5 +1,5 @@
 
-const pixel = require('../../shared/js/background/pixel.es6')
+const pixel = require('../../shared/js/background/broken-site-report')
 const url = 'https://improving.duckduckgo.com/t/'
 const getURLTestCases = [
     {

--- a/unit-test/background/classes/https-redirects.es6.js
+++ b/unit-test/background/classes/https-redirects.es6.js
@@ -1,6 +1,5 @@
 const HttpsRedirects = require('../../../shared/js/background/classes/https-redirects.es6')
 const tk = require('timekeeper')
-const pixel = require('../../../shared/js/background/pixel.es6')
 let httpsRedirects
 
 /**
@@ -9,7 +8,6 @@ let httpsRedirects
 
 const setup = () => {
     httpsRedirects = new HttpsRedirects()
-    spyOn(pixel, 'fire')
 }
 
 let id = 5

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -1,7 +1,7 @@
 require('../../helpers/mock-browser-api')
 
 const submitBreakageForm = require('../../../shared/js/ui/models/submit-breakage-form.es6')
-const pixel = require('../../../shared/js/background/pixel.es6')
+const submitBrokenSiteReport = require('../../../shared/js/background/broken-site-report')
 const loadPixel = require('../../../shared/js/background/load.es6')
 const testSets = require('../../data/reference-tests/broken-site-reporting/tests.json')
 
@@ -47,9 +47,9 @@ for (const setName of Object.keys(testSets)) {
                             }
                         }
                     },
-                    // normally pixel params are passed from popup to background script via messaging,
+                    // normally report params are passed from popup to background script via messaging,
                     // we are making a shortcut here
-                    firePixel: params => pixel.fire.apply(null, params),
+                    submitBrokenSiteReport: params => submitBrokenSiteReport.fire.apply(null, params),
                     set: () => {},
                     sendMessage: () => {}
                 }, test.category)


### PR DESCRIPTION
**Reviewer:** @kdzwinel 

## Description:

Removes all tracking pixels other than the site report as it was all unused.

I renamed the class and hard coded the pixel name so it can't be used again without reimplementing it as it breaks addon policy.

https://app.asana.com/0/892838074342800/1200747843240318/f

## Steps to test this PR:

1. Open up the browser inspector
2. Report a broken site
3. Ensure the report is firing correctly

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
