### PR TITLE
Reference tests update and surrogate reporting fix

### DIFF
--- a/shared/js/ui/models/submit-breakage-form.es6.js
+++ b/shared/js/ui/models/submit-breakage-form.es6.js
@@ -18,9 +18,10 @@ module.exports = function (category) {
         const trackerDomains = trackerObjects[tracker].urls
         Object.keys(trackerDomains).forEach((domain) => {
             if (trackerDomains[domain].isBlocked) {
-                blockedTrackers.push(domain)
                 if (trackerDomains[domain].reason === 'matched rule - surrogate') {
                     surrogates.push(domain)
+                } else {
+                    blockedTrackers.push(domain)
                 }
             }
         })

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -64,7 +64,7 @@ for (const setName of Object.keys(testSets)) {
 
                 if (test.expectReportURLParams) {
                     test.expectReportURLParams.forEach(param => {
-                        expect(requestURLString).toContain(`${param.name}=${param.value}`)
+                        expect(requestURLString).toMatch(new RegExp(`[?&]${param.name}=${param.value}[&$]`))
                     })
                 }
             })

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -63,8 +63,12 @@ for (const setName of Object.keys(testSets)) {
                 }
 
                 if (test.expectReportURLParams) {
+                    const requestUrl = new URL(requestURLString)
+                    // we can't use searchParams because those are automatically decoded
+                    const searchItems = requestUrl.search.split('&')
+
                     test.expectReportURLParams.forEach(param => {
-                        expect(requestURLString).toMatch(new RegExp(`[?&]${param.name}=${param.value}[&$]`))
+                        expect(searchItems).toContain(`${param.name}=${param.value}`)
                     })
                 }
             })


### PR DESCRIPTION
**Reviewer:** @sammacbeth 

## Description:
This PR updates reference tests after latest changes to HTTPS tests and small adjustment to broken site reporting tests - https://github.com/duckduckgo/privacy-reference-tests/pull/24 . It also fixes a bug in how surrogates are reported in the breakage reports (previously surrogated hosts went into both `blockedTrackers` and `surrogates` fields, they should have gone only to `surrogates`).

## Steps to test this PR:
1. Send a breakage report from a site that uses a surrogate (e.g. https://privacy-test-pages.glitch.me/tracker-reporting/1major-with-surrogate.html) and double check that report being sent only mentions surrogate in the `surrogates` field and not the `blockedTrackers` field of the report
2. Double check that blocked trackers are still correctly sent with `blockedTrackers`

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
