### PR TITLE
Rethink Click to Play events

### DIFF
--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -97,8 +97,16 @@
         window.open('about:blank', popupName, popupParams)
     }
 
-    window.addEventListener('ddg-ctp-Facebook-load-sdk', enableFacebookSDK)
-    window.addEventListener('ddg-ctp-Facebook-run-login', runFacebookLogin)
+    window.addEventListener('ddg-ctp-load-sdk', event => {
+        if (event.detail.entity === 'Facebook') {
+            enableFacebookSDK()
+        }
+    })
+    window.addEventListener('ddg-ctp-run-login', event => {
+        if (event.detail.entity === 'Facebook') {
+            runFacebookLogin()
+        }
+    })
 
     function init () {
         if (window.fbAsyncInit) {

--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -357,6 +357,21 @@
             this.dataElements = {}
             this.gatherDataElements()
             this.entity = entity
+            this.widgetID = Math.random()
+        }
+
+        dispatchEvent (eventTarget, eventName) {
+            eventTarget.dispatchEvent(
+                new CustomEvent(
+                    eventName, {
+                        detail: {
+                            entity: this.entity,
+                            replaceSettings: this.replaceSettings,
+                            widgetID: this.widgetID
+                        }
+                    }
+                )
+            )
         }
 
         // Collect and store data elements from original widget. Store default values
@@ -508,7 +523,7 @@
                     // notify surrogate to enable SDK and replace original element.
                     if (this.clickAction.type === 'allowFull') {
                         parent.replaceChild(originalElement, replacementElement)
-                        window.dispatchEvent(new CustomEvent(`ddg-ctp-${this.entity}-load-sdk`))
+                        this.dispatchEvent(window, 'ddg-ctp-load-sdk')
                         return
                     }
                     // Create a container for the new FB element
@@ -718,7 +733,13 @@
 
     function runLogin (entity) {
         enableSocialTracker(entity, true)
-        window.dispatchEvent(new CustomEvent(`ddg-ctp-${entity}-run-login`))
+        window.dispatchEvent(
+            new CustomEvent('ddg-ctp-run-login', {
+                detail: {
+                    entity
+                }
+            })
+        )
     }
 
     /*********************************************************

--- a/shared/js/content-scripts/fb-surrogate-xray.js
+++ b/shared/js/content-scripts/fb-surrogate-xray.js
@@ -106,8 +106,16 @@
             siteInit = wrappedWindow.fbAsyncInit
             wrappedWindow.fbAsyncInit()
         }
-        window.addEventListener('ddg-ctp-Facebook-load-sdk', enableFacebookSDK)
-        window.addEventListener('ddg-ctp-Facebook-run-login', runFacebookLogin)
+        window.addEventListener('ddg-ctp-load-sdk', event => {
+            if (event.detail.entity === 'Facebook') {
+                enableFacebookSDK()
+            }
+        })
+        window.addEventListener('ddg-ctp-run-login', event => {
+            if (event.detail.entity === 'Facebook') {
+                runFacebookLogin()
+            }
+        })
     }
 
     if (!wrappedWindow.FB) {


### PR DESCRIPTION
Move the entity name into the event details for Click to Play events,
instead of putting them in the event name. Also include the
replaceSettings and random widget ID where relevant.

**Reviewer:** @jonathanKingston 

## Description:
Some tweaks to how we do the CTP events ready for the YouTube changes. 

## Steps to test this PR:
1. Test that the Facebook CTP feature still works OK https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
