### PR TITLE
Rename Facebook Click to Load integration test file

### DIFF
--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -5,7 +5,7 @@ let browser
 let bgPage
 let teardown
 
-describe('Test Click To Load', () => {
+describe('Test Facebook Click To Load', () => {
     beforeAll(async () => {
         ({ browser, bgPage, teardown } = await harness.setup())
 
@@ -26,7 +26,7 @@ describe('Test Click To Load', () => {
         } catch (e) {}
     })
 
-    it('CTL: Should block FB requests by default', async () => {
+    it('CTL: Should block Facebook requests by default', async () => {
         const page = await browser.newPage()
 
         try {
@@ -52,7 +52,7 @@ describe('Test Click To Load', () => {
         } catch (e) {}
     })
 
-    xit('CTL: Should load facebook elements on click', async () => {
+    xit('CTL: Should load Facebook elements on click', async () => {
         const page = await browser.newPage()
 
         try {


### PR DESCRIPTION
Since we're planning to expand the Click to Load feature to apply to
embedded content from other companies, we should rename the
Facebook-specific integration tests.

**Reviewer:** @sammacbeth 

**CC:** @jonathanKingston @ladamski 

## Description:
I've split out the file rename from my work to make these tests more reliable. I wanted to avoid losing the commit history of this file, sometimes Git gets confused and messed up the history for files when they are renamed and changed substantially at the same time.

## Steps to test this PR:
1. Ensure the Facebook CTP integration tests still run and test (flakily).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
