### PR TITLE
Same-entity rule for 1p cookie protections

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -227,7 +227,7 @@ function handleRequest (requestData) {
         }
 
         // If we didn't block this script and it's a tracker, notify the content script.
-        if (requestData.type === 'script' && tracker) {
+        if (requestData.type === 'script' && tracker && !tracker.firstParty) {
             utils.sendTabMessage(requestData.tabId, {
                 type: 'update',
                 trackerDefinition: true,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
We are currently restricting 1p cookie access to tracker scripts which are on a 3rd party domain to the site's domain. We should, however, not be doing this for trackers which share the same ownership as the site. This PR fixes this so we properly honor our same-entity exception.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
