### PR TITLE
Don't create Tab objects for initial tabs until config is loaded.

### DIFF
--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -489,15 +489,6 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
  * on start up
  */
 const onStartup = async () => {
-    const savedTabs = await browser.tabs.query({ currentWindow: true, status: 'complete' })
-    for (let i = 0; i < savedTabs.length; i++) {
-        const tab = savedTabs[i]
-
-        if (tab.url) {
-            tabManager.create(tab)
-        }
-    }
-
     await settings.ready()
     experiment.setActiveExperiment()
 
@@ -520,6 +511,15 @@ const onStartup = async () => {
     if (userData && userData.token) {
         if (!userData.nextAlias) await fetchAlias()
         showContextMenuAction()
+    }
+
+    const savedTabs = await browser.tabs.query({ currentWindow: true, status: 'complete' })
+    for (let i = 0; i < savedTabs.length; i++) {
+        const tab = savedTabs[i]
+
+        if (tab.url) {
+            tabManager.create(tab)
+        }
     }
 }
 

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -163,10 +163,10 @@ function handleRequest (requestData) {
             // just default to true.
             const sameDomain = isSameDomainRequest(thisTab, requestData)
 
-            // only count trackers on pages with 200 response. Trackers on these sites are still
+            // Trackers on these sites are still
             // blocked below but not counted on the popup. We can also run into a case where
             // we block a tracker faster then we can update the tab so we check sameDomain.
-            if (thisTab.statusCode === 200 && sameDomain) {
+            if (sameDomain) {
                 // record all tracker urls on a site even if we don't block them
                 thisTab.site.addTracker(tracker)
 
@@ -179,10 +179,8 @@ function handleRequest (requestData) {
             browserWrapper.notifyPopup({ updateTabData: true })
             // Block the request if the site is not allowlisted
             if (blockingEnabled && tracker.action.match(/block|redirect/)) {
-                if (thisTab.statusCode === 200) {
-                    Companies.add(tracker.tracker.owner)
-                    if (sameDomain) thisTab.addOrUpdateTrackersBlocked(tracker)
-                }
+                Companies.add(tracker.tracker.owner)
+                if (sameDomain) thisTab.addOrUpdateTrackersBlocked(tracker)
 
                 // for debugging specific requests. see test/tests/debugSite.js
                 if (debugRequest && debugRequest.length) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Fixes an issue where we incorrectly showed the message "temporarily disabled Privacy Protection" for all tabs which are open on extension start.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
