### PR TITLE
Prepare release 2022.2.22

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2022.1.17",
+    "version": "2022.2.22",
     "icons": {
         "16": "img/icon_16.png",
         "48": "img/icon_48.png",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -6,7 +6,7 @@
             "strict_min_version": "65.0"
         }
     },
-    "version": "2022.1.17",
+    "version": "2022.2.22",
     "description": "Privacy, simplified. Protect your data as you search and browse: tracker blocking, smarter encryption, private search, and more.",
     "icons": {
         "16": "img/icon_16.png",

--- a/shared/data/bundled/extension-config.json
+++ b/shared/data/bundled/extension-config.json
@@ -1,6 +1,6 @@
 {
     "readme": "https://github.com/duckduckgo/privacy-configuration",
-    "version": 1642335495631,
+    "version": 1645459859348,
     "features": {
         "ampLinks": {
             "exceptions": [],
@@ -254,6 +254,28 @@
             "state": "enabled",
             "settings": {
                 "allowlistedTrackers": {
+                    "amazon-adsystem.com": {
+                        "rules": [
+                            {
+                                "rule": "c.amazon-adsystem.com/aax2/apstag.js",
+                                "domains": [
+                                    "seattletimes.com"
+                                ],
+                                "reason": "adwall"
+                            }
+                        ]
+                    },
+                    "cloudflare.com": {
+                        "rules": [
+                            {
+                                "rule": "cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.8.6/fingerprint2.min.js",
+                                "domains": [
+                                    "winnipegfreepress.com"
+                                ],
+                                "reason": "content not loading"
+                            }
+                        ]
+                    },
                     "doubleclick.net": {
                         "rules": [
                             {
@@ -284,6 +306,24 @@
                             }
                         ]
                     },
+                    "evidon.com": {
+                        "rules": [
+                            {
+                                "rule": "c.evidon.com/geo/country.js",
+                                "domains": [
+                                    "crunchyroll.com"
+                                ],
+                                "reason": "video not loading"
+                            },
+                            {
+                                "rule": "evidon.com/sitenotice/",
+                                "domains": [
+                                    "crunchyroll.com"
+                                ],
+                                "reason": "video not loading"
+                            }
+                        ]
+                    },
                     "googlesyndication.com": {
                         "rules": [
                             {
@@ -292,6 +332,54 @@
                                     "youmath.it"
                                 ],
                                 "reason": "adwall"
+                            },
+                            {
+                                "rule": "tpc.googlesyndication.com/pagead/js/loader21.html",
+                                "domains": [
+                                    "rumble.com"
+                                ],
+                                "reason": "adwall (video blocked)"
+                            }
+                        ]
+                    },
+                    "googletagmanager.com": {
+                        "rules": [
+                            {
+                                "rule": "googletagmanager.com/gtm.js",
+                                "domains": [
+                                    "rbcroyalbank.com"
+                                ],
+                                "reason": "page not loading"
+                            }
+                        ]
+                    },
+                    "shopeemobile.com": {
+                        "rules": [
+                            {
+                                "rule": "deo.shopeemobile.com/shopee/shopee-pcmall-live-sg//assets/2581.e008c4d7fc4804de8ba6.js",
+                                "domains": [
+                                    "shopee.co.id",
+                                    "shopee.co.th",
+                                    "shopee.com.br",
+                                    "shopee.com.my",
+                                    "shopee.ph",
+                                    "shopee.sg",
+                                    "shopee.tw",
+                                    "shopee.vn"
+                                ],
+                                "reason": "content not loading"
+                            }
+                        ]
+                    },
+                    "theplatform.com": {
+                        "rules": [
+                            {
+                                "rule": "pdk.theplatform.com/5.9.6/pdk/tpPdk.js",
+                                "domains": [
+                                    "bravotv.com",
+                                    "oxygen.com"
+                                ],
+                                "reason": "video not loading"
                             }
                         ]
                     },
@@ -304,6 +392,13 @@
                                     "upworthy.com"
                                 ],
                                 "reason": "content not rendering"
+                            },
+                            {
+                                "rule": "platform.twitter.com/widgets/tweet_button",
+                                "domains": [
+                                    "winnipegfreepress.com"
+                                ],
+                                "reason": "missing tweet button"
                             }
                         ]
                     }
@@ -318,7 +413,12 @@
                     "maxAge": 86400
                 }
             },
-            "exceptions": [],
+            "exceptions": [
+                {
+                    "domain": "nespresso.com",
+                    "reason": "login issues"
+                }
+            ],
             "state": "enabled"
         },
         "trackingCookies3p": {

--- a/shared/data/etags.json
+++ b/shared/data/etags.json
@@ -1,1 +1,1 @@
-{"config-etag":"W/\"6e8bb82c64dad99ce9ad87b8de7bbd28\""}
+{"config-etag":"W/\"3ac959af96a992b20f1762323bddedcc\""}


### PR DESCRIPTION
* [`f1165223`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/f11652236c31d17b9e26d01423c025486c4c0b79) - Same-entity rule for 1p cookie protections (#1035)
* [`a296f3a5`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/a296f3a5cac5178983db4734baa0cbc819cd8b17) - Implement YouTube Click to Load (#978)
* [`1308e917`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/1308e917eac264b1a9794d0c71c6d71a30dc9c99) - Improve Facebook Click to Load integration tests (#1039)
* [`49285f81`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/49285f81f00d3ad1d7dcb8c8ab5e30f952b5289a) - Reference tests integration: third party cookie blocking (#1036)
* [`7b5d9236`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/7b5d92361bb8808ed243f9ae6beb12ac855f2ca3) - Reference tests integration: Expire 1p tracking cookies tests (#1043)
* [`05a9f0a8`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/05a9f0a8331cfb3ca56c30cb7fdb7a74d966c52e) - Test ATB is loaded from storage on reload. (#1052)
* [`600ee036`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/600ee0360a38daeaf1787f2a83d5f829249b3970) - Add API schema tests for Click to Load surrogate scripts (#1041)
* [`e30d7ba8`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/e30d7ba8cc635df873a1dee9aa55ee543e2309e9) - Bump karma from 6.3.11 to 6.3.14 (#1048)
* [`013e2483`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/013e248320e7eb1f50286b66b131207aeb238d57) - Bump @babel/preset-env from 7.16.7 to 7.16.11 (#1032)
* [`2082d084`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/2082d0841bc277794d63cf4e85ac90293e02e15d) - Bump sass from 1.47.0 to 1.49.7 (#1042)
* [`8790d512`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/8790d512d428ea157c034e7474c7fb5da24ed5d6) - Don't create Tab objects for initial tabs until config is loaded. (#1056)
* [`5679f032`](http://github.com/duckduckgo/duckduckgo-privacy-extension/commit/5679f03257ada8b2392f1fae0d2737b3ac27a2bd) - Bump @babel/node from 7.16.7 to 7.16.8 (#1018)

