### PR TITLE
Implement URL tracking parameters protection feature

### DIFF
--- a/integration-test/background/url-parameters.js
+++ b/integration-test/background/url-parameters.js
@@ -1,0 +1,102 @@
+const harness = require('../helpers/harness')
+const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
+const backgroundWait = require('../helpers/backgroundWait')
+
+const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/'
+
+/**
+ * Returns the value of the `urlParametersRemoved` breakage flag for the current
+ * active tab. The flag is true/false, but null indicates failure.
+ * @param {Page} bgPage
+ *   The background extension page.
+ * @returns {boolean|null}
+ *   The value of `urlParametersRemoved` for the currently active tab, or null
+ *   on failure.
+ */
+function getUrlParametersRemoved (bgPage) {
+    return bgPage.evaluate(async () => {
+        const [{ id: tabId }] = await new Promise(resolve => {
+            chrome.tabs.query(
+                { active: true, currentWindow: true },
+                resolve
+            )
+        })
+
+        if (typeof tabId !== 'number') {
+            return null
+        }
+
+        const tab = window.dbg.tabManager.get({ tabId })
+        return tab ? tab.urlParametersRemoved : null
+    })
+}
+
+describe('Test URL tracking parameters protection', () => {
+    let browser
+    let bgPage
+    let teardown
+
+    beforeAll(async () => {
+        ({ browser, bgPage, teardown } = await harness.setup())
+        await backgroundWait.forAllConfiguration(bgPage)
+
+        // Overwrite the parts of the configuration needed for our tests.
+        await loadTestConfig(bgPage, 'url-parameters.json')
+    })
+
+    afterAll(async () => {
+        // Restore the original configuration.
+        await unloadTestConfig(bgPage)
+
+        try {
+            await teardown()
+        } catch (e) {}
+    })
+
+    it('Strips tracking parameters correctly', async () => {
+        // Load the test page.
+        const page = await browser.newPage()
+        await page.goto(testSite, { waitUntil: 'networkidle0' })
+
+        // Check that the `urlParametersRemoved` breakage flag isn't set.
+        expect(await getUrlParametersRemoved(bgPage)).toEqual(false)
+
+        // Scrape the list of test cases.
+        const testCases = []
+        for (const li of await page.$$('li')) {
+            testCases.push(await page.evaluate(li => {
+                const { innerText: description, href: initialUrl } = li.querySelector('a')
+                let { innerText: expectedSearch } = li.querySelector('.expected')
+
+                // Strip the 'Expected: "..."' wrapper if it exists.
+                const match = /"([^"]*)"/.exec(expectedSearch)
+                if (match) {
+                    expectedSearch = match[1]
+                }
+
+                let expectedUrl = new URL(initialUrl)
+                expectedUrl.search = expectedSearch
+                expectedUrl = expectedUrl.href
+
+                return { initialUrl, expectedUrl, description }
+            }, li))
+        }
+
+        // Perform the tests.
+        for (const { initialUrl, expectedUrl, description } of testCases) {
+            // Test the tracking parameters were stripped.
+            await page.goto(initialUrl, { waitUntil: 'networkidle0' })
+            expect(page.url()).withContext(description).toEqual(expectedUrl)
+
+            // Test the `urlParametersRemoved` breakage flag was set correctly.
+            // Note: `null` denotes tab not found.
+            expect(await getUrlParametersRemoved(bgPage))
+                .withContext(description + ' (urlParametersRemoved)')
+                .toEqual(expectedUrl.length < initialUrl.length)
+
+            // Reload the page, to check that `urlParametersRemoved` was cleared.
+            await page.reload({ waitUntil: 'networkidle0' })
+            expect(await getUrlParametersRemoved(bgPage)).toEqual(false)
+        }
+    })
+})

--- a/integration-test/data/configs/url-parameters.json
+++ b/integration-test/data/configs/url-parameters.json
@@ -1,0 +1,13 @@
+{
+    "window.dbg.tds.config.features.trackingParameters": {
+        "state": "enabled",
+        "exceptions": [ ],
+        "settings": {
+            "parameters": [
+                "utm_[a-z]+",
+                "fbclid",
+                "fb_source"
+            ]
+        }
+    }
+}

--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -59,39 +59,29 @@ const ATB = (() => {
             })
         },
 
-        redirectURL: (request) => {
-            if (request.url.search(regExpAboutPage) !== -1) {
-                if (request.url.indexOf('atb=') !== -1) {
-                    return
-                }
-
-                const atbSetting = settings.getSetting('atb')
-
-                if (!atbSetting) {
-                    return
-                }
-
-                // handle anchor tags for pages like about#newsletter
-                const urlParts = request.url.split('#')
-                let newURL = request.url
-                let anchor = ''
-
-                // if we have an anchor tag
-                if (urlParts.length === 2) {
-                    newURL = urlParts[0]
-                    anchor = '#' + urlParts[1]
-                }
-
-                if (request.url.indexOf('?') !== -1) {
-                    newURL += '&'
-                } else {
-                    newURL += '?'
-                }
-
-                newURL += 'atb=' + atbSetting + anchor
-
-                return { redirectUrl: newURL }
+        /**
+        * Accept the URL of a main_frame request in progress. If atb parameters
+        * should be added by redirection, mutate the URL to add the parameters
+        * and return true. Otherwise, return false.
+        * @param {URL} url
+        *   The request URL.
+        *   Note: This is mutated to add parameters where necessary.
+        * @returns {boolean}
+        *   True if parameters were added and the request should be redirected,
+        *   false otherwise.
+        */
+        addParametersMainFrameRequestUrl (url) {
+            if (url.searchParams.has('atb')) {
+                return false
             }
+
+            const atbSetting = settings.getSetting('atb')
+            if (!atbSetting || !regExpAboutPage.test(url.href)) {
+                return false
+            }
+
+            url.searchParams.append('atb', atbSetting)
+            return true
         },
 
         setInitialVersions: (numTries) => {

--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -42,6 +42,8 @@ class Tab {
         this.upgradedHttps = false
         this.hasHttpsError = false
         this.mainFrameUpgraded = false
+        this.urlParametersRemoved = false
+        this.urlParametersRemovedUrl = null
         this.requestId = tabData.requestId
         this.status = tabData.status
         this.site = new Site(this.url)

--- a/shared/js/background/url-parameters.es6.js
+++ b/shared/js/background/url-parameters.es6.js
@@ -1,0 +1,134 @@
+const Site = require('./classes/site.es6')
+const tdsStorage = require('./storage/tds.es6')
+
+/** @module */
+
+// Tracking parameters listed in the configuration are sometimes to be treated
+// as plain-text, but sometimes as regular expressions. The implementation guide
+// dictates that tracking parameter should be treated as plain-text unless they
+// contain one of the following characters: * + ? { } [ ]
+const regexpParameterTest = /[*+?{}[\]]/
+
+let plainTextTrackingParameters = null
+let regexpTrackingParameters = null
+
+function ensureTrackingParametersConfig () {
+    if (plainTextTrackingParameters && regexpTrackingParameters) {
+        return true
+    }
+
+    if (!tdsStorage.config ||
+        !tdsStorage.config.features ||
+        !tdsStorage.config.features.trackingParameters ||
+        !tdsStorage.config.features.trackingParameters.settings ||
+        !tdsStorage.config.features.trackingParameters.settings.parameters) {
+        return false
+    }
+
+    plainTextTrackingParameters = []
+    regexpTrackingParameters = []
+    for (const key of
+        tdsStorage.config.features.trackingParameters.settings.parameters) {
+        if (regexpParameterTest.test(key)) {
+            regexpTrackingParameters.push(new RegExp(key))
+        } else {
+            plainTextTrackingParameters.push(key)
+        }
+    }
+
+    return true
+}
+
+/**
+ * Strip any known tracking GET parameters from the given URL. Return true if
+ * any parameters were stripped, false otherwise.
+ * @param {URL} url
+ *   The request URL.
+ *   Note: This is mutated to add parameters where necessary.
+ * @returns {boolean}
+ *   True if tracking parameters were stripped, false otherwise.
+ */
+function stripTrackingParameters (url) {
+    let parametersRemoved = false
+
+    // No parameters, nothing to remove.
+    if (url.search.length <= 1) {
+        return parametersRemoved
+    }
+
+    // Make sure that the tracking parameters configuration has been processed
+    // since the extension config was last updated.
+    if (!ensureTrackingParametersConfig()) {
+        return parametersRemoved
+    }
+
+    // Remove any plain-text tracking parameters first, since they are cheaper
+    // to remove.
+    for (const key of plainTextTrackingParameters) {
+        if (url.searchParams.has(key)) {
+            url.searchParams.delete(key)
+            parametersRemoved = true
+        }
+    }
+
+    // No parameters left, nothing further to remove.
+    if (url.search.length <= 1) {
+        return parametersRemoved
+    }
+
+    // Remove any regular expression tracking parameters.
+    // Note: This is potentially slow, in the future it might be worth
+    //       optimising. For example, perhaps the minimum match lengths could
+    //       be stored with the regular expression tracking parameters. That
+    //       way, shorter keys could be skipped cheaply.
+    for (const key of Array.from(url.searchParams.keys())) {
+        for (const regexp of regexpTrackingParameters) {
+            if (regexp.test(key)) {
+                url.searchParams.delete(key)
+                parametersRemoved = true
+                break
+            }
+        }
+    }
+
+    return parametersRemoved
+}
+
+/**
+ * Returns true if the 'trackingParameters' feature is active for the given site
+ * and initiator URL.
+ * @param {Site} site
+ *   The Site Object for the request URL in question.
+ * @param {string} [initiatorUrl]
+ *   The initiator URL of the request (if any).
+ * @returns {boolean}
+ *   True if the 'trackingParameters' feature is active, false otherwise.
+ */
+function trackingParametersStrippingEnabled (site, initiatorUrl) {
+    // Only strip tracking parameters if the feature is enabled for the
+    // request URL (URL that the user is navigating to).
+    if (site.specialDomainName || !site.isFeatureEnabled('trackingParameters')) {
+        return false
+    }
+
+    // Also only strip tracking parameters if the feature is enabled for
+    // the initiating URL (the URL that the user navigated from, if any).
+    if (initiatorUrl) {
+        const initiatorSite = new Site(initiatorUrl)
+        if (initiatorSite.specialDomainName ||
+            !initiatorSite.isFeatureEnabled('trackingParameters')) {
+            return false
+        }
+    }
+
+    return true
+}
+
+tdsStorage.onUpdate('config', () => {
+    plainTextTrackingParameters = null
+    regexpTrackingParameters = null
+})
+
+module.exports = {
+    trackingParametersStrippingEnabled, stripTrackingParameters
+}

--- a/shared/js/ui/models/submit-breakage-form.es6.js
+++ b/shared/js/ui/models/submit-breakage-form.es6.js
@@ -7,11 +7,13 @@ module.exports = function (category) {
     // remove params and fragments from url to avoid including sensitive data
     const siteUrl = this.tab.url.split('?')[0].split('#')[0]
     const trackerObjects = this.tab.trackersBlocked
+    const urlParametersRemoved = this.tab.urlParametersRemoved ? 'true' : 'false'
     const brokenSiteParams = [
         { category: category },
         { siteUrl: encodeURIComponent(siteUrl) },
         { upgradedHttps: upgradedHttps.toString() },
-        { tds: this.tds }
+        { tds: this.tds },
+        { urlParametersRemoved }
     ]
 
     for (const tracker in trackerObjects) {

--- a/unit-test/background/atb.es6.js
+++ b/unit-test/background/atb.es6.js
@@ -54,7 +54,7 @@ describe('atb.canShowPostInstall()', () => {
     })
 })
 
-describe('atb.redirectURL()', () => {
+describe('atb.addParametersMainFrameRequestUrl()', () => {
     const tests = [
         { url: 'http://duckduckgo.com/?q=something', rewrite: true },
         { url: 'https://duckduckgo.com/?q=something', rewrite: true },
@@ -83,12 +83,13 @@ describe('atb.redirectURL()', () => {
 
     tests.forEach((test) => {
         it(`should${test.rewrite ? '' : ' not'} rewrite url: ${test.url}`, () => {
-            const result = atb.redirectURL({ url: test.url })
+            const url = new URL(test.url)
+            const result = atb.addParametersMainFrameRequestUrl(url)
 
             if (test.rewrite) {
-                expect(result.redirectUrl).toBeTruthy()
+                expect(result).toBeTrue()
             } else {
-                expect(result).toBeFalsy()
+                expect(result).toBeFalse()
             }
         })
     })
@@ -100,7 +101,10 @@ describe('atb.redirectURL()', () => {
 
     correctUrlTests.forEach((test) => {
         it(`should rewrite ${test.url} correctly`, () => {
-            expect(atb.redirectURL({ url: test.url }).redirectUrl).toEqual(test.expected)
+            const url = new URL(test.url)
+            const result = atb.addParametersMainFrameRequestUrl(url)
+            expect(result).toBeTrue()
+            expect(url.href).toEqual(test.expected)
         })
     })
 })

--- a/unit-test/background/reference-tests/url-parameters-tests.js
+++ b/unit-test/background/reference-tests/url-parameters-tests.js
@@ -1,0 +1,46 @@
+const Site = require('../../../shared/js/background/classes/site.es6')
+const tds = require('../../../shared/js/background/trackers.es6')
+const tdsStorageStub = require('../../helpers/tds.es6')
+const tdsStorage = require('../../../shared/js/background/storage/tds.es6')
+
+const config = require('../../data/reference-tests/url-parameters/config_reference.json')
+const {
+    trackingParameters: { name: featureDescription, tests }
+} = require('../../data/reference-tests/url-parameters/tests.json')
+
+const {
+    stripTrackingParameters,
+    trackingParametersStrippingEnabled
+} = require('../../../shared/js/background/url-parameters.es6')
+
+describe(featureDescription + ': ', () => {
+    beforeAll(() => {
+        tdsStorageStub.stub({ config })
+
+        return tdsStorage.getLists().then(lists => tds.setLists(lists))
+    })
+
+    for (const {
+        name: testDescription, testURL: initialUrl, initiatorURL: initiatorUrl,
+        expectURL: expectedUrl, exceptPlatforms: skippedPlatforms = []
+    } of tests) {
+        if (skippedPlatforms.includes('web-extension')) {
+            continue
+        }
+
+        it(testDescription, () => {
+            // stripTrackingParameters returns true if any parameters were
+            // removed.
+            const expectedResult = expectedUrl.length < initialUrl.length
+
+            const urlObject = new URL(initialUrl)
+            const stripResult = trackingParametersStrippingEnabled(
+                new Site(initialUrl), initiatorUrl
+            ) && stripTrackingParameters(urlObject)
+            const strippedUrl = urlObject.href
+
+            expect(stripResult).toEqual(expectedResult)
+            expect(strippedUrl).toEqual(expectedUrl)
+        })
+    }
+})


### PR DESCRIPTION
Implement the URL tracking parameters protection feature. The feature
strips known tracking parameters for navigations, assuming that
neither the initiator URL (referrer) nor request URL (destination) are
allowlisted.

See also the reference tests[1] and test pages[2] for more details.

1 - https://github.com/duckduckgo/privacy-reference-tests/tree/main/url-parameters
2 - https://privacy-test-pages.glitch.me/privacy-protections/query-parameters

**Reviewer:** @SlayterDev 
**CC:** @kdzwinel 

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
