### PR TITLE
Include notes when duplicating the testing tasks

### DIFF
--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -129,7 +129,7 @@ const run = async () => {
             testingSubtask.gid,
             {
                 name: 'Extension Testing',
-                include: ['parent', 'subtasks']
+                include: ['notes', 'parent', 'subtasks']
             }
         )
         await asana.tasks.updateTask(


### PR DESCRIPTION
**Reviewer:** @jonathanKingston @shakyShane 

## Description:
In the latest release I noticed that the testing subtasks didn't show testing steps. This should fix it.
