### PR TITLE
Add back in node module watching and building for content-scope-scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ The extension imports several DDG-owned modules (see [package.json](https://gith
     1. In the local directory of the module (e.g., `content-scope-scripts`) run `npm link`.
     2. In the extension directory run `npm link @duckduckgo/<module_name>`
     3. Verify that the link succeeded. You should see a symlink for the module in question when you run `ls -al node_modules/@duckduckgo/` from the extension directory.
-2. Manually run the module's build step (e.g., `npm run build`)
-3. Manually run the extension's build command (e.g. `make dev browser=firefox type=dev`). Running `npm run dev-firefox` will overwrite the symlink back to the remote module.
+2. Manually run the module's build step (e.g., `npm run build`) - (If you're running a watch command like dev-chrome or dev-firefox you can skip this step).
+3. Manually run the extension's build command (e.g. `npm run dev-firefox`)
 
 ### Testing
 - Unit tests: `npm test`

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,8 @@ module.exports = function (grunt) {
         baseFileMap.background['<%= dirs.public.js %>/background.js'].unshift('<%= dirs.src.js %>/background/debug.es6.js')
     }
 
+    const ddgContentScope = 'node_modules/@duckduckgo/content-scope-scripts/'
+
     /* watch any base files and browser specific files */
     const watch = {
         sass: ['<%= dirs.src.scss %>/**/*.scss'],
@@ -65,7 +67,7 @@ module.exports = function (grunt) {
         contentScripts: ['<%= dirs.src.js %>/content-scripts/*.js'],
         autofillContentScript: ['<%= ddgAutofill %>/*.js'],
         autofillCSS: ['<%= ddgAutofill %>/*.css'],
-        contentScope: ['shared/content-scope-scripts/**/*.js'],
+        contentScope: [`${ddgContentScope}/src/**/*.js`, `${ddgContentScope}/inject/**/*.js`],
         data: ['<%= dirs.data %>/*.js']
     }
 
@@ -90,6 +92,14 @@ module.exports = function (grunt) {
                 level: 'debug'
             }
         })
+    }
+
+    let contentScopeInstall = 'echo "Skipping content-scope-scripts install";'
+    let contentScopeBuild = ''
+    // If we're watching the content scope files, regenerate them
+    if (grunt.option('watch')) {
+        contentScopeInstall = `cd ${ddgContentScope} && npm install --legacy-peer-deps`
+        contentScopeBuild = `cd ${ddgContentScope} && npm run build && cd - && `
     }
 
     const ddgAutofill = 'node_modules/@duckduckgo/autofill/dist'
@@ -177,7 +187,8 @@ module.exports = function (grunt) {
         // used by watch to copy shared/js to build dir
         exec: {
             copyjs: `cp shared/js/*.js build/${browser}/${buildType}/js/ && rm build/${browser}/${buildType}/js/*.es6.js`,
-            copyContentScope: `cp node_modules/@duckduckgo/content-scope-scripts/build/${browser}/inject.js build/${browser}/${buildType}/public/js/inject.js`,
+            installContentScope: contentScopeInstall,
+            copyContentScope: `${contentScopeBuild} cp ${ddgContentScope}/build/${browser}/inject.js build/${browser}/${buildType}/public/js/inject.js`,
             copyContentScripts: `cp shared/js/content-scripts/*.js build/${browser}/${buildType}/public/js/content-scripts/`,
             copyData: `cp -r shared/data build/${browser}/${buildType}/`,
             copyAutofillJs: `mkdir -p build/${browser}/${buildType}/public/js/content-scripts/ && cp ${ddgAutofill}/*.js build/${browser}/${buildType}/public/js/content-scripts/`,
@@ -238,7 +249,17 @@ module.exports = function (grunt) {
         }
     })
 
-    grunt.registerTask('build', 'Build project(s)css, templates, js', ['sass', 'browserify:ui', 'browserify:background', 'browserify:backgroundTest', 'exec:copyContentScope', 'exec:copyAutofillJs', 'exec:copyAutofillCSS', 'exec:copyAutofillHostCSS'])
+    grunt.registerTask('build', 'Build project(s)css, templates, js', [
+        'sass',
+        'browserify:ui',
+        'browserify:background',
+        'browserify:backgroundTest',
+        'exec:installContentScope',
+        'exec:copyContentScope',
+        'exec:copyAutofillJs',
+        'exec:copyAutofillCSS',
+        'exec:copyAutofillHostCSS'
+    ])
 
     const devTasks = ['build']
     if (grunt.option('watch')) {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
         "test-int": "make setup-artifacts-dir && make dev browser=chrome type=dev && jasmine --config=integration-test/config.json",
         "test-int-x": "xvfb-run --server-args='-screen 0 1024x768x24' npm run test-int",
         "test-ci": "npm run lint && npm test && npm run test-int-x",
-        "dev-firefox": "npm install && make dev browser=firefox type=dev watch=1",
+        "dev-firefox": "make dev browser=firefox type=dev watch=1",
         "open-dev-firefox": "web-ext run -s build/firefox/dev/ -u https://privacy-test-pages.glitch.me/",
         "release-firefox": "make browser=firefox type=release",
-        "dev-chrome": "npm install && make dev browser=chrome type=dev watch=1",
+        "dev-chrome": "make dev browser=chrome type=dev watch=1",
         "beta-firefox": "make beta-firefox browser=firefox type=release",
         "release-chrome": "make browser=chrome type=release && make chrome-release-zip"
     },


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @englehardt 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

This reinstates the watching for content scope.

- I removed the `npm install` step from the dev commands to prevent overriding `npm link`.
- I skipped autofill for now as it's a little more involved and we can add it later.
- This force installs the node_module dependencies and builds it.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
