### PR TITLE
Add support for feature settings in args object

### DIFF
--- a/shared/js/background/helpers/arguments-object.js
+++ b/shared/js/background/helpers/arguments-object.js
@@ -32,6 +32,14 @@ function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
         site.enabledFeatures = site.enabledFeatures.filter(feature => aboutBlankEnabled.includes(feature))
     }
 
+    const featureSettings = {}
+    for (const feature of site.enabledFeatures) {
+        const settings = utils.getFeatureSettings(feature)
+        if (Object.keys(settings).length) {
+            featureSettings[feature] = settings
+        }
+    }
+
     // Extra contextual data required for 1p and 3p cookie protection - only send if at least one is enabled here
     if (tab.site.isFeatureEnabled('trackingCookies3p') || tab.site.isFeatureEnabled('trackingCookies1p')) {
         // determine the register domain of the sending tab
@@ -50,6 +58,7 @@ function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
         cookie.shouldBlock = !utils.isCookieExcluded(documentUrl)
     }
     return {
+        featureSettings,
         debug: devtools.isActive(tabId),
         cookie,
         globalPrivacyControlValue: settings.getSetting('GPC'),


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @SlayterDev 


## Description:

For https://github.com/duckduckgo/content-scope-scripts/pull/48 to expose the settings configuration to content scope scripts.
- This exposes the ability to do feature flag checks as otherwise the data isn't available in the content script at runtime.
- It removes the need to send blank settings objects to reduce data sent a little.

@SlayterDev This is going to be needed in your next project also for hardware fingerprinting


## Steps to test this PR: 
1. With the debugger to ensure the config is passed to the `args` property
2. Alternatively check out the content scope patch and ensure https://coveryourtracks.eff.org/ WebGL is working with the flag en/disabled.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
