### PR TITLE
Run the integration tests in headless Chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "karma-source-map-support": "1.4.0",
                 "load-grunt-tasks": "5.1.0",
                 "node-fetch": "^3.2.3",
-                "puppeteer": "13.6.0",
+                "puppeteer": "13.7.0",
                 "sass": "^1.50.1",
                 "standard": "17.0.0",
                 "timekeeper": "^2.1.1",
@@ -12139,9 +12139,9 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.6.0.tgz",
-            "integrity": "sha512-EJXhTyY5bXNPLFXPGcY9JaF6EKJIX8ll8cGG3WUK+553Jx96oDf1cB+lkFOro9p0X16tY+9xx7zYWl+vnWgW2g==",
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.7.0.tgz",
+            "integrity": "sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -12149,7 +12149,7 @@
                 "debug": "4.3.4",
                 "devtools-protocol": "0.0.981744",
                 "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.0",
+                "https-proxy-agent": "5.0.1",
                 "pkg-dir": "4.2.0",
                 "progress": "2.0.3",
                 "proxy-from-env": "1.1.0",
@@ -12173,19 +12173,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/puppeteer/node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/puppeteer/node_modules/locate-path": {
@@ -18071,7 +18058,7 @@
         "asana": {
             "version": "git+ssh://git@github.com/Asana/node-asana.git#0847653c98660e6f3e07c1487224e3583723f8ca",
             "dev": true,
-            "from": "asana@https://github.com/Asana/node-asana",
+            "from": "asana@github:Asana/node-asana",
             "requires": {
                 "bluebird": "^3.7.2",
                 "browser-request": "^0.3.2",
@@ -25218,16 +25205,16 @@
             }
         },
         "puppeteer": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.6.0.tgz",
-            "integrity": "sha512-EJXhTyY5bXNPLFXPGcY9JaF6EKJIX8ll8cGG3WUK+553Jx96oDf1cB+lkFOro9p0X16tY+9xx7zYWl+vnWgW2g==",
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.7.0.tgz",
+            "integrity": "sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==",
             "dev": true,
             "requires": {
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
                 "devtools-protocol": "0.0.981744",
                 "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.0",
+                "https-proxy-agent": "5.0.1",
                 "pkg-dir": "4.2.0",
                 "progress": "2.0.3",
                 "proxy-from-env": "1.1.0",
@@ -25245,16 +25232,6 @@
                     "requires": {
                         "locate-path": "^5.0.0",
                         "path-exists": "^4.0.0"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-                    "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "6",
-                        "debug": "4"
                     }
                 },
                 "locate-path": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "karma-source-map-support": "1.4.0",
         "load-grunt-tasks": "5.1.0",
         "node-fetch": "^3.2.3",
-        "puppeteer": "13.6.0",
+        "puppeteer": "13.7.0",
         "sass": "^1.50.1",
         "standard": "17.0.0",
         "timekeeper": "^2.1.1",


### PR DESCRIPTION
Puppeteer recently added headless support for running Chrome
extensions[1], so let's make use of that. Also, let's take care to
properly wait for the extension's background page to load.

1 - https://github.com/puppeteer/puppeteer/pull/8260

**Reviewer:** @jonathanKingston 

**CC:** @kdzwinel, @ladamski 

## Steps to test this PR:
Verify that integration tests are still passing both on CI and locally.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
