### PR TITLE
Disable failing Twitter privacy grade test case

### DIFF
--- a/integration-test/background/grades.js
+++ b/integration-test/background/grades.js
@@ -7,7 +7,8 @@ const tests = [
     { url: 'google.com', siteGrade: 'D', enhancedGrade: 'D' },
     { url: 'reddit.com', siteGrade: ['D', 'D-', 'C'], enhancedGrade: 'B' },
     { url: 'facebook.com', siteGrade: ['D', 'C+'], enhancedGrade: 'C+' },
-    { url: 'twitter.com', siteGrade: 'C', enhancedGrade: 'B' },
+    // FIXME - This case is flaking.
+    // { url: 'twitter.com', siteGrade: 'C', enhancedGrade: 'B' },
     { url: 'en.wikipedia.org', siteGrade: 'B+', enhancedGrade: 'B+' }
 ]
 


### PR DESCRIPTION
The privacy grade tests were often failing on the Twitter test case,
let's disable that one for now to get the tests passing more
reliably.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
Verify that the integration tests pass locally and in CI.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
