### PR TITLE
Require Chrome >=101 for the Chrome MV3 extension

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -9,6 +9,7 @@
         "128": "img/icon_128.png"
     },
     "manifest_version": 3,
+    "minimum_chrome_version": "101.0",
     "action": {
         "default_icon": "img/icon_48.png",
         "default_popup": "html/popup.html"


### PR DESCRIPTION
With Chrome 101 support for requestDomains match conditions was added
to the declarativeNetRequest API[1]. We need those for fundamental
extension functionality, so let's set that as the minimum version to
ensure the MV3 build of the extension works correctly.

1 - https://groups.google.com/a/chromium.org/g/chromium-extensions/c/4971ZS9cI7E/m/pkmHIGv3DgAJ

**Reviewer:** @jdorweiler 

## Steps to test this PR:
None really, this just affects the WIP Chrome MV3 build.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
