### PR TITLE
Suppress duplicate context menu error

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -51,6 +51,15 @@ browser.contextMenus.create({
     title: 'Use Duck Address',
     contexts: ['editable'],
     visible: false
+}, () => {
+    // It's fine if this context menu already exists, suppress that error.
+    // Note: Since webextension-polyfill does not wrap the contextMenus.create
+    //       API, the old callback + runtime.lastError approach must be used.
+    const { lastError } = browser.runtime
+    if (lastError &&
+        !lastError.message.startsWith('Cannot create item with duplicate id')) {
+        throw lastError
+    }
 })
 browser.contextMenus.onClicked.addListener((info, tab) => {
     const userData = getSetting('userData')


### PR DESCRIPTION
An error is thrown if our context menu already exists when we attempt
to create it. That error can be simply ignored, since there is no
further action required.

**Reviewer:** @GioSensation 

## Steps to test this PR:
1. Verify that the "Use Duck Address" context menu still works when you right click on email input fields.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
