### PR TITLE
Replace `window` usage in the background

### DIFF
--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -10,7 +10,7 @@ const https = require('./https.es6')
 const tds = require('./storage/tds.es6')
 const messageHandlers = require('./message-handlers')
 
-window.dbg = {
+self.dbg = {
     settings,
     tabManager,
     atb,

--- a/shared/js/shared-utils/parse-user-agent-string.es6.js
+++ b/shared/js/shared-utils/parse-user-agent-string.es6.js
@@ -14,7 +14,7 @@ module.exports = (uaString) => {
         version = parsedUaParts[2]
 
         // Brave doesn't include any information in the UserAgent
-        if (window.navigator.brave) {
+        if (globalThis.navigator.brave) {
             browser = 'Brave'
         }
     } catch (e) {


### PR DESCRIPTION
The background "page" of an extension is replaced with a background
ServiceWorker in Chrome MV3. ServiceWorker's do not have access to the
`window` Object, instead `self` or `globalThis` must be used.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
- Ensure the integration tests still pass.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
