### PR TITLE
Disable inject.js content script for MV3 extension

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -42,9 +42,6 @@
             "css": [
                 "public/css/noatb.css"
             ],
-            "js": [
-                "public/js/inject.js"
-            ],
             "run_at": "document_start"
         },
         {


### PR DESCRIPTION
The inject.js content script attempts to run scripts in a way that
isn't allowed with Chrome MV3. For now, let's simply disable that
content script while we get the build running.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

## Steps to test this PR:
None really, this just affects the WIP Chrome MV3 build.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
