### PR TITLE
Add Chrome MV3 integration test runner

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -1,0 +1,5 @@
+{
+    "spec_dir": "integration-test",
+    "spec_files": [
+    ]
+}

--- a/integration-test/helpers/backgroundWait.js
+++ b/integration-test/helpers/backgroundWait.js
@@ -1,3 +1,52 @@
+const puppeteer = require('puppeteer')
+
+// Puppeteer does not yet (as of 14) provide a waitForTimeout method for
+// WebWorkers.
+function manuallyWaitForTimeout (timeout) {
+    return new Promise(resolve => {
+        setTimeout(resolve, timeout)
+    })
+}
+
+function forTimeout (bgPage, timeout) {
+    if (bgPage.waitForTimeout) {
+        return bgPage.waitForTimeout(timeout)
+    }
+
+    return manuallyWaitForTimeout(timeout)
+}
+
+// Puppeteer does not yet (as of 14) provide a waitForFunction method for
+// WebWorkers. The evaluate method is available though.
+function manuallyWaitForFunction (bgPage, func, { polling, timeout }, ...args) {
+    return new Promise((resolve, reject) => {
+        const startTime = Date.now()
+        const waitForFunction = async () => {
+            let result
+            try {
+                result = await bgPage.evaluate(func, ...args)
+            } catch (e) {
+                reject(e)
+            }
+            if (result) {
+                resolve(result)
+            } else {
+                if (Date.now() - startTime > timeout) {
+                    reject(
+                        new puppeteer.errors.TimeoutError(
+                            'Manually waiting for function timed out: ' +
+                            func.toString()
+                        )
+                    )
+                } else {
+                    setTimeout(waitForFunction, polling)
+                }
+            }
+        }
+        waitForFunction()
+    })
+}
+
 // Helpers that aid in waiting for the background page's state.
 // Notes:
 //   - Puppeteer's `waitForFunction` uses `requestAnimationFrame` by default,
@@ -7,13 +56,26 @@
 //     (rather than the default of 30 seconds) to improve the error output on
 //     timeout.
 function forFunction (bgPage, func, ...args) {
-    return bgPage.waitForFunction(func, { polling: 10, timeout: 15000 }, ...args)
+    const waitForFunction = bgPage.waitForFunction
+        ? bgPage.waitForFunction.bind(bgPage)
+        : manuallyWaitForFunction.bind(null, bgPage)
+    return waitForFunction(func, { polling: 10, timeout: 15000 }, ...args)
 }
 
-function forSetting (bgPage, key) {
-    return forFunction(
-        bgPage, key => window.dbg?.settings?.getSetting(key), key
-    )
+async function forSetting (bgPage, key) {
+    try {
+        return await forFunction(
+            bgPage, key => self.dbg?.settings?.getSetting(key), key
+        )
+    } catch (e) {
+        if (e instanceof puppeteer.errors.TimeoutError) {
+            throw new puppeteer.errors.TimeoutError(
+                'Timed out waiting for setting: ' + key
+            )
+        } else {
+            throw e
+        }
+    }
 }
 
 // Note: This is likely incomplete. Please add further checks as they come up!
@@ -53,6 +115,7 @@ async function forAllConfiguration (bgPage) {
 }
 
 module.exports = {
+    forTimeout,
     forFunction,
     forSetting,
     forAllConfiguration

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "test": "grunt test --browser=chrome --type=dev",
         "test-debug": "grunt test --browser=chrome --type=dev --test-debug",
         "test-int": "make setup-artifacts-dir && make dev browser=chrome type=dev && jasmine --config=integration-test/config.json",
+        "test-int-mv3": "make setup-artifacts-dir && make dev browser=chrome-mv3 type=dev && jasmine --config=integration-test/config-mv3.json",
         "dev-firefox": "make dev browser=firefox type=dev watch=1",
         "open-dev-firefox": "web-ext run -s build/firefox/dev/ -u https://privacy-test-pages.glitch.me/",
         "release-firefox": "make browser=firefox type=release",


### PR DESCRIPTION
Add an integration test runner for Chrome MV3. This is to aid the
transition between Chrome MV2 and Chrome MV3.

Also expand on the integration test helpers to properly handle
extensions with a background ServiceWorker instead of a background
page.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Steps to test this PR:
Check that the MV2 integration tests are still passing.
Note: This PR does not actually enable any MV3 integration tests, that will come later!

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
