### PR TITLE
Fix CTP getImage exceptions

### DIFF
--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -1,6 +1,6 @@
 /* global cloneInto */
 (function clickToLoad () {
-    function sendMessage (messageType, options = {}) {
+    function sendMessage (messageType, options) {
         return new Promise((resolve, reject) => {
             chrome.runtime.sendMessage({ messageType, options }, response => {
                 if (chrome.runtime.lastError) {


### PR DESCRIPTION
When sending the "getImage" message, an empty options Object wasn't
being handled correctly and resulted in an attempt to fetch an image
called "/img/social/[object%20Object]".

This regression was introduced when Promisifying the CTP messaging
code, see https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/ad1fb76eb6ef04ad6ac79a442e24f9069ae1569f#diff-b739ace550706db1913f39023ec658272583c9b920f50576ad216ad164f289dcR2

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

**CC:** @ladamski 
**Depends on:** 

## Steps to test this PR:
1. Install the extension
2. Open the background console, clear any errors/logs.
3. Load https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/ in a new tab.
4. Ensure the placeholders (and icons in placeholders are displayed correctly).
5. Ensure there are not lots of errors about loading image "/img/social/[object%20Object]" in the background console.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
