### PR TITLE
Add executeScript and insertCSS wrappers

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -65,6 +65,7 @@
         "contextMenus",
         "declarativeNetRequest",
         "declarativeNetRequestFeedback",
+        "scripting",
         "storage",
         "tabs",
         "webRequest",

--- a/shared/js/background/onboarding.es6.js
+++ b/shared/js/background/onboarding.es6.js
@@ -9,12 +9,6 @@
 *    - Assess if the extension has been deactivated by Chrome
 *    - Reschedule the onboarding for the next restart
 */
-function createOnboardingCodeInjectedAtDocumentEnd (params) {
-    // TODO: upgrade to `chrome.scripting.executeScript` when we upgrade to manifest v3
-    // as it allows to inject a function with _arguments_. Here we simulate that in a hacky way
-    return `(${onDocumentEnd.toString()})(${JSON.stringify(params)})`
-}
-
 function onDocumentEnd ({
     isAddressBarQuery,
     showWelcomeBanner,
@@ -109,12 +103,6 @@ function onDocumentEnd ({
     }
 }
 
-function createOnboardingCodeInjectedAtDocumentStart (params) {
-    // TODO: upgrade to `chrome.scripting.executeScript` when we upgrade to manifest v3
-    // as it allows to inject a function with _arguments_. Here we simulate that in a hacky way
-    return `(${onDocumentStart.toString()})(${JSON.stringify(params)})`
-}
-
 function onDocumentStart ({ duckDuckGoSerpHostname }) {
     const hadFocusOnStart = document.hasFocus()
 
@@ -127,6 +115,6 @@ function onDocumentStart ({ duckDuckGoSerpHostname }) {
 }
 
 module.exports = {
-    createOnboardingCodeInjectedAtDocumentEnd,
-    createOnboardingCodeInjectedAtDocumentStart
+    onDocumentEnd,
+    onDocumentStart
 }

--- a/shared/js/background/wrapper.es6.js
+++ b/shared/js/background/wrapper.es6.js
@@ -64,8 +64,9 @@ export async function getDDGTabUrls () {
     const tabs = await browser.tabs.query({ url: 'https://*.duckduckgo.com/*' }) || []
 
     tabs.forEach(tab => {
-        browser.tabs.insertCSS(tab.id, {
-            file: '/public/css/noatb.css'
+        insertCSS({
+            target: { tabId: tab.id },
+            files: ['/public/css/noatb.css']
         })
     })
 
@@ -78,4 +79,129 @@ export function setUninstallURL (url) {
 
 export function changeTabURL (tabId, url) {
     return browser.tabs.update(tabId, { url })
+}
+
+function convertScriptingAPIOptionsForTabsAPI (options) {
+    if (typeof options !== 'object') {
+        throw new Error(
+            'Missing/invalid options Object.'
+        )
+    }
+
+    if (typeof options.file !== 'undefined' ||
+        typeof options.frameId !== 'undefined' ||
+        typeof options.runAt !== 'undefined' ||
+        typeof options.allFrames !== 'undefined' ||
+        typeof options.code !== 'undefined') {
+        throw new Error(
+            'Please provide options compatible with the (MV3) scripting API, ' +
+            'instead of the (MV2) tabs API.'
+        )
+    }
+
+    if (typeof options.world !== 'undefined') {
+        throw new Error(
+            'World targetting not supported by MV2.'
+        )
+    }
+
+    const { allFrames, frameIds, tabId } = options.target
+    delete options.target
+
+    if (Array.isArray(frameIds) && frameIds.length > 0) {
+        if (frameIds.length > 1) {
+            throw new Error(
+                'Targetting multiple frames by ID not supported by MV2.'
+            )
+        }
+
+        options.frameId = frameIds[0]
+    }
+
+    if (typeof options.files !== 'undefined') {
+        if (Array.isArray(options.files) && options.files.length > 0) {
+            if (options.files.length > 1) {
+                throw new Error(
+                    'Inserting multiple stylesheets/scripts in one go not supported by MV2.'
+                )
+            }
+            options.file = options.files[0]
+        }
+        delete options.files
+    }
+
+    if (typeof allFrames !== 'undefined') {
+        options.allFrames = allFrames
+    }
+
+    if (typeof options.injectImmediately !== 'undefined') {
+        if (options.injectImmediately) {
+            options.runAt = 'document_start'
+        }
+        delete options.injectImmediately
+    }
+
+    let stringifiedArgs = ''
+    if (typeof options.args !== 'undefined') {
+        if (Array.isArray(options.args)) {
+            stringifiedArgs = '...' + JSON.stringify(options.args)
+        }
+        delete options.args
+    }
+
+    if (typeof options.func !== 'undefined') {
+        if (typeof options.func === 'function') {
+            options.code = '(' + options.func.toString() + ')(' + stringifiedArgs + ')'
+        }
+        delete options.func
+    }
+
+    return [tabId, options]
+}
+
+/**
+ * Execute a script/function in the target tab.
+ * This is a wrapper around tabs.executeScript (MV2) and
+ * scripting.executeScript (MV3). Arguments are expected in the
+ * scripting.executeScript[1] format.
+ * Notes:
+ *   - Instead of passing the `code` option (JavaScript string to execute), pass
+ *     the `func` option (JavaScript function to execute).
+ *   - Some features are not supported in MV2, including targetting multiple
+ *     specific frames and targetting execution 'world'.
+ * 1 - https://developer.chrome.com/docs/extensions/reference/scripting/#method-executeScript
+ * @param {object} options
+ *   Script injection options.
+ * @param {*} result
+ *   The result of executing the script.
+ */
+export async function executeScript (options) {
+    if (typeof browser.scripting === 'undefined') {
+        return await browser.tabs.executeScript(
+            ...convertScriptingAPIOptionsForTabsAPI(options)
+        )
+    }
+
+    return await browser.scripting.executeScript(options)
+}
+
+/**
+ * Insert CSS in the target tab.
+ * This is a wrapper around tabs.insertCSS (MV2) and scripting.insertCSS (MV3).
+ * Arguments are expected in the scripting.insertCSS[1] format.
+ * Notes:
+ *   - Some features are not supported in MV2, including targetting multiple
+ *     specific frames and targetting execution 'world'.
+ * 1 - https://developer.chrome.com/docs/extensions/reference/scripting/#method-insertCSS
+ * @param {object} options
+ *   CSS insertion options.
+ */
+export async function insertCSS (options) {
+    if (typeof browser.scripting === 'undefined') {
+        return await browser.tabs.insertCSS(
+            ...convertScriptingAPIOptionsForTabsAPI(options)
+        )
+    }
+
+    return await browser.scripting.insertCSS(options)
 }


### PR DESCRIPTION
Chrome MV3 replaces tabs.executeScript and tabs.insertCSS with
scripting.executeScript and scripting.insertCSS respectively. Add API
wrappers that abstract the differences between those APIs (as far as
possible).

Also, add the "scripting" permission for the Chrome MV3 extension, so
we can use the new APIs.

See https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#code-execution

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Verify the integration tests are still passing.
2. Build and install the MV2 extension, then test the following:
  - Open a new tab, perform a search on duckduckgo.com and verify the purple welcome banner is shown.
  - Facebook Click to Play works correctly, [using the test page](https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/)
  - Click the extension icon, enable Email Protection, [using the test page](https://privacy-test-pages.glitch.me/autofill/modal.html) ensure the DuckDuckGo autofill icon is displayed for the form and works correctly.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
