### PR TITLE
Require Chrome >=102 for the Chrome MV3 extension

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -9,7 +9,7 @@
         "128": "img/icon_128.png"
     },
     "manifest_version": 3,
-    "minimum_chrome_version": "101.0",
+    "minimum_chrome_version": "102.0",
     "action": {
         "default_icon": "img/icon_48.png",
         "default_popup": "html/popup.html"


### PR DESCRIPTION
It turns out chrome.scripting.executeScript support for the
injectImmediately option[1] was only added with Chrome
102[2]. Increase the minimum supported Chrome version to 102 for the
MV3 build.

1 - https://developer.chrome.com/docs/extensions/reference/scripting/#property-ScriptInjection-injectImmediately
2 - https://bugs.chromium.org/p/chromium/issues/detail?id=1217895#c20

**Reviewer:** @jdorweiler 

## Steps to test this PR:
Nothing to test really.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
