### PR TITLE
Use `globalThis` instead of `window` in integration tests

### DIFF
--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -1,4 +1,3 @@
-/* global dbg:false */
 const harness = require('../helpers/harness')
 const backgroundWait = require('../helpers/backgroundWait')
 const pageWait = require('../helpers/pageWait')
@@ -52,9 +51,9 @@ describe('install workflow', () => {
             await backgroundWait.forSetting(bgPage, 'extiSent')
 
             await bgPage.evaluate(() => {
-                dbg.settings.removeSetting('atb')
-                dbg.settings.removeSetting('set_atb')
-                dbg.settings.removeSetting('extiSent')
+                globalThis.dbg.settings.removeSetting('atb')
+                globalThis.dbg.settings.removeSetting('set_atb')
+                globalThis.dbg.settings.removeSetting('extiSent')
             })
 
             while (requests.length) {
@@ -69,12 +68,12 @@ describe('install workflow', () => {
 
         it('should get its ATB param from atb.js when there\'s no install success page', async () => {
             // try get ATB params
-            await bgPage.evaluate(() => dbg.atb.updateATBValues())
+            await bgPage.evaluate(() => globalThis.dbg.atb.updateATBValues())
             await backgroundWait.forSetting(bgPage, 'extiSent')
 
-            const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
-            const setAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
-            const extiSent = await bgPage.evaluate(() => dbg.settings.getSetting('extiSent'))
+            const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
+            const setAtb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
+            const extiSent = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('extiSent'))
 
             // check the extension's internal state is correct
             expect(atb).toMatch(/v\d+-[1-7]/)
@@ -102,12 +101,12 @@ describe('install workflow', () => {
             await pageWait.forGoto(successPage, 'https://duckduckgo.com/?natb=v123-4ab&cp=atbhc')
 
             // try get ATB params again
-            await bgPage.evaluate(() => dbg.atb.updateATBValues())
+            await bgPage.evaluate(() => globalThis.dbg.atb.updateATBValues())
             await backgroundWait.forSetting(bgPage, 'extiSent')
 
-            const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
-            const setAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
-            const extiSent = await bgPage.evaluate(() => dbg.settings.getSetting('extiSent'))
+            const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
+            const setAtb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
+            const extiSent = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('extiSent'))
 
             // check the extension's internal state is correct
             expect(atb).toMatch(/v123-4ab/)
@@ -143,11 +142,12 @@ describe('install workflow', () => {
         it('should retreive stored ATB value on reload', async () => {
             // set an ATB value from the past
             const pastATBValue = 'v123-1'
-            await bgPage.evaluate((pastATBValue) => dbg.settings.updateSetting('atb', pastATBValue), pastATBValue)
-            // reload background
-            await bgPage.evaluate(() => window.location.reload())
+            await bgPage.evaluate((pastATBValue) => globalThis.dbg.settings.updateSetting('atb', pastATBValue), pastATBValue)
+            // Reload background
+            // FIXME - Will not work for MV3, switch to browser.runtime.reload()?
+            await bgPage.evaluate(() => globalThis.location.reload())
             await backgroundWait.forSetting(bgPage, 'extiSent')
-            const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
+            const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
             expect(atb).toEqual(pastATBValue)
         })
     })
@@ -179,45 +179,45 @@ describe('search workflow', () => {
     })
     beforeEach(async () => {
         try {
-            await bgPage.evaluate((atb) => dbg.settings.updateSetting('atb', atb), twoWeeksAgoAtb)
+            await bgPage.evaluate((atb) => globalThis.dbg.settings.updateSetting('atb', atb), twoWeeksAgoAtb)
         } catch (e) {}
     })
     it('should not update set_atb if a repeat search is made on the same day', async () => {
         // set set_atb to today's version
-        await bgPage.evaluate((todaysAtb) => dbg.settings.updateSetting('set_atb', todaysAtb), todaysAtb)
+        await bgPage.evaluate((todaysAtb) => globalThis.dbg.settings.updateSetting('set_atb', todaysAtb), todaysAtb)
 
         // run a search
         const searchPage = await browser.newPage()
         await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
-        const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
-        const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
+        const newSetAtb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
+        const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
         expect(newSetAtb).toEqual(todaysAtb)
         expect(atb).toEqual(twoWeeksAgoAtb)
     })
     it('should update set_atb if a repeat search is made on a different day', async () => {
         // set set_atb to an older version
-        await bgPage.evaluate((lastWeeksAtb) => dbg.settings.updateSetting('set_atb', lastWeeksAtb), lastWeeksAtb)
+        await bgPage.evaluate((lastWeeksAtb) => globalThis.dbg.settings.updateSetting('set_atb', lastWeeksAtb), lastWeeksAtb)
         // run a search
         const searchPage = await browser.newPage()
         await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
-        const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
-        const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
+        const newSetAtb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
+        const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
         expect(newSetAtb).toEqual(todaysAtb)
         expect(atb).toEqual(twoWeeksAgoAtb)
     })
     it('should update atb if the server passes back updateVersion', async () => {
         // set set_atb and atb to older versions
-        await bgPage.evaluate((lastWeeksAtb) => dbg.settings.updateSetting('set_atb', lastWeeksAtb), lastWeeksAtb)
-        await bgPage.evaluate(() => dbg.settings.updateSetting('atb', 'v123-6'))
+        await bgPage.evaluate((lastWeeksAtb) => globalThis.dbg.settings.updateSetting('set_atb', lastWeeksAtb), lastWeeksAtb)
+        await bgPage.evaluate(() => globalThis.dbg.settings.updateSetting('atb', 'v123-6'))
 
         // run a search
         const searchPage = await browser.newPage()
         await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
-        const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
-        const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
+        const newSetAtb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
+        const atb = await bgPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
         expect(newSetAtb).toEqual(todaysAtb)
         expect(atb).toEqual('v123-1')
     })

--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -94,14 +94,16 @@ describe('Test Facebook Click To Load', () => {
         // loaded and the content should be unblocked.
         clearRequests()
         const buttonCount = await page.evaluate(() => {
-            window.buttons =
+            globalThis.buttons =
                 Array.from(document.querySelectorAll('body > div'))
                     .map(div => div.shadowRoot && div.shadowRoot.querySelector('button'))
                     .filter(button => button)
-            return window.buttons.length
+            return globalThis.buttons.length
         })
         for (let i = 0; i < buttonCount; i++) {
-            const button = await page.evaluateHandle(i => window.buttons[i], i)
+            const button = await page.evaluateHandle(
+                i => globalThis.buttons[i], i
+            )
             try {
                 await button.click()
             } catch (e) { }

--- a/integration-test/background/grades.js
+++ b/integration-test/background/grades.js
@@ -1,4 +1,3 @@
-/* global dbg:false */
 const harness = require('../helpers/harness')
 const backgroundWait = require('../helpers/backgroundWait')
 const pageWait = require('../helpers/pageWait')
@@ -10,6 +9,7 @@ const tests = [
     { url: 'reddit.com', siteGrade: ['D', 'D-', 'C'], enhancedGrade: 'B' },
     { url: 'facebook.com', siteGrade: ['D', 'C+'], enhancedGrade: 'C+' },
     // FIXME - This case is flaking.
+    //         Enhanced grade is something B and sometimes C.
     // { url: 'twitter.com', siteGrade: 'C', enhancedGrade: 'B' },
     { url: 'en.wikipedia.org', siteGrade: 'B+', enhancedGrade: 'B+' }
 ]
@@ -22,7 +22,7 @@ let teardown
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
 
 const getGradeByUrl = (url) => {
-    const tabsById = dbg.tabManager.tabContainer
+    const tabsById = globalThis.dbg.tabManager.tabContainer
     let tab
 
     Object.keys(tabsById).some((id) => {

--- a/integration-test/background/onboarding.js
+++ b/integration-test/background/onboarding.js
@@ -21,8 +21,8 @@ describe('onboarding', () => {
     it('should manage the onboarding state and inject a script that calls window.onFirstSearchPostExtensionInstall on the first search post extension', async () => {
         const params = await bgPage.evaluate(() => {
             return {
-                showWelcomeBanner: self.dbg.settings.getSetting('showWelcomeBanner'),
-                showCounterMessaging: self.dbg.settings.getSetting('showCounterMessaging')
+                showWelcomeBanner: globalThis.dbg.settings.getSetting('showWelcomeBanner'),
+                showCounterMessaging: globalThis.dbg.settings.getSetting('showCounterMessaging')
             }
         })
 
@@ -41,8 +41,8 @@ describe('onboarding', () => {
 
         const nextParams = await bgPage.evaluate(() => {
             return {
-                showWelcomeBanner: self.dbg.settings.getSetting('showWelcomeBanner'),
-                showCounterMessaging: self.dbg.settings.getSetting('showCounterMessaging')
+                showWelcomeBanner: globalThis.dbg.settings.getSetting('showWelcomeBanner'),
+                showCounterMessaging: globalThis.dbg.settings.getSetting('showCounterMessaging')
             }
         })
 
@@ -65,15 +65,15 @@ describe('onboarding', () => {
 
         const data = await page.evaluate(() => {
             return new Promise((resolve) => {
-                window.addEventListener('message', (e) => {
-                    if (e.origin === window.location.origin && e.data.type === 'healthCheckResponse') {
+                globalThis.addEventListener('message', (e) => {
+                    if (e.origin === globalThis.location.origin && e.data.type === 'healthCheckResponse') {
                         resolve({
                             type: e.data.type,
                             isAlive: e.data.isAlive
                         })
                     }
                 })
-                window.postMessage({ type: 'healthCheckRequest' }, window.location.origin)
+                globalThis.postMessage({ type: 'healthCheckRequest' }, globalThis.location.origin)
             })
         })
 
@@ -94,12 +94,12 @@ describe('onboarding', () => {
         }, { polling: 'mutation' })
 
         await page.evaluate(() => {
-            window.postMessage({ type: 'rescheduleCounterMessagingRequest' }, window.location.origin)
+            globalThis.postMessage({ type: 'rescheduleCounterMessagingRequest' }, globalThis.location.origin)
         })
 
         await backgroundWait.forSetting(bgPage, 'rescheduleCounterMessagingOnStart')
         const rescheduleCounterMessagingOnStart = await bgPage.evaluate(() => {
-            return self.dbg.settings.getSetting('rescheduleCounterMessagingOnStart')
+            return globalThis.dbg.settings.getSetting('rescheduleCounterMessagingOnStart')
         })
         expect(rescheduleCounterMessagingOnStart).toBe(true)
 

--- a/integration-test/background/test-fingerprint.js
+++ b/integration-test/background/test-fingerprint.js
@@ -52,8 +52,8 @@ describe('Fingerprint Defense Tests', () => {
                 return {
                     availTop: screen.availTop,
                     availLeft: screen.availLeft,
-                    wAvailTop: window.screen.availTop,
-                    wAvailLeft: window.screen.availLeft,
+                    wAvailTop: globalThis.screen.availTop,
+                    wAvailLeft: globalThis.screen.availLeft,
                     colorDepth: screen.colorDepth,
                     pixelDepth: screen.pixelDepth,
                     productSub: navigator.productSub,
@@ -143,7 +143,7 @@ describe('Verify injected script is not visible to the page', () => {
             await pageWait.forGoto(page, `http://${test.url}`)
 
             const sjclVal = await page.evaluate(() => {
-                if ('sjcl' in window) {
+                if ('sjcl' in globalThis) {
                     return 'visible'
                 } else {
                     return 'invisible'

--- a/integration-test/background/url-parameters.js
+++ b/integration-test/background/url-parameters.js
@@ -27,7 +27,7 @@ function getUrlParametersRemoved (bgPage) {
             return null
         }
 
-        const tab = window.dbg.tabManager.get({ tabId })
+        const tab = globalThis.dbg.tabManager.get({ tabId })
         return tab ? tab.urlParametersRemoved : null
     })
 }

--- a/integration-test/content-scripts/autofill-test.js
+++ b/integration-test/content-scripts/autofill-test.js
@@ -23,7 +23,7 @@ describe('Autofill input detection Tests', () => {
         const page = await browser.newPage()
         await pageWait.forGoto(page, 'https://duckduckgo.com')
         await page.evaluate(() =>
-            window.postMessage({ addUserData: { userName: '', token: '' } }, window.origin)
+            globalThis.postMessage({ addUserData: { userName: '', token: '' } }, globalThis.origin)
         )
         await page.close()
     })

--- a/integration-test/content-scripts/input-detection-site-list.js
+++ b/integration-test/content-scripts/input-detection-site-list.js
@@ -344,7 +344,7 @@ const sites = [
     {
         name: 'BlazeTV newsletter',
         url: 'https://www.theblaze.com/',
-        actions: [{ action: 'evaluate', arg: () => window.scrollBy(0, window.innerHeight) }],
+        actions: [{ action: 'evaluate', arg: () => globalThis.scrollBy(0, globalThis.innerHeight) }],
         autofillExpected: 1
     },
     {

--- a/integration-test/data/configs/click-to-load-facebook.json
+++ b/integration-test/data/configs/click-to-load-facebook.json
@@ -1,5 +1,5 @@
 {
-    "window.dbg.tds.ClickToLoadConfig.Facebook": {
+    "globalThis.dbg.tds.ClickToLoadConfig.Facebook": {
         "domains": [
             "facebook.com",
             "facebook.net"

--- a/integration-test/data/configs/click-to-load-youtube.json
+++ b/integration-test/data/configs/click-to-load-youtube.json
@@ -1,5 +1,5 @@
 {
-    "window.dbg.tds.tds.trackers.youtube\\.com": {
+    "globalThis.dbg.tds.tds.trackers.youtube\\.com": {
         "owner": {
             "name": "Google LLC",
             "displayName": "YouTube",
@@ -8,7 +8,7 @@
         },
         "default": "ignore"
     },
-    "window.dbg.tds.tds.trackers.youtube-nocookie\\.com": {
+    "globalThis.dbg.tds.tds.trackers.youtube-nocookie\\.com": {
         "owner": {
             "name": "Google LLC",
             "displayName": "YouTube",
@@ -17,7 +17,7 @@
         },
         "default": "ignore"
     },
-    "window.dbg.tds.ClickToLoadConfig.Google LLC": {
+    "globalThis.dbg.tds.ClickToLoadConfig.Google LLC": {
         "domains": [
             "youtube.com",
             "youtube-nocookie.com"

--- a/integration-test/data/configs/storage-blocking.json
+++ b/integration-test/data/configs/storage-blocking.json
@@ -1,19 +1,19 @@
 {
-    "window.dbg.tds.config.features.trackingCookies3p": {
+    "globalThis.dbg.tds.config.features.trackingCookies3p": {
         "state": "enabled",
         "exceptions": [ ],
         "settings": {
             "excludedCookieDomains": [ ]
         }
     },
-    "window.dbg.tds.config.features.nonTracking3pCookies": {
+    "globalThis.dbg.tds.config.features.nonTracking3pCookies": {
         "state": "enabled",
         "exceptions": [ ],
         "settings": {
             "excludedCookieDomains": [ ]
         }
     },
-    "window.dbg.tds.config.features.trackingCookies1p": {
+    "globalThis.dbg.tds.config.features.trackingCookies1p": {
         "settings": {
             "firstPartyTrackerCookiePolicy": {
                 "threshold": 86400,
@@ -23,7 +23,7 @@
         "exceptions": [ ],
         "state": "enabled"
     },
-    "window.dbg.tds.config.features.cookie": {
+    "globalThis.dbg.tds.config.features.cookie": {
         "settings": {
             "firstPartyTrackerCookiePolicy": {
                 "threshold": 86400,

--- a/integration-test/data/configs/url-parameters.json
+++ b/integration-test/data/configs/url-parameters.json
@@ -1,5 +1,5 @@
 {
-    "window.dbg.tds.config.features.trackingParameters": {
+    "globalThis.dbg.tds.config.features.trackingParameters": {
         "state": "enabled",
         "exceptions": [ ],
         "settings": {

--- a/integration-test/helpers/apiSchema.js
+++ b/integration-test/helpers/apiSchema.js
@@ -18,7 +18,7 @@ const puppeteer = require('puppeteer')
  *   The Puppeteer page to inspect.
  * @param {string} targetObjectName
  *   The name of the Object to inspect. A string which when eval'd in the page
- *   returns the target Object. For example, "window.someApi".
+ *   returns the target Object. For example, "globalThis.someApi".
  * @returns {Object}
  *   The target Object's schema.
  */
@@ -88,7 +88,7 @@ async function getObjectSchema (page, targetObjectName) {
  *   Note: Should not include the path, that is hard-coded.
  * @param {string[]} targetObjectNames
  *   The names of Objects to inspect. Strings which when eval'd in the page
- *   return the target Objects. For example, "window.someApi".
+ *   return the target Objects. For example, "globalThis.someApi".
  * @returns {Object}
  *   The target Object's schema.
  */

--- a/integration-test/helpers/backgroundWait.js
+++ b/integration-test/helpers/backgroundWait.js
@@ -65,7 +65,7 @@ function forFunction (bgPage, func, ...args) {
 async function forSetting (bgPage, key) {
     try {
         return await forFunction(
-            bgPage, key => self.dbg?.settings?.getSetting(key), key
+            bgPage, key => globalThis.dbg?.settings?.getSetting(key), key
         )
     } catch (e) {
         if (e instanceof puppeteer.errors.TimeoutError) {
@@ -81,17 +81,17 @@ async function forSetting (bgPage, key) {
 async function forAllConfiguration (bgPage) {
     try {
         await forFunction(bgPage, async () => {
-            if (!self.dbg?.https?.isReady ||
-                !self.dbg?.settings?.ready ||
-                !self.dbg?.startup?.ready ||
-                !self.dbg?.tds?.ready) {
+            if (!globalThis.dbg?.https?.isReady ||
+                !globalThis.dbg?.settings?.ready ||
+                !globalThis.dbg?.startup?.ready ||
+                !globalThis.dbg?.tds?.ready) {
                 return false
             }
 
             await Promise.all([
-                self.dbg.settings.ready(),
-                self.dbg.startup.ready(),
-                self.dbg.tds.ready()
+                globalThis.dbg.settings.ready(),
+                globalThis.dbg.startup.ready(),
+                globalThis.dbg.tds.ready()
             ])
 
             return true

--- a/integration-test/helpers/testConfig.js
+++ b/integration-test/helpers/testConfig.js
@@ -49,12 +49,12 @@ function parsePath (path) {
  *   The file name of your JSON test configuration, in the
  *   /integration-test/data/configs/ directory.
  *    - the keys are a string containing the configuration's "path", for example
- *      "window.dbg.tds.tds.trackers.duckduckgo\\.com".
+ *      "globalThis.dbg.tds.tds.trackers.duckduckgo\\.com".
  *    - the values should be your test configuration to set for that path, for
  *      the above example an Object containing the tracker entry.
  *   Note:
  *    - Paths containing '.' can  be escaped with a backslash.
- *    - Make sure to include the 'window.' (or similar global Object) prefix.
+ *    - Make sure to include the 'globalThis.' (or similar global Object) prefix.
  *    - There's no need to escape whitespace in paths.
  */
 async function loadTestConfig (bgPage, testConfigFilename) {
@@ -64,13 +64,13 @@ async function loadTestConfig (bgPage, testConfigFilename) {
     const testConfig = JSON.parse(fs.readFileSync(filePath).toString())
 
     await bgPage.evaluate((testConfig, parsePathString) => {
-        window.configBackup = window.configBackup || {}
+        globalThis.configBackup = globalThis.configBackup || {}
         // eslint-disable-next-line no-eval
         eval(parsePathString)
 
         for (const path of Object.keys(testConfig)) {
             const [target, lastPathPart] = parsePath(path)
-            window.configBackup[path] = target[lastPathPart]
+            globalThis.configBackup[path] = target[lastPathPart]
             target[lastPathPart] = testConfig[path]
         }
     }, testConfig, parsePath.toString())
@@ -83,7 +83,7 @@ async function loadTestConfig (bgPage, testConfigFilename) {
  */
 async function unloadTestConfig (bgPage) {
     await bgPage.evaluate(parsePathString => {
-        const { configBackup } = window
+        const { configBackup } = globalThis
         if (!configBackup) {
             return
         }


### PR DESCRIPTION
With Chrome Manifest V3, the extension's background page is replaced
with a background ServiceWorker that no longer has access to a
`window` Object. Let's replace (where possible) references to the
`window` Object (and implicit references to `window.dbg`) with
references to `globalThis`. While this isn't enough to get the
integration tests passing for Chrome MV3, it removes one more reason
for the tests to fail!

Note: Some references to `window` would have worked, since they are in
      a page instead of the background ServiceWorker. `self` would
      have worked too. Let's replace those anyway, to set a clear
      example about which global Object to use.

**Reviewer:** @jonathanKingston 
**CC:** @ladamski 

## Steps to test this PR:
1. Ensure integration tests are still passing.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
