### PR TITLE
Save integration test artifacts before running MV3 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,10 +55,10 @@ jobs:
         sudo apt-get install xvfb
         npm run install-ci
     - run: npm run test-int
-    - run: npm run test-int-mv3
     - name: Store test artifacts
       if: always()
       uses: actions/upload-artifact@v2
       with:
         name: integration-test-artifacts
         path: integration-test/artifacts
+    - run: npm run test-int-mv3


### PR DESCRIPTION
The test artifacts from the MV2 integration tests are cleared when we
run the MV3 integration tests, so we should save them beforehand.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
1. Check that GitHub saves the integration test artifacts successfully.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
