### PR TITLE
Use backgroundWait and pageWait integration test helpers consistently

### DIFF
--- a/integration-test/background/atb.js
+++ b/integration-test/background/atb.js
@@ -1,6 +1,8 @@
 /* global dbg:false */
 const harness = require('../helpers/harness')
 const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
+
 const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args))
 
 let browser
@@ -28,7 +30,7 @@ describe('install workflow', () => {
             while (!postInstallOpened) {
                 const urls = await Promise.all(browser.targets().map(target => target.url()))
                 postInstallOpened = urls.some(url => url.includes('duckduckgo.com/app?post=1'))
-                await bgPage.waitForTimeout(100)
+                await backgroundWait.forTimeout(bgPage, 100)
             }
 
             expect(postInstallOpened).toBeTruthy()
@@ -97,11 +99,7 @@ describe('install workflow', () => {
         it('should get its ATB param from the success page when one is present', async () => {
             // open a success page and wait for it to have finished loading
             const successPage = await browser.newPage()
-            try {
-                await successPage.goto('https://duckduckgo.com/?natb=v123-4ab&cp=atbhc')
-            } catch (e) {
-                // goto may time out, but continue test anyway in case of partial load.
-            }
+            await pageWait.forGoto(successPage, 'https://duckduckgo.com/?natb=v123-4ab&cp=atbhc')
 
             // try get ATB params again
             await bgPage.evaluate(() => dbg.atb.updateATBValues())
@@ -190,13 +188,7 @@ describe('search workflow', () => {
 
         // run a search
         const searchPage = await browser.newPage()
-        try {
-            await searchPage.goto('https://duckduckgo.com/?q=test')
-            // Extra wait for page load
-            await bgPage.waitForTimeout(1000)
-        } catch (e) {
-            // goto may time out, but continue test anyway in case of partial load.
-        }
+        await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
         const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
         const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
@@ -208,13 +200,7 @@ describe('search workflow', () => {
         await bgPage.evaluate((lastWeeksAtb) => dbg.settings.updateSetting('set_atb', lastWeeksAtb), lastWeeksAtb)
         // run a search
         const searchPage = await browser.newPage()
-        try {
-            await searchPage.goto('https://duckduckgo.com/?q=test', { waitUntil: 'networkidle0' })
-            // Extra wait for page load
-            await bgPage.waitForTimeout(1000)
-        } catch (e) {
-            // goto may time out, but continue test anyway in case of partial load.
-        }
+        await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
         const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
         const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))
@@ -228,13 +214,7 @@ describe('search workflow', () => {
 
         // run a search
         const searchPage = await browser.newPage()
-        try {
-            await searchPage.goto('https://duckduckgo.com/?q=test', { waitUntil: 'networkidle0' })
-            // Extra wait for page load
-            await bgPage.waitForTimeout(1000)
-        } catch (e) {
-            // goto may time out, but continue test anyway in case of partial load.
-        }
+        await pageWait.forGoto(searchPage, 'https://duckduckgo.com/?q=test')
 
         const newSetAtb = await bgPage.evaluate(() => dbg.settings.getSetting('set_atb'))
         const atb = await bgPage.evaluate(() => dbg.settings.getSetting('atb'))

--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -109,9 +109,7 @@ describe('Test Facebook Click To Load', () => {
 
         // Wait for the embedded content to finish loading, but give up after
         // 15 seconds. That avoids the tests failing if the network is slow.
-        try {
-            await page.waitForNetworkIdle({ idleTime: 1000, timeout: 15000 })
-        } catch (e) { }
+        await pageWait.forNetworkIdle(page)
 
         {
             const {

--- a/integration-test/background/click-to-load-youtube.js
+++ b/integration-test/background/click-to-load-youtube.js
@@ -105,7 +105,7 @@ describe('Test YouTube Click To Load', () => {
             '.shadowRoot.querySelector("button")'
         )
         await button.click()
-        await page.waitForNetworkIdle({ idleTime: 1000 })
+        await pageWait.forNetworkIdle(page)
         {
             const {
                 youTubeIframeApi, youTubeStandard, youTubeNocookie
@@ -142,7 +142,7 @@ describe('Test YouTube Click To Load', () => {
             '.shadowRoot.querySelector("#DuckDuckGoPrivacyEssentialsCTLElementTitleTextButton")'
         )
         await headerButton.click()
-        await page.waitForNetworkIdle({ idleTime: 1000 })
+        await pageWait.forNetworkIdle(page)
         {
             const {
                 youTubeIframeApi, youTubeStandard, youTubeNocookie
@@ -180,7 +180,7 @@ describe('Test YouTube Click To Load', () => {
             )
             await button.click()
             await waitForExpectedBorder('orange')
-            await page.waitForNetworkIdle({ idleTime: 1000 })
+            await pageWait.forNetworkIdle(page)
 
             await page.click('#play-existing-video')
             await waitForExpectedBorder('green')
@@ -212,7 +212,7 @@ describe('Test YouTube Click To Load', () => {
             await button.focus()
             await button.click()
             await waitForExpectedRoll('0.0000')
-            await page.waitForNetworkIdle({ idleTime: 1000 })
+            await pageWait.forNetworkIdle(page)
 
             // Play video and keep clicking roll button until it flips. The
             // video doesn't flip until its finished loading, so this way we

--- a/integration-test/background/https-loop-protection.js
+++ b/integration-test/background/https-loop-protection.js
@@ -2,8 +2,9 @@
  *  Tests for https upgrading to prevent infinate loops
  */
 
-/* global dbg:false */
 const harness = require('../helpers/harness')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
 
 let browser
 let bgPage
@@ -12,12 +13,7 @@ let teardown
 describe('Loop protection', () => {
     beforeAll(async () => {
         ({ browser, bgPage, teardown } = await harness.setup())
-
-        // wait for HTTPs to successfully load
-        await bgPage.waitForFunction(
-            () => window.dbg && dbg.https.isReady,
-            { polling: 100, timeout: 60000 }
-        )
+        await backgroundWait.forAllConfiguration(bgPage)
     })
     afterAll(async () => {
         await teardown()
@@ -27,11 +23,7 @@ describe('Loop protection', () => {
         const loopProtectionPage = 'https://good.third-party.site/privacy-protections/https-loop-protection/'
         const page = await browser.newPage()
 
-        try {
-            await page.goto(loopProtectionPage, { waitUntil: 'networkidle0' })
-        } catch (e) {
-            // timed out waiting for page to load, let's try running the test anyway
-        }
+        await pageWait.forGoto(page, loopProtectionPage)
         await page.click('#start')
         await page.waitForFunction(
             () => results.date !== null && results.results[0].value !== null,

--- a/integration-test/background/onboarding.js
+++ b/integration-test/background/onboarding.js
@@ -1,5 +1,6 @@
 const harness = require('../helpers/harness')
 const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
 
 let browser, bgPage, teardown
 
@@ -30,10 +31,7 @@ describe('onboarding', () => {
 
         const page = await browser.newPage()
 
-        await page.goto(
-            'https://duckduckgo.com/?q=hello',
-            { waitUntil: ['load', 'domcontentloaded', 'networkidle0'] }
-        )
+        await pageWait.forGoto(page, 'https://duckduckgo.com/?q=hello')
 
         const hasScriptHandle = await page.waitForFunction(() => {
             const scripts = document.querySelectorAll('script:not([src])')
@@ -57,10 +55,7 @@ describe('onboarding', () => {
     it('should allow the site to perform extension health checks (Chrome only)', async () => {
         const page = await browser.newPage()
 
-        await page.goto(
-            'https://duckduckgo.com/?q=hello',
-            { waitUntil: ['load', 'domcontentloaded', 'networkidle0'] }
-        )
+        await pageWait.forGoto(page, 'https://duckduckgo.com/?q=hello')
 
         // we wait that the onboarding content script is injected
         await page.waitForFunction(() => {
@@ -90,10 +85,7 @@ describe('onboarding', () => {
 
     it('should allow the site to reschedule the counter messaging (Chrome only)', async () => {
         const page = await browser.newPage()
-        await page.goto(
-            'https://duckduckgo.com/?q=hello',
-            { waitUntil: ['load', 'domcontentloaded', 'networkidle0'] }
-        )
+        await pageWait.forGoto(page, 'https://duckduckgo.com/?q=hello')
 
         // we wait that the onboarding content script is injected
         await page.waitForFunction(() => {

--- a/integration-test/background/url-parameters.js
+++ b/integration-test/background/url-parameters.js
@@ -1,6 +1,7 @@
 const harness = require('../helpers/harness')
 const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
 const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
 
 const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/'
 
@@ -56,7 +57,7 @@ describe('Test URL tracking parameters protection', () => {
     it('Strips tracking parameters correctly', async () => {
         // Load the test page.
         const page = await browser.newPage()
-        await page.goto(testSite, { waitUntil: 'networkidle0' })
+        await pageWait.forGoto(page, testSite)
 
         // Check that the `urlParametersRemoved` breakage flag isn't set.
         expect(await getUrlParametersRemoved(bgPage)).toEqual(false)
@@ -85,7 +86,7 @@ describe('Test URL tracking parameters protection', () => {
         // Perform the tests.
         for (const { initialUrl, expectedUrl, description } of testCases) {
             // Test the tracking parameters were stripped.
-            await page.goto(initialUrl, { waitUntil: 'networkidle0' })
+            await pageWait.forGoto(page, initialUrl)
             expect(page.url()).withContext(description).toEqual(expectedUrl)
 
             // Test the `urlParametersRemoved` breakage flag was set correctly.
@@ -95,7 +96,7 @@ describe('Test URL tracking parameters protection', () => {
                 .toEqual(expectedUrl.length < initialUrl.length)
 
             // Reload the page, to check that `urlParametersRemoved` was cleared.
-            await page.reload({ waitUntil: 'networkidle0' })
+            await pageWait.forReload(page)
             expect(await getUrlParametersRemoved(bgPage)).toEqual(false)
         }
     })

--- a/integration-test/content-scripts/autofill-test.js
+++ b/integration-test/content-scripts/autofill-test.js
@@ -2,8 +2,9 @@
  *  Test autofill
  */
 
-/* global dbg:false */
 const harness = require('../helpers/harness')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
 const _sites = require('./input-detection-site-list')
 
 // Add sites to the focusedSites to only execute those
@@ -16,15 +17,11 @@ let teardown
 describe('Autofill input detection Tests', () => {
     beforeAll(async () => {
         ({ browser, bgPage, teardown } = await harness.setup())
+        await backgroundWait.forAllConfiguration(bgPage)
 
-        // wait for HTTPs to successfully load
-        await bgPage.waitForFunction(
-            () => window.dbg && dbg.https.isReady,
-            { polling: 100, timeout: 60000 }
-        )
         // Sign in in the extension
         const page = await browser.newPage()
-        await page.goto('https://duckduckgo.com', { waitUntil: 'networkidle0' })
+        await pageWait.forGoto(page, 'https://duckduckgo.com')
         await page.evaluate(() =>
             window.postMessage({ addUserData: { userName: '', token: '' } }, window.origin)
         )
@@ -41,18 +38,14 @@ describe('Autofill input detection Tests', () => {
             const ua = await browser.userAgent()
             await page.setUserAgent(ua.replace(/Headless /, '') + ' test')
 
-            try {
-                await page.goto(`${url}`, { waitUntil: 'networkidle0' })
-            } catch (e) {
-                // timed out waiting for page to load, let's try running the test anyway
-            }
+            await pageWait.forGoto(page, `${url}`)
 
             if (actions) {
                 for (const action of actions) {
                     await page[action.action](action.arg)
                         .catch(e => !action.optional && fail(`Action ${action.action} failed on ${name}: ${e.message}.`))
                     // Wait a bit to give it time to execute. If you need more, add an explicit waitFor action
-                    await page.waitForTimeout(750)
+                    await backgroundWait.forTimeout(bgPage, 750)
                 }
             }
 

--- a/integration-test/content-scripts/gpc.js
+++ b/integration-test/content-scripts/gpc.js
@@ -2,8 +2,9 @@
  *  Tests for injecting GPC into the page, these tests load a example website server.
  */
 
-/* global dbg:false */
 const harness = require('../helpers/harness')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
 
 let browser
 let bgPage
@@ -49,11 +50,7 @@ describe('Ensure GPC is injected into frames', () => {
         server = setupServer({}, 8080)
         server2 = setupServer({}, 8081)
 
-        // wait for HTTPs to successfully load
-        await bgPage.waitForFunction(
-            () => window.dbg && dbg.https.isReady,
-            { polling: 100, timeout: 6000 }
-        )
+        await backgroundWait.forAllConfiguration(bgPage)
     })
     afterAll(async () => {
         await server.close()
@@ -65,7 +62,7 @@ describe('Ensure GPC is injected into frames', () => {
         it(`${iframeHost} frame should match the parent frame`, async () => {
             const page = await browser.newPage()
             // Load an page with an iframe from a different hostname
-            await page.goto(`http://127.0.0.1:8080/index.html?host=${iframeHost}`, { waitUntil: 'networkidle0' })
+            await pageWait.forGoto(page, `http://127.0.0.1:8080/index.html?host=${iframeHost}`)
             const gpc = await getGPCValueOfContext(page)
 
             const iframe = page.frames().find(iframe => iframe.url() === iframeHost + '/framed.html')
@@ -77,7 +74,7 @@ describe('Ensure GPC is injected into frames', () => {
 
         it(`${iframeHost} should work with about:blank injected frames`, async () => {
             const page = await browser.newPage()
-            await page.goto('http://127.0.0.1:8080/blank_framer.html', { waitUntil: 'networkidle0' })
+            await pageWait.forGoto(page, 'http://127.0.0.1:8080/blank_framer.html')
             const gpc = await getGPCValueOfContext(page)
 
             const iframe = page.frames().find(iframe => iframe.url() === 'about:blank')

--- a/integration-test/helpers/pageWait.js
+++ b/integration-test/helpers/pageWait.js
@@ -1,24 +1,61 @@
+const puppeteer = require('puppeteer')
+
+async function waitForNetworkIdleInternal (page) {
+    try {
+        await page.waitForNetworkIdle({ idleTime: 1000, timeout: 15000 })
+    } catch (e) {
+        if (e instanceof puppeteer.errors.TimeoutError) {
+            throw new puppeteer.errors.TimeoutError(
+                'Timed out waiting for network idle.'
+            )
+        } else {
+            throw e
+        }
+    }
+}
+
+async function forNetworkIdle (page) {
+    try {
+        await waitForNetworkIdleInternal(page)
+    } catch (e) {
+        if (e instanceof puppeteer.errors.TimeoutError) {
+            pending(e.message)
+        } else {
+            throw e
+        }
+    }
+}
+
 async function forGoto (page, url) {
     try {
         await page.goto(
             url, { waitUntil: 'networkidle0', timeout: 15000 }
         )
-        await page.waitForNetworkIdle({ idleTime: 1000, timeout: 15000 })
+        await waitForNetworkIdleInternal(page)
     } catch (e) {
-        pending('Failed to load URL: ' + url)
+        if (e instanceof puppeteer.errors.TimeoutError) {
+            pending('Timed out loading URL: ' + url)
+        } else {
+            throw e
+        }
     }
 }
 
 async function forReload (page) {
     try {
         await page.reload({ waitUntil: 'networkidle0', timeout: 15000 })
-        await page.waitForNetworkIdle({ idleTime: 1000, timeout: 15000 })
+        await waitForNetworkIdleInternal(page)
     } catch (e) {
-        pending('Failed to reload page: ' + page.url())
+        if (e instanceof puppeteer.errors.TimeoutError) {
+            pending('Timed out reloading page: ' + page.url())
+        } else {
+            throw e
+        }
     }
 }
 
 module.exports = {
     forGoto,
-    forReload
+    forReload,
+    forNetworkIdle
 }


### PR DESCRIPTION
Use the `backgroundWait` and `pageWait` integration test helpers
consistently. That way, we can avoid repeating code and avoid failing
when pages/requests load too slowly. It also means that we're properly
waiting for the extension configuration to have loaded before running
the tests.

Along with that, expand the `pageWait` test helpers to provide more
useful output on timeout and to provide a `waitForNetworkIdle` wrapper.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
1. Ensure integration tests are still passing.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
