### PR TITLE
Fire handleRequest onBeforeRequest listener for all request types

### DIFF
--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -16,7 +16,6 @@ function getConfigFileName () {
 
 module.exports = {
     displayCategories: ['Analytics', 'Advertising', 'Social Network'],
-    requestListenerTypes: ['main_frame', 'sub_frame', 'stylesheet', 'script', 'image', 'object', 'xmlhttprequest', 'websocket', 'other'], // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
     feedbackUrl: 'https://duckduckgo.com/feedback.js?type=extension-feedback',
     tosdrMessages: {
         A: 'Good',

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -177,16 +177,12 @@ const redirect = require('./redirect.es6')
 const tabManager = require('./tab-manager.es6')
 const https = require('./https.es6')
 
-const requestListenerTypes = utils.getUpdatedRequestListenerTypes()
-
-// Shallow copy of request types
 // And add beacon type based on browser, so we can block it
 if (manifestVersion === 2) {
     browser.webRequest.onBeforeRequest.addListener(
         redirect.handleRequest,
         {
-            urls: ['<all_urls>'],
-            types: requestListenerTypes
+            urls: ['<all_urls>']
         },
         ['blocking']
     )

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -4,7 +4,6 @@ import tdsStorage from './storage/tds.es6'
 import settings from './settings.es6'
 import load from './load.es6'
 import * as tldts from 'tldts'
-import constants from '../../data/constants'
 import parseUserAgentString from '../shared-utils/parse-user-agent-string.es6'
 const browserInfo = parseUserAgentString()
 
@@ -128,31 +127,6 @@ export function getClickToPlaySupport (tab) {
         return false
     }
     return (tab && tab.site.isFeatureEnabled('clickToPlay'))
-}
-
-// Chrome errors with 'beacon', but supports 'ping'
-// Firefox only blocks 'beacon' (even though it should support 'ping')
-export function getBeaconName () {
-    const beaconNamesByBrowser = {
-        chrome: 'ping',
-        moz: 'beacon',
-        edg: 'ping',
-        brave: 'ping',
-        default: 'ping'
-    }
-    let name = getBrowserName()
-    if (!Object.keys(beaconNamesByBrowser).includes(name)) {
-        name = 'default'
-    }
-    return beaconNamesByBrowser[name]
-}
-
-// Return requestListenerTypes + beacon or ping
-export function getUpdatedRequestListenerTypes () {
-    const requestListenerTypes = constants.requestListenerTypes.slice()
-    requestListenerTypes.push(getBeaconName())
-
-    return requestListenerTypes
 }
 
 // return true if browser allows to handle request async

--- a/unit-test/background/utils.es6.js
+++ b/unit-test/background/utils.es6.js
@@ -112,14 +112,6 @@ describe('utils.extractHostFromURL()', () => {
     })
 })
 
-describe('utils.getUpgradeToSecureSupport()', () => {
-    it('should return ping in headless chrome', () => {
-        const result = utils.getBeaconName()
-        const chromeBeaconName = 'ping'
-        expect(result).toEqual(chromeBeaconName)
-    })
-})
-
 describe('utils.isSameTopLevelDomain()', () => {
     [
         ['example.com', 'example.com', true],


### PR DESCRIPTION
Our main webRequest.onBeforeRequest listener, responsible for core
extension functionality like tracker blocking and smarter encryption
only fired for a subset of the available request types:

  ["main_frame", "sub_frame", "stylesheet", "script", "image",
   "object", "xmlhttprequest", "websocket", "other", "ping"/"beacon"]

At the time of writing, that misses the following request types on
Chrome:

  ["csp_report", "font", "media"]

and the following requests types on Firefox:

  ["object_subrequest", "xslt", "xml_dtd", "font", "media",
   "csp_report", "imageset", "web_manifest", "speculative"]

We want to intercept all request types, and since the default is to simply
match all request types[1], we can just remove the request type filter
entirely.

1 - https://chromium.googlesource.com/chromium/src/+/11e044a9241cbda03dc09c899d1663c93ec32570/chrome/browser/extensions/api/web_request/web_request_api.cc#1297

**Reviewer:** @kdzwinel 

## Steps to test this PR:
1. Ensure tracker blocking and smarter encryption is still working correctly. You could use [the test pages](https://privacy-test-pages.glitch.me/), or you could smoke test (e.g. navigate to http://nginx.org and check you're upgraded to HTTPS and check trackers are blocked for news websites).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
