### PR TITLE
Properly handle requests initiated by ServiceWorkers

### DIFF
--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -48,7 +48,17 @@ class Tab {
         this.cleanAmpUrl = null
         this.requestId = tabData.requestId
         this.status = tabData.status
-        this.site = new Site(this.url)
+
+        // Consider the site URL to be the request initiator for requests fired
+        // inside opaque 'tabs' (e.g. via ServiceWorkers). Otherwise, consider
+        // the site URL to be the request URL.
+        const requestInitiator = tabData.initiator || tabData.originUrl
+        if (this.id === -1 && requestInitiator) {
+            this.site = new Site(requestInitiator)
+        } else {
+            this.site = new Site(this.url)
+        }
+
         this.httpsRedirects = new HttpsRedirects()
         this.statusCode = null // statusCode is set when headers are recieved in tabManager.js
         this.stopwatch = {
@@ -56,7 +66,13 @@ class Tab {
             end: null,
             completeMs: null
         }
-        this.resetBadgeIcon()
+
+        // Set the default extension icon for the new tab, assuming it's really
+        // a tab (e.g. not a ServiceWorker).
+        if (this.id !== -1) {
+            this.resetBadgeIcon()
+        }
+
         this.webResourceAccess = []
         this.surrogates = {}
     };

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -83,9 +83,6 @@ function handleAmpRedirect (thisTab, url) {
 
 function handleRequest (requestData) {
     const tabId = requestData.tabId
-    // Skip requests to background tabs
-    if (tabId === -1) { return }
-
     let thisTab = tabManager.get(requestData)
 
     // control access to web accessible resources

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -8,6 +8,11 @@ class TabManager {
         this.tabContainer = {}
     };
 
+    _createInternal (tabData) {
+        const normalizedData = browserWrapper.normalizeTabData(tabData)
+        return new Tab(normalizedData)
+    }
+
     /* This overwrites the current tab data for a given
      * id and is only called in three cases:
      * 1. When we rebuild saved tabs when the browser is restarted
@@ -15,8 +20,7 @@ class TabManager {
      * 3. When we get a new main_frame request
      */
     create (tabData) {
-        const normalizedData = browserWrapper.normalizeTabData(tabData)
-        const newTab = new Tab(normalizedData)
+        const newTab = this._createInternal(tabData)
 
         const oldTab = this.tabContainer[newTab.id]
         if (oldTab) {
@@ -36,6 +40,12 @@ class TabManager {
      * get({tabId: ###});
      */
     get (tabData) {
+        // Opaque 'tab' (e.g. ServiceWorker). Create the Tab Object, but don't
+        // store it for later lookup.
+        if (tabData.tabId === -1) {
+            return this._createInternal(tabData)
+        }
+
         return this.tabContainer[tabData.tabId]
     };
 


### PR DESCRIPTION
Requests initiated by ServiceWorkers are given a tabId of -1, but we
still want to block tracking requests that they might make. So let's:
 - Stop ignoring requests with a tabId of -1.
 - Create an opaque Tab Object for those requests, but skip storing it
   for later lookup (since by definition we aren't sure which tab the
   request originated from).
 - Consider the site URL for such requests to be the request
   initiator, when available. Otherwise, the request will always be
   considered to have originated from its own URL and will therefore
   always be considered a first party request.

**Reviewer:** @kdzwinel 

## Steps to test this PR:
1. Check that ServiceWorker initiated requests can be blocked, e.g. by using the test page https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
