### PR TITLE
Add createAlarm wrapper to avoid overwriting existing alarms

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill'
 const { getSetting, updateSetting } = require('./settings.es6')
+const browserWrapper = require('./wrapper.es6')
 const REFETCH_ALIAS_ALARM = 'refetchAlias'
 
 // Keep track of the number of attempted fetches. Stop trying after 5.
@@ -36,7 +37,7 @@ const fetchAlias = () => {
             console.log('Error fetching new alias', e)
             // Don't try fetching more than 5 times in a row
             if (attempts < 5) {
-                browser.alarms.create(REFETCH_ALIAS_ALARM, { delayInMinutes: 2 })
+                browserWrapper.createAlarm(REFETCH_ALIAS_ALARM, { delayInMinutes: 2 })
                 attempts++
             }
             // Return the error so we can handle it

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -432,17 +432,17 @@ const httpsService = require('./https-service.es6')
 const trackers = require('./trackers.es6')
 
 // recheck tracker and https lists every 12 hrs
-browser.alarms.create('updateHTTPSLists', { periodInMinutes: 12 * 60 })
+browserWrapper.createAlarm('updateHTTPSLists', { periodInMinutes: 12 * 60 })
 // tracker lists / content blocking lists are 30 minutes
-browser.alarms.create('updateLists', { periodInMinutes: 30 })
+browserWrapper.createAlarm('updateLists', { periodInMinutes: 30 })
 // update uninstall URL every 10 minutes
-browser.alarms.create('updateUninstallURL', { periodInMinutes: 10 })
+browserWrapper.createAlarm('updateUninstallURL', { periodInMinutes: 10 })
 // remove expired HTTPS service entries
-browser.alarms.create('clearExpiredHTTPSServiceCache', { periodInMinutes: 60 })
+browserWrapper.createAlarm('clearExpiredHTTPSServiceCache', { periodInMinutes: 60 })
 // Rotate the user agent spoofed
-browser.alarms.create('rotateUserAgent', { periodInMinutes: 24 * 60 })
+browserWrapper.createAlarm('rotateUserAgent', { periodInMinutes: 24 * 60 })
 // Rotate the sessionKey
-browser.alarms.create('rotateSessionKey', { periodInMinutes: 24 * 60 })
+browserWrapper.createAlarm('rotateSessionKey', { periodInMinutes: 24 * 60 })
 
 browser.alarms.onAlarm.addListener(async alarmEvent => {
     if (alarmEvent.name === 'updateHTTPSLists') {

--- a/shared/js/background/wrapper.es6.js
+++ b/shared/js/background/wrapper.es6.js
@@ -254,3 +254,20 @@ export async function getFromSessionStorage (key) {
 
     return sessionStorageFallback.get(key)
 }
+
+/**
+ * Create an alarm, taking care to check it doesn't exist first.
+ * See https://stackoverflow.com/questions/66391018/how-do-i-call-a-function-periodically-in-a-manifest-v3-chrome-extension/66391601#66391601
+ * @param {string} name
+ *   The alarm name.
+ * @param {Object} alarmInfo
+ *   Details that determine when the alarm should fire.
+ *   See https://developer.chrome.com/docs/extensions/reference/alarms/#type-AlarmCreateInfo
+ * @return {Promise}
+ */
+export async function createAlarm (name, alarmInfo) {
+    const existingAlarm = await browser.alarms.get(name)
+    if (!existingAlarm) {
+        return await browser.alarms.create(name, alarmInfo)
+    }
+}


### PR DESCRIPTION
With Manifest v3, the background ServiceWorker restarts often. It
turns out that the code that sets up periodic alarms is re-run each
time the ServiceWorker restarts, and that causes the alarms to
reset - they are always X minutes from firing, but will never fire!

We need to take care to check an alarm doesn't already exist, before
attempting to create it. Let's add a createAlarms wrapper to make that
easy to get right.

See also this great writeup by wOxxOm:
https://stackoverflow.com/questions/66391018/how-do-i-call-a-function-periodically-in-a-manifest-v3-chrome-extension/66391601#66391601

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 
**CC:** @jonathanKingston 

## Steps to test this PR:
1. This is not easy to test, but the easiest way is probably to add console logging to `onAlarm` listener in events.es6.js to ensure the scheduled alarms fire when expected.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
