### PR TITLE
Fix FB.api callback in fb-sdk.js "surrogate script"

### DIFF
--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -117,7 +117,7 @@
 
     if (!window.FB) {
         window.FB = {
-            api: function () {},
+            api: function (url, cb) { cb() },
             init: function (obj) {
                 if (obj) {
                     initData = obj


### PR DESCRIPTION
It turns out that the FB.api() function accepts a callback, which the
caller may then wait to be called. Let's ensure the callback is
called, to avoid breaking websites that expect it to be.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 
**CC:** @GuiltyDolphin 

## Steps to test this PR:
1. Navigate to https://www.grubhub.com/login?redirectUrl=%2Fhelp%2Fcontact-us%2Fchat-with-reason-completed-order
2. Ensure Facebook login button loads and works.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
