### PR TITLE
Mark integration tests as pending if page fails to load/reload

### DIFF
--- a/integration-test/helpers/pageWait.js
+++ b/integration-test/helpers/pageWait.js
@@ -36,7 +36,7 @@ async function forGoto (page, url) {
         if (e instanceof puppeteer.errors.TimeoutError) {
             pending('Timed out loading URL: ' + url)
         } else {
-            throw e
+            pending(`Failed to load URL: ${url} (${e.message}).`)
         }
     }
 }
@@ -49,7 +49,7 @@ async function forReload (page) {
         if (e instanceof puppeteer.errors.TimeoutError) {
             pending('Timed out reloading page: ' + page.url())
         } else {
-            throw e
+            pending(`Failed to reload page: ${page.url()} (${e.message}).`)
         }
     }
 }


### PR DESCRIPTION
We mark integration tests as pending (skipped) if the test page loads
too slowly and therefore times out. We should also mark tests as
pending when the page fails to load entirely.

Recently the fingerprinting protection tests were failing since
Wikipedia had network issues. It would have been nicer if they were
skipped instead.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @ladamski 

## Steps to test this PR:
1. Add a /etc/hosts entry of `0.0.0.0 privacy-test-pages.glitch.me`.
2. Run the integration tests.
3. Ensure that some tests are skipped with a suitable message. (Note that some tests will still fail, that is to be expected.)

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
