### PR TITLE
Update content-scope-scripts dependency

### DIFF
--- a/integration-test/background/storage.js
+++ b/integration-test/background/storage.js
@@ -79,14 +79,18 @@ describe('Storage blocking Tests', () => {
         it('does not block 1st party JS cookies set by non-trackers', () => {
             const jsCookie = cookies.find(({ name, domain }) => name === 'tpsdata' && domain === testPageDomain)
             expect(jsCookie).toBeTruthy()
-            expect(jsCookie.expires).toBeGreaterThan(Date.now() / 1000 + 950400) // 11 days in the future
         })
 
-        it('reduces the expiry of 1st party JS cookies set by trackers to 8 days', () => {
-            const jsCookie = cookies.find(({ name, domain }) => name === 'tptdata' && domain === testPageDomain)
-            expect(jsCookie).toBeTruthy()
-            expect(jsCookie.expires).toBeGreaterThan(Date.now() / 1000)
-            expect(jsCookie.expires).toBeLessThan(Date.now() / 1000 + 864000) // 10 days in the future
+        it('reduces the expiry of all 1st party JS cookies to 7 days', () => {
+            const nowSeconds = Date.now() / 1000
+            const jsCookies = new Set(['jsdata', 'tptdata', 'tpsdata'])
+
+            for (const { expires, name } of cookies) {
+                if (!jsCookies.has(name)) continue
+
+                expect(expires - nowSeconds).toBeGreaterThan(0)
+                expect(expires - nowSeconds).toBeLessThan(604800)
+            }
         })
     })
 

--- a/integration-test/data/configs/storage-blocking.json
+++ b/integration-test/data/configs/storage-blocking.json
@@ -15,9 +15,9 @@
     },
     "globalThis.dbg.tds.config.features.trackingCookies1p": {
         "settings": {
-            "firstPartyTrackerCookiePolicy": {
-                "threshold": 86400,
-                "maxAge": 86400
+            "firstPartyCookiePolicy": {
+                "threshold": 604800,
+                "maxAge": 604800
             }
         },
         "exceptions": [ ],
@@ -25,9 +25,9 @@
     },
     "globalThis.dbg.tds.config.features.cookie": {
         "settings": {
-            "firstPartyTrackerCookiePolicy": {
-                "threshold": 86400,
-                "maxAge": 86400
+            "firstPartyCookiePolicy": {
+                "threshold": 604800,
+                "maxAge": 604800
             },
             "excludedCookieDomains": [ ],
             "trackerCookie": "enabled",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#4.6.0",
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.0.3",
+                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "1.1.0",
                 "bel": "6.0.0",
@@ -1837,7 +1837,7 @@
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
             "version": "1.1.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0250282b107afa0f1f9d1e1ca8c1db8345d89e66",
+            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#228c8787e0dc8bcb6f49132009bfbe4a88544f99",
             "hasInstallScript": true,
             "dependencies": {
                 "seedrandom": "^3.0.5",
@@ -17351,8 +17351,8 @@
             }
         },
         "@duckduckgo/content-scope-scripts": {
-            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0250282b107afa0f1f9d1e1ca8c1db8345d89e66",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#2.0.3",
+            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#228c8787e0dc8bcb6f49132009bfbe4a88544f99",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#2.1.0",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#4.6.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.0.3",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.0",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "1.1.0",
         "bel": "6.0.0",

--- a/shared/data/bundled/extension-config.json
+++ b/shared/data/bundled/extension-config.json
@@ -1,6 +1,6 @@
 {
     "readme": "https://github.com/duckduckgo/privacy-configuration",
-    "version": 1655291983548,
+    "version": 1655989238391,
     "features": {
         "ampLinks": {
             "exceptions": [
@@ -263,8 +263,13 @@
                     }
                 ],
                 "firstPartyTrackerCookiePolicy": {
+                    "readme": "This policy is deprecated. We are expanding this protection to all first party cookies set by scripts and using firstPartyCookiePolicy policy instead.",
                     "threshold": 86400,
                     "maxAge": 86400
+                },
+                "firstPartyCookiePolicy": {
+                    "threshold": 604800,
+                    "maxAge": 604800
                 }
             }
         },
@@ -278,6 +283,10 @@
                     {
                         "domain": "sovietgames.su",
                         "reason": "Wordpress plugin reports our browser as a bot"
+                    },
+                    {
+                        "domain": "thingiverse.com",
+                        "reason": "Site loads blank"
                     },
                     {
                         "domain": "accounts.google.com",
@@ -525,6 +534,17 @@
                             }
                         ]
                     },
+                    "aldi-digital.co.uk": {
+                        "rules": [
+                            {
+                                "rule": "assets.aldi-digital.co.uk/assets/050b4966c22c430e5c9308903ebb87e1/dist/scripts/main.js",
+                                "domains": [
+                                    "aldi.co.uk"
+                                ],
+                                "reason": "product images missing"
+                            }
+                        ]
+                    },
                     "alicdn.com": {
                         "rules": [
                             {
@@ -668,6 +688,17 @@
                                     "crunchyroll.com"
                                 ],
                                 "reason": "video not loading"
+                            }
+                        ]
+                    },
+                    "facebook.net": {
+                        "rules": [
+                            {
+                                "rule": "connect.facebook.net/en_US/sdk.js",
+                                "domains": [
+                                    "grubhub.com"
+                                ],
+                                "reason": "broken login"
                             }
                         ]
                     },
@@ -866,6 +897,17 @@
                                     "eonline.com"
                                 ],
                                 "reason": "video not loading"
+                            }
+                        ]
+                    },
+                    "tiqcdn.com": {
+                        "rules": [
+                            {
+                                "rule": "tags.tiqcdn.com/utag/agl/community/prod/utag.sync.js",
+                                "domains": [
+                                    "agl.com.au"
+                                ],
+                                "reason": "site loading delayed"
                             }
                         ]
                     },

--- a/shared/data/etags.json
+++ b/shared/data/etags.json
@@ -1,1 +1,1 @@
-{"config-etag":"W/\"bd9780af2a74f8b4200c70552a56ff08\""}
+{"config-etag":"W/\"463d29680c0f901d2fe5ec25c05f79fd\""}

--- a/unit-test/background/reference-tests/expire-1p-tracking-cookies.js
+++ b/unit-test/background/reference-tests/expire-1p-tracking-cookies.js
@@ -9,9 +9,9 @@ const tabManager = require('../../../shared/js/background/tab-manager.es6')
 const browserWrapper = require('../../../shared/js/background/wrapper.es6')
 const getArgumentsObject = require('../../../shared/js/background/helpers/arguments-object')
 
-const configReference = require('../../data/reference-tests/expire-first-party-tracking-cookies/config_reference.json')
-const blocklistReference = require('../../data/reference-tests/expire-first-party-tracking-cookies/tracker_radar_reference.json')
-const testSets = require('../../data/reference-tests/expire-first-party-tracking-cookies/tests.json')
+const configReference = require('../../data/reference-tests/expire-first-party-js-cookies/config_reference.json')
+const blocklistReference = require('../../data/reference-tests/expire-first-party-js-cookies/tracker_radar_reference.json')
+const testSets = require('../../data/reference-tests/expire-first-party-js-cookies/tests.json')
 
 const jsdom = require('jsdom')
 const { JSDOM } = jsdom


### PR DESCRIPTION
We have recently improved first-party cookie protection to also cover
first-party cookies created by first-party scripts. Update the
content-scope-scripts dependency to include those improvements, update
the bundled extension configuration and make the corresponding changes
to the tests.

**Reviewer:** @englehardt 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Navigate to https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking
2. Click to start the test.
3. Using the developer tools, ensure that the cookies `jsdata`, `tptdata` and `tpsdata` have an expiry date of 7 days in the future.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
