### PR TITLE
Add all locales for options view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/background.js
 integration-test/artifacts/
 shared/tracker-surrogates/
 shared/content-scope-scripts/
+.vscode

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,8 @@ module.exports = function (grunt) {
                     debug: buildType === 'dev'
                 },
                 transform: [
-                    ['babelify']
+                    ['babelify'],
+                    ['require-globify']
                 ]
             },
             ui: {
@@ -166,7 +167,8 @@ module.exports = function (grunt) {
                                 ]
                             }]]
                         }],
-                        ['brfs']
+                        ['brfs'],
+                        ['require-globify']
                     ]
                 },
                 files: baseFileMap.unitTest

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "normalize.scss": "0.1.0",
                 "psl": "1.8.0",
                 "punycode": "2.1.1",
+                "require-globify": "^1.4.1",
                 "runtimer": "1.0.3",
                 "seedrandom": "^3.0.5",
                 "tldts": "^5.7.81",
@@ -3798,6 +3799,15 @@
                 }
             ]
         },
+        "node_modules/browserify-transform-tools": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz",
+            "integrity": "sha512-D4/vMGx4ILHI/+Qokdo2x7cxPJqy7uXt0zugOBbDvnCcrQL9/WrgK71GJgrNHF/L4XLErA4cMGlTVmc2sICRnA==",
+            "dependencies": {
+                "falafel": "^2.0.0",
+                "through": "^2.3.7"
+            }
+        },
         "node_modules/browserify-zlib": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
@@ -6972,6 +6982,23 @@
             "engines": [
                 "node >=0.6.0"
             ]
+        },
+        "node_modules/falafel": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+            "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
+            "dependencies": {
+                "acorn": "^7.1.1",
+                "isarray": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/falafel/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -12822,6 +12849,34 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-globify": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/require-globify/-/require-globify-1.4.1.tgz",
+            "integrity": "sha512-ddYqhgOEQJ6roA46AeT5GXiZHEJWKyjeV17K7GPRY/poFYR5dE/ZHXnpRGrXwuMj26qfyV73HMLwvuRCBj6PFw==",
+            "dependencies": {
+                "browserify-transform-tools": "^1.6.0",
+                "glob": "^7.0.5"
+            }
+        },
+        "node_modules/require-globify/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/requires-port": {
@@ -18929,6 +18984,15 @@
                 }
             }
         },
+        "browserify-transform-tools": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz",
+            "integrity": "sha512-D4/vMGx4ILHI/+Qokdo2x7cxPJqy7uXt0zugOBbDvnCcrQL9/WrgK71GJgrNHF/L4XLErA4cMGlTVmc2sICRnA==",
+            "requires": {
+                "falafel": "^2.0.0",
+                "through": "^2.3.7"
+            }
+        },
         "browserify-zlib": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
@@ -21395,6 +21459,22 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "falafel": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+            "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
+            "requires": {
+                "acorn": "^7.1.1",
+                "isarray": "^2.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+                }
+            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -25873,6 +25953,30 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "require-globify": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/require-globify/-/require-globify-1.4.1.tgz",
+            "integrity": "sha512-ddYqhgOEQJ6roA46AeT5GXiZHEJWKyjeV17K7GPRY/poFYR5dE/ZHXnpRGrXwuMj26qfyV73HMLwvuRCBj6PFw==",
+            "requires": {
+                "browserify-transform-tools": "^1.6.0",
+                "glob": "^7.0.5"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
         },
         "requires-port": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "normalize.scss": "0.1.0",
         "psl": "1.8.0",
         "punycode": "2.1.1",
+        "require-globify": "^1.4.1",
         "runtimer": "1.0.3",
         "seedrandom": "^3.0.5",
         "tldts": "^5.7.81",

--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -139,6 +139,5 @@ module.exports = {
     },
     platform: {
         name: 'extension'
-    },
-    supportedLocales: ['cimode', 'en'] // cimode is for testing
+    }
 }

--- a/shared/js/ui/base/localize.es6.js
+++ b/shared/js/ui/base/localize.es6.js
@@ -11,7 +11,7 @@ const resources = localeResources.reduce((mapping, { name, module }) => {
 }, {})
 
 function getBrowserLocale () {
-    let browserLocale = chrome.i18n ? chrome.i18n.getUILanguage() : navigator.language
+    const browserLocale = chrome.i18n ? chrome.i18n.getUILanguage() : navigator.language
     return browserLocale.split('-')[0] // drop country suffix
 }
 

--- a/shared/js/ui/base/localize.es6.js
+++ b/shared/js/ui/base/localize.es6.js
@@ -1,37 +1,30 @@
 import i18next from 'i18next'
 import ICU from 'i18next-icu'
-import config from '../../../data/constants.js'
 
-const supportedLocales = config.supportedLocales
+const localeResources = require('../../../locales/*/*.json', { mode: 'list' })
 
-function buildLocalesList () {
-    const resources = {}
-    // hard coding for now till we figure out dynamic bundling
-    resources.en = {
-        shared: require('../../../locales/en/shared.json'),
-        options: require('../../../locales/en/options.json')
-    }
-    return resources
-}
+const resources = localeResources.reduce((mapping, { name, module }) => {
+    const [locale, namespace] = name.split('/')
+    mapping[locale] = mapping[locale] || {}
+    mapping[locale][namespace] = module
+    return mapping
+}, {})
 
-function getLocale (supportedLocales) {
-    // truncate locale by dropping country suffix
+function getBrowserLocale () {
     let browserLocale = chrome.i18n ? chrome.i18n.getUILanguage() : navigator.language
-    browserLocale = browserLocale.split('-')[0]
-
-    return supportedLocales.includes[browserLocale] || 'en' // probably redundant due to fallbackLng in init() below?
+    return browserLocale.split('-')[0] // drop country suffix
 }
 
 i18next
     .use(ICU)
     .init({
-        // debug: true,
+        debug: true,
         initImmediate: false,
         fallbackLng: 'en',
-        lng: getLocale(supportedLocales),
+        lng: getBrowserLocale(),
         ns: ['shared', 'options'],
         defaultNS: 'shared',
-        resources: buildLocalesList()
+        resources: resources
     })
 
 module.exports = i18next

--- a/shared/locales/bg/options.json
+++ b/shared/locales/bg/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Опции за DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Можете да търсите и да сърфирате в мрежата, без да Ви следят.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo защитава поверителността на данните Ви онлайн с\nповерително търсене,\nблокиране на тракери\nи криптиране на сайтове.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Споделяне на отзив",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Подаване на сигнал за повреден сайт",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Показване на вградени туитове",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Глобален контрол на поверителността (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Вашите лични данни не са за продажба. Ние в DuckDuckGo сме съгласни с това.\nАктивирайте настройката „Глобален контрол на поверителността“ (GPC) и ние ще\nуведомяваме уебсайтовете за Вашето предпочитание:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Да не продават Вашите лични данни.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Да ограничат споделянето на личните Ви данни с други компании.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Тъй като Глобалният контрол на поверителността (GPC) е нов стандарт,\nповечето уебсайтове все още не го признават, но ние полагаме усилия\nстандартът да бъде приет по целия свят.</b> Въпреки това от уеб сайтовете се изисква да предприемат действия по даден сигнал\nдо степента, до която приложимото законодателство им налага това. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Защита на имейл",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Автоматичното попълване е деактивирано",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Активирано е автоматично попълване за <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Няма добавени незащитени сайтове",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Незащитени сайтове",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Към тези сайтове няма да бъде приложена защита на поверителността.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Добавяне на незащитен сайт",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Въведете URL адрес",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Невалиден URL адрес",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/bg/shared.json
+++ b/shared/locales/bg/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Опции",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Научете повече",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Активиране",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Забрани",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Добавяне",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/cs/options.json
+++ b/shared/locales/cs/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Možnosti DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Nenech se sledovat při vyhledávání a prohlížení webu.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo chrání tvoje soukromí na webu soukromým vyhledáváním\n,blokováním trackerů\na šifrováním stránek.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Poděl se o zpětnou vazbu",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Nahlásit nefunkční web",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Zobrazit vložené tweety",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globální kontrola ochrany osobních údajů (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Tvoje data nesmí být na prodej. Přesně tak to v DuckDuckGo vidíme.\nAktivuj nastavení „Global Privacy Control“ (GPC) a my dáme webovým stránkám signál, že preferuješ:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Neprodávat osobní údaje.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Omezit sdílení vašich osobních údajů s jinými společnosti.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>I když je Globální kontrola ochrany osobních údajů (GPC)\n nový standard, většina webových stránek ho zatím nerozpozná, nicméně tvrdě pracujeme\n na tom, abychom zajistili, že bude akceptována po celém světě.</b> Webové stránky jsou nicméně povinny řešit podněty pouze v rozsahu, v jakém je k tomu donutí příslušné zákony.",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Ochrana e-mailu",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Vypnuté automatické vyplňování",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Je zapnuté automatické vyplňování pro uživatele <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nebyly přidány žádné nechráněné weby",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Nechráněné stránky",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Tyto stránky nebudou vylepšeny ochranou soukromí.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Přidat nechráněný web",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Zadej adresu URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Neplatná adresa URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/cs/shared.json
+++ b/shared/locales/cs/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Možnosti",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Více informací",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Povolit",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Vypnout",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Přidat",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/da/options.json
+++ b/shared/locales/da/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Indstillinger for DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Søg og browse på nettet uden at blive sporet.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo beskytter dit privatliv online med\nprivat søgning,\ntracker-blokering,\nog kryptering af websteder.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Del feedback",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Rapportér ødelagt websted",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Vis indlejrede tweets",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Dine data burde ikke være til salg. Det er vi enige i hos DuckDuckGo.Aktivér indstillingen \"Global Privacy Control\" (GPC), så\nsignalerer vi til websteder, at du foretrækker:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Ikke at sælge dine personlige data.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "At begrænse deling af dine personlige data til andre virksomheder.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Da Global Privacy Control (GPC) er en ny standard,\ngenkender de fleste websteder det endnu ikke, men vi arbejder hårdt\npå at sikre, at det bliver accepteret over hele verden.</b> Websteder er dog kun forpligtet til at reagere på signalet i det omfang, de er forpligtede ifølge loven til at gøre det. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-mailbeskyttelse",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatisk udfyldning er deaktiveret",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automatisk udfyldning aktiveret for <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Ingen ubeskyttede websteder tilføjet",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Ubeskyttede websteder",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Disse websteder vil ikke blive forbedret ved Beskyttelse af privatlivet.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Tilføj ubeskyttet websted",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Indtast URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Ugyldig URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/da/shared.json
+++ b/shared/locales/da/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Valgmuligheder",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Mere info",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Aktiver",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Deaktiver",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Tilføj",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/de/options.json
+++ b/shared/locales/de/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo-Optionen",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Durchsuche und browse das Web ohne getrackt zu werden.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo schützt deine Privatsphäre online mit\nprivater Suche,\nTracker-Blockade\nund Website-Verschlüsselung.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Feedback teilen",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Fehlerhafte Seite melden",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Eingebettete Tweets anzeigen",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Deine Daten sollten nicht zum Verkauf stehen. Und bei DuckDuckGo vertreten wir ebendiese Meinung.\nAktiviere die „Global Privacy Control“ (GPC)-Einstellungen und wir\nteilen Websites mit, dass du Folgendes bevorzugst:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Deine personenbezogenen Daten nicht verkaufen.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Personenbezogene Daten wenn möglich nicht an andere Unternehmen weiterleiten.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Global Privacy Control (GPC) ist noch ganz neu und die meisten Websites werden den Standard nicht sofort erkennen. Wir arbeiten aber darauf hin, dass der GPC-Standard bald weltweit akzeptiert wird.</b> Websites sind jedoch nur dann verpflichtet, den Aufruf zu beherzigen und umzusetzen, wenn die geltenden Gesetze sie dazu verpflichten. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-Mail-Schutz",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Autovervollständigen deaktiviert",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Autovervollständigen aktiviert für <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Keine ungeschützten Seiten hinzugefügt",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Ungeschützte Websites",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Für diese Websites ist der Datenschutz nicht aktiviert.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Ungeschützte Website hinzufügen",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "URL eingeben",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Ungültige URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/de/shared.json
+++ b/shared/locales/de/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Optionen",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Mehr erfahren",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Aktivieren",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Deaktivieren",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Hinzufügen",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/el/options.json
+++ b/shared/locales/el/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Επιλογές DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Αναζητήστε και περιηγηθείτε στον Ιστό χωρίς να σας παρακολουθούν.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "Το DuckDuckGo προστατεύει την ιδιωτικότητά σας στο διαδίκτυο με\nιδιωτική αναζήτηση,\nαποκλεισμό παρακολούθησης,\nκαι κρυπτογράφηση ιστότοπων.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Κοινοποίηση σχολίου",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Αναφορά ιστότοπου που δεν λειτουργεί",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Εμφάνιση ενσωματωμένων Tweet",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Παγκόσμιος έλεγχος απορρήτου (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Τα δεδομένα σας δεν πρέπει να πωλούνται. Στην DuckDuckGo συμφωνούμε.Ενεργοποιήστε τις ρυθμίσεις για τον «Παγκόσμιο έλεγχο απορρήτου» (GPC) και θα\nεπισημάνουμε στους ιστότοπους την προτίμησή σας:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Να μην πωλούν τα προσωπικά δεδομένα σας.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Να περιορίσουν την κοινοποίηση των προσωπικών δεδομένων σας σε άλλες εταιρείες.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Καθώς ο Παγκόσμιος έλεγχος απορρήτου (GPC) αποτελεί νέο πρότυπο, οι περισσότεροι ιστότοποι δεν θα το αναγνωρίζουν ακόμη, ωστόσο εργαζόμαστε σκληρά ώστε να εξασφαλίσουμε ότι θα γίνει αποδεκτό παγκοσμίως.</b> Ωστόσο, οι ιστότοποι είναι υποχρεωμένοι να ενεργούν μόνο στον βαθμό που τους υποχρεώνουν οι ισχύοντες νόμοι. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Προστασία email",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Η αυτόματη συμπλήρωση απενεργοποιήθηκε",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Η αυτόματη συμπλήρωση είναι ενεργοποιημένη για τον χρήστη <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Δεν έχουν προστεθεί μη προστατευμένοι ιστότοποι",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Μη προστατευόμενοι ιστότοποι",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Οι ιστότοποι αυτοί δεν θα ενισχυθούν από την Προστασία προσωπικών δεδομένων.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Προσθήκη μη προστατευμένου ιστότοπου",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Εισαγάγετε διεύθυνση URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Μη έγκυρη διεύθυνση URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/el/shared.json
+++ b/shared/locales/el/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Επιλογές",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Μάθετε περισσότερα",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Ενεργοποίηση",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Απενεργοποίηση",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Προσθήκη",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/es/options.json
+++ b/shared/locales/es/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Opciones de DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Busca y navega por la web sin que te rastreen.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo protege tu privacidad en línea con\nbúsquedas privadas, \nbloqueo de rastreadores\ny cifrado de sitios.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Compartir opiniones",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Informar de sitio web dañado",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Mostrar tuits incrustados",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Control Global de Privacidad (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Tus datos no deberían estar a la venta. En DuckDuckGo, estamos de acuerdo.Activa la configuración de «Control Global de Privacidad» (GPC) e\ninformaremos a los sitios web de que prefieres:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "No vender tus datos personales.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Limitar el uso compartido de tus datos personales con otras empresas.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Dado que el Control Global de Privacidad (GPC) es un nuevo estándar,\nla mayoría de los sitios web no lo reconoce todavía, pero estamos trabajando\npara garantizar que se acepte en todo el mundo.</b> Sin embargo, solo se exige a los sitios web que actúen conforme a esta indicación en la\nmedida en que lo dictamine la legislación aplicable. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Protección del correo electrónico",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Autocompletar desactivado",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Autocompletar habilitado para <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "No se han añadido sitios no protegidos",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Sitios no protegidos",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "La protección de privacidad está deshabilitada para estos sitios.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Añadir sitio no protegido",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Introducir URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL no válida",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/es/shared.json
+++ b/shared/locales/es/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opciones",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Más información",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Activar",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Deshabilitar",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Añadir",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/et/options.json
+++ b/shared/locales/et/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo valikud",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Otsi ja sirvi veebis ilma jälgimiseta.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo kaitseb sinu privaatsust veebis\nprivaatse otsingu,\njälgimise blokeerimise,\nja saidi krüptimise abil.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Jaga tagasisidet",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Teata mittetoimivast saidist",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Näita manustatud säutse",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Üleilmne privaatsuskontroll (Global Privacy Control (GPC))",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Sinu andmeid ei ole müügiks DuckDuckGo nõustub sellega.Aktiveeri seadistus „Üleilmne privaatsuskontroll“ (GPC) ja me anname veebisaitidele märku sinu eelistusest:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Sinu andmed ei ole müügiks.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "piirata sinu isikuandmete jagamist teiste ettevõtetega.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Kuna ülemaailmne privaatsuskontroll (GPC) on uus standard,\n ei tunne enamik veebisaite seda veel ära, kuid me töötame selle nimel, et seda aktsepteeritaks üleilmselt.</b> Kuid veebisaidid peavad reageerima signaalile ainult niivõrd,\nkuivõrd kehtivad seadused neid selleks sunnivad. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-posti kaitse",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automaatne täitmine keelatud",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automaatne täitmine on <strong class=\"js-userdata-container\">{userName}</strong> jaoks lubatud",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Kaitseta saite ei ole lisatud",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Kaitseta saidid",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Nendele saitidele ei laienePrivaatsuse kaitse.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Kaitseta saidi lisamine",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Sisestage URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Vale URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/et/shared.json
+++ b/shared/locales/et/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Valikud",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Loe edasi",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Luba",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Keela",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Lisa",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/fi/options.json
+++ b/shared/locales/fi/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo-asetukset",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Tee hakuja ja selaile nettiä ilman, että sinua seurataan.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo suojaa yksityisyyttäsi verkossa tarjoten\nyksityisen haun,\nseurannan eston\nja sivuston salauksen.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Jaa palaute",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Ilmoita viallisesta sivustosta",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Näytä upotetut twiitit",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Tietojesi ei pitäisi olla myynnissä. DuckDuckGo on samaa mieltä.\nOta \"Global Privacy Control\" (GPC) -asetukset käyttöön, niin me\nkerromme verkkosivustoille, että:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "ne eivät saa myydä henkilötietojasi.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "niiden täytyy rajoittaa henkilötietojesi jakamista muille yrityksille.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Koska Global Privacy Control (GPC) on uusi standardi,\nuseimmat verkkosivustot eivät vielä tunnista sitä, mutta teemme parhaamme, että\nstandardi hyväksyttäisiin kaikkialla maailmassa.</b> Verkkosivujen täytyy kuitenkin noudattaa kehotusta vain siinä laajuudessa kuin sovellettavat lait määräävät.",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Sähköpostisuojaus",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automaattinen täyttö poistettu käytöstä",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automaattinen täyttö käytössä osoitteessa <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Suojaamattomia sivustoja ei ole lisätty.",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Suojaamattomat sivustot",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Yksityisyyden suoja ei paranna näitä sivustoja.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Lisää suojaamaton sivusto",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Kirjoita URL-osoite",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Virheellinen URL-osoite",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/fi/shared.json
+++ b/shared/locales/fi/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Valinnat",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Lue lisää",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Ota käyttöön",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Poista Käytöstä",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Lisää",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/fr/options.json
+++ b/shared/locales/fr/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Options DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Faites des recherches et naviguez sur le Web sans être suivi.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo protège votre confidentialité en ligne grâce à la recherche privée, au blocage des traqueurs et au cryptage de site.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Partager des commentaires",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Signaler un problème de site",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Afficher les tweets intégrés",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Vos données ne sont pas à vendre. C'est aussi la philosophie de DuckDuckGo.\nActivez les paramètres « Global Privacy Control » (GPC) et nous indiquerons aux sites Web que vous leur demandez de :",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Ne pas vendre vos données personnelles.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Limiter le partage de vos données personnelles avec d'autres entreprises.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Étant donné que le Global Privacy Control (GPC) est une nouvelle norme, la plupart des sites Web ne la reconnaissent pas encore, mais nous mettons tout en œuvre pour qu'elle soit reconnue dans le monde entier.</b> Cependant, les sites Web ne sont tenus de respecter cette demande que dans la mesure où les lois applicables les y obligent. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Protection des e-mails",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Saisie automatique désactivée",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Saisie automatique activée pour <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Aucun ajout de site non protégé",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Sites non protégés",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Les sites suivants ne bénéficient pas de la protection de la confidentialité.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Ajouter un site non protégé",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Saisissez une URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL non valide",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/fr/shared.json
+++ b/shared/locales/fr/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Options",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "En savoir plus",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Activer",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Désactiver",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Ajouter",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/hr/options.json
+++ b/shared/locales/hr/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo mogućnosti",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Pretražuj i pregledavaj mrežu bez praćenja.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo štiti tvoju privatnost na mreži koristeći\nprivatno pretraživanje,\nblokiranje alata za praćenje\n i enkripcijom stranica.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Podijeli povratne informacije",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Prijavi neispravno web-mjesto",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Pokaži ugrađene tweetove",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globalna kontrola privatnosti (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Tvoji podaci ne bi trebali biti na prodaju. Mi u DuckDuckGo mislimo isto.\nAktiviraj postavke \"Globalne kontrole privatnosti\" (GPC) i mi ćemo\nweb lokacijama signalizirati koje želiš:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Ne prodavati svoje osobne podatke.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Ograničiti dijeljenje osobnih podataka s drugim tvrtkama.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Budući da je Globalna kontrola privatnosti (GPC) novi standard,\nvećina web-mjesta još ga neće prepoznati, ali naporno radimo na tome da postane prihvaćen u cijelom svijetu.</b> Međutim, web-mjesta moraju djelovati na signal samo u mjeri u kojoj ih obvezuju važeći zakoni.",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Zaštita e-pošte",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatsko popunjavanje onemogućeno",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automatsko popunjavanje omogućeno za <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nema dodanih nezaštićenih web-mjesta",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Nezaštićena web-mjesta",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Ova web-mjesta neće biti unaprijeđena zaštitom privatnosti.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Dodavanje nezaštićenog web-mjesta",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Unesi URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL nije valjan",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/hr/shared.json
+++ b/shared/locales/hr/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opcije",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Saznajte više",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Omogući",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Onemogući",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Dodaj",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/hu/options.json
+++ b/shared/locales/hu/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo beállítások",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Keress és böngéssz az interneten anélkül, hogy nyomon követnének.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "A DuckDuckGo privát kereséssel, \nnyomkövetők blokkolásával,\nés webhelyek titkosításával \nvédi az adataidat online.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Visszajelzés megosztása",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Hibás weboldal jelentése",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Beágyazott tweetek megjelenítése",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Nemzetközi adatvédelmi szabályozás (Global Privacy Control, GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Az adataidnak nem lenne szabad eladónak lenniük. A DuckDuckGónál mi egyetértünk ezzel.\nAktiváld a „Globális adatvédelmi szabályozás” (GPC) beállítást, és mi\njelezzük a webhelyeknek, hogy te a következőket szeretnéd:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Ne adják el a személyes adataidat.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Korlátozzák a személyes adataid megosztását más vállalatokkal.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Mivel a Nemzetközi Adatvédelmi Szabályozás (Global Privacy Control, GPC) új szabvány,\na legtöbb weboldal még nem fogja felismerni, de keményen dolgozunk azon,\nhogy világszerte elfogadottá váljon.</b> A weboldalaknak azonban csak olyan mértékben kell eleget tenniük a kérésnek, amennyire a hatályos törvények ezt megkövetelik tőlük. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-mail védelem",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatikus kitöltés letiltva",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Az automatikus kitöltés <strong class=\"js-userdata-container\">{userName}</strong> számára engedélyezve van.",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nincsenek hozzáadva védtelen webhelyek",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Védelem nélküli weboldalak",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Ezeket az oldalakat nem erősíti adatvédelem.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Védtelen webhely hozzáadása",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "URL megadása",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Érvénytelen URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/hu/shared.json
+++ b/shared/locales/hu/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opciók",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "További részletek",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Engedélyezés",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Letilt",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Hozzáadás",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/it/options.json
+++ b/shared/locales/it/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Opzioni di DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Cerca e naviga sul Web senza che altri ti traccino.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo protegge la tua privacy online con\nnavigazione in incognito, \nblocco dei sistemi di tracciamento\ne crittografia del sito.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Condividi feedback",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Segnala sito danneggiato",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Mostra tweet incorporati",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "I tuoi dati non dovrebbero mai essere messi in vendita. Noi di DuckDuckGo ne siamo convinti.\nAttiva l'impostazione \"Global Privacy Control\" (GPC) e\nsegnaleremo ai siti web di:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Non vendere i tuoi dati personali.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Limitare la condivisione dei tuoi dati personali con altre aziende.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Dal momento che il Global Privacy Control (GPC) rappresenta un nuovo standard,\nla maggior parte dei siti web ancora non lo riconosce, ma ci stiamo impegnando al massimo per assicurarci che venga accettato in tutto il mondo.</b> Tuttavia, i siti web sono tenuti a rispondere alla segnalazione esclusivamente nei limiti delle leggi pertinenti che li obbligano ad agire in tal senso. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Protezione email",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Compilazione automatica disabilitata",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Compilazione automatica abilitata per <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Non è stato aggiunto nessun sito non protetto",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Siti non protetti",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Questi siti non saranno ottimizzati dalla tutela della privacy.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Aggiungi sito non protetto",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Inserisci URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL non valido",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/it/shared.json
+++ b/shared/locales/it/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opzioni",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Ulteriori informazioni",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Attiva",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Disabilita",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Aggiungi",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/lt/options.json
+++ b/shared/locales/lt/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "„DuckDuckGo“ parinktys",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Ieškokite ir naršykite žiniatinklyje nesekami.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "„DuckDuckGo“ saugo jūsų privatumą internete naudodama\nprivačią paiešką,\nsekėjų blokavimą\nir svetainių šifravimą.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Bendrinti atsiliepimą",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Pranešti apie sugadintą svetainę",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Rodyti įterptas žinutes",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Visuotinė privatumo kontrolė (VPK)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Jūsų duomenys neturi būti pardavinėjami. Svetainėje „DuckDuckGo“ su tuo sutinkame.\nĮjunkite Pasaulinės privatumo kontrolės (angl. „Global Privacy Control“, GPC) nustatymus ir mes\nsignalizuosime svetainėms, kurioms teikiate pirmenybę:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Neparduodu savo asmens duomenų.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Apriboti jūsų asmens duomenų dalijimąsi su kitomis įmonėmis.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Kadangi visuotinė privatumo kontrolė (VPK) yra naujas standartas,\n daugelis svetainių jo neatpažįsta, tačiau mes stengiamės užtikrinti,\n kad jis būtų priimtas visame pasaulyje.</b> Tačiau svetainės turi veikti tik remiantis signalu tiek,\n kiek taikoma pagal taikytiną teisę. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "El. pašto apsauga",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Išjungtas automatinis pildymas",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Įjungtas automatinis pildymas <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nepridėta jokių neapsaugotų svetainių",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Neapsaugotos svetainės",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Šių svetainių nepatobulins privatumo apsauga.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Pridėti neapsaugotą svetainę",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Įveskite URL adresą",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Netinkamas URL adresas",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/lt/shared.json
+++ b/shared/locales/lt/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Parinktys",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Sužinoti daugiau",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Įjungti",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Išjungti",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Papildyti",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/lv/options.json
+++ b/shared/locales/lv/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo opcijas",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Meklē un pārlūko tīmekli bez izsekošanas.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo aizsargā tavu privātumu tiešsaistē ar\nprivāto meklēšanu,\nizsekotāju bloķēšanu,\nun vietņu šifrēšanu.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Sniegt atsauksmes",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Ziņot par bojātu vietni",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Rādīt iegultos tvītus",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globālā privātuma kontrole (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Taviem datiem nav jākļūst par preci. DuckDuckGo tam piekrīt.\nAktivizē \"Globālās privātuma parvaldīšanas\" (GPC) iestatījumus, un mēs\npaziņosim tīmekļa vietnēm tavu izvēli:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Nepārdot personas datus.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Ierobežot tavu personas datu kopīgošanu ar citiem uzņēmumiem.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Tā kā Globālā privātuma pārvaldīšana (GPC) ir jauns standarts,\nvairums vietņu to vēl neatpazīs, taču mēs strādājam,\nlai nodrošinātu, ka tas tiek pieņemts visā pasaulē.</b> Tomēr vietnēm ir obligāti jārīkojas tikai uz tām attiecināmo piemērojamo tiesību aktu ietvaros. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-pasta aizsardzība",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automātiskā aizpildīšana atspējota",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Ieslēgta automātiskā aizpildīšana lietotājam <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nav pievienota neviena neaizsargāta vietne",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Neaizsargātas vietnes",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Šīs vietnes netiks uzlabotas ar privātuma aizsardzību.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Pievienot neaizsargātu vietni",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Ievadi URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Nederīgs URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/lv/shared.json
+++ b/shared/locales/lv/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opcijas",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Uzzināt vairāk",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Iespējot",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Atslēgt",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Pievienot",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/nb/options.json
+++ b/shared/locales/nb/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckduckGo-alternativer",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Søk og surf på nettet uten å bli sporet.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo beskytter personvernet ditt på nettet med\nprivat søk,\n sporingsblokkering\nog nettstedskryptering.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Del tilbakemelding",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Rapporter nettstedfeil",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Vis innebygde tweeter",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Opplysningene dine skal ikke være til salgs. Hos DuckDuckGo deler vi denne oppfatningen.\nAktiver innstillingene for «Global Privacy Control» (GPC), så\nsignaliserer vi preferansene dine til nettsteder for at de",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "ikke skal selge dine personlige data.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "skal begrense deling av personopplysningene dine med andre selskaper.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Siden Global Privacy Control (GPC) er en ny standard,\nanerkjennes den nok ikke av nettsteder flest ennå, men vi jobber\nhardt for å sørge for at den blir godkjent over hele verden.</b> Mange nettsteder er imidlertid kun pålagt å ta dette signalet til følge når\ngjeldende lover pålegger dem å gjøre det. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-postbeskyttelse",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Autofyll deaktivert",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Autofyll aktivert for <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Ingen ubeskyttede nettsteder er lagt til",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Ubeskyttede nettsteder",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Disse nettstedene blir ikke dekket av personvernbeskyttelse.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Legg til ubeskyttet nettsted",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Skriv inn URL-adresse",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Ugyldig URL-adresse",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/nb/shared.json
+++ b/shared/locales/nb/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Alternativer",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Finn ut mer",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Aktiver",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Slå av",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Legg til",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/nl/options.json
+++ b/shared/locales/nl/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo-opties",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Zoek en surf op internet zonder te worden gevolgd.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo beschermt je privacy online met \n privézoekopdrachten, \n trackerblokkering \n en websiteversleuteling.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Feedback delen",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Defecte website melden",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Ingesloten tweets weergeven",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Je gegevens zouden niet mogen worden verhandeld. Bij DuckDuckGo zijn we het daarmee eens.Activeer de instellingen voor 'Global Privacy Control' (GPC). We zullen\n vervolgens aan websites je voorkeuren doorgeven om:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Verkoop je persoonlijke gegevens niet.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "• Het delen van je persoonsgegevens met andere bedrijven te beperken.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Global Privacy Control (GPC) is een nieuwe standaard.\n Daarom herkennen de meeste websites deze nog niet. We werken er hard aan om ervoor te zorgen dat GCP wereldwijd wordt geaccepteerd.</b> Maar websites zijn alleen verplicht om op dit signaal te reageren voor zover de toepasselijke wetgeving dat vereist.&nbsp;",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-mailbescherming",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatisch invullen uitgeschakeld",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automatisch invullen ingeschakeld voor <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Geen onbeveiligde sites toegevoegd",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Onbeschermde sites",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Deze sites worden niet beschermd met Privacybescherming.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Onbeveiligde site toevoegen",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "URL invoeren",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Ongeldige URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/nl/shared.json
+++ b/shared/locales/nl/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opties",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Meer informatie",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Inschakelen",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Uitschakelen",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Toevoegen",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/pl/options.json
+++ b/shared/locales/pl/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Opcje DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Przeszukuj i przeglądaj Internet bez bez ryzyka, że ktoś Cię śledzi.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo chroni Twoją prywatność w sieci dzięki prywatnemu wyszukiwaniu\n, blokowaniu skryptów śledzących\n\ni szyfrowaniu stron.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Podziel się opinią",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Zgłoś uszkodzoną witrynę",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Pokaż osadzone tweety",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globalna Kontrola Prywatności (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Twoje dane nie są na sprzedaż. W DuckDuckGo w pełni się z tym zgadzamy.Aktywuj ustawienie „Globalna kontrola prywatności” (GPC), a my przekażemy witrynom Twoje preferencje:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Nie sprzedawać Twoich danych osobowych.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Ograniczać udostępnianie Twoich danych osobowych innym firmom.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Ponieważ Globalna Kontrola Prywatności (GPC) to nowy standard, większość witryn jeszcze go nie rozpoznaje, ale ciężko pracujemy nad tym, aby był uznawany na całym świecie.</b> Witryny internetowe są jednak zobowiązane do działania na podstawie sygnału wyłącznie w zakresie, w jakim jest to wymagane przez obowiązujące prawo. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Ochrona poczty e-mail",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Wyłączono autouzupełnianie",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Włączono autouzupełnianie dla <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nie dodano żadnych niezabezpieczonych witryn",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Niezabezpieczone witryny",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Te witryny nie będą ulepszane przez ochronę prywatności.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Dodaj niezabezpieczoną witrynę",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Wprowadź adres URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Nieprawidłowy adres URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/pl/shared.json
+++ b/shared/locales/pl/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opcje",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Dowiedz się więcej",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Włącz",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Wyłącz",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Dodaj",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/pt/options.json
+++ b/shared/locales/pt/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Opções do DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Pesquisa e navega na Internet sem deixares rasto.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "O DuckDuckGo protege a tua privacidade online com\npesquisa privada,\nbloqueio de trackers\ne encriptação de sites.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Partilhar comentários",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Denunciar site danificado",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Mostrar Tweets incorporados",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Controlo Global de Privacidade (CGP)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Os teus dados não são para vender. É isto que a DuckDuckGo defende.\nAtiva as definições do \"Controlo de Privacidade Global\" (GPC) para\nsinalizarmos aos sites que:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Não devem vender os teus dados pessoais.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "• Devem limitar a partilha dos teus dados pessoais com outras empresas.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Uma vez que o Controlo de Privacidade Global (GPC) é uma norma nova,\na maioria dos sites ainda não o reconhecem. No entanto, estamos a trabalhar arduamente\npara que seja aceite em todo o mundo.</b> Porém, os sites só têm de agir em conformidade com o sinal\nna medida em que a legislação aplicável os obrigar a isso. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Proteção de e-mail",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Preenchimento automático desativado",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Preenchimento automático ativado para <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nenhum site desprotegido adicionado",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Sites desprotegidos",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Estes sites não serão aprimorados pela Proteção de Privacidade.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Adicionar site desprotegido",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Introduz o URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL inválido",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/pt/shared.json
+++ b/shared/locales/pt/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opções",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Saiba mais",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Permitir",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Desabilitar (fora)",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Adicionar",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/ro/options.json
+++ b/shared/locales/ro/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Opțiuni DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Caută și navighează pe web fără a fi urmărit.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo îți protejează confidențialitatea online cu \ncăutarea privată,\nblocarea tehnologiilor de urmărire\nși criptarea site-urilor.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Partajează feedback",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Raportează site-ul defect",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Afișează tweeturi încorporate",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Datele tale nu ar trebui să fie de vânzare. La DuckDuckGo, suntem de acord cu acest lucru.\nActivează setările „Control global al confidențialității” (CGC) și noi vom \nsemnala site-urilor preferințele tale de:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "a nu se vinde datele tale cu caracter personal.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "a se limita distribuirea datelor tale cu caracter personal către alte companii.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Întrucât controlul global al confidențialității (CGC) este un standard nou,\n majoritatea site-urilor nu îl vor recunoaște încă, însă ne străduim\nsă ne asigurăm că acesta va fi acceptat în întreaga lume.</b> Cu toate acestea, site-urile sunt obligate să acționeze în virtutea semnalului\nîn măsura în care legile aplicabile le obligă să facă acest lucru. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Protecția comunicațiilor prin e-mail",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Completarea automată este dezactivată",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Completarea automată este activată pentru <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Nu s-au adăugat site-uri neprotejate",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Site-uri neprotejate",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Aceste site-uri nu vor fi îmbunătățite de protecția confidențialității.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Adaugă un site neprotejat",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Introdu adresa URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "URL nevalid",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/ro/shared.json
+++ b/shared/locales/ro/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Opțiuni",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Află mai multe",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Activare",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Dezactivează",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Adăugați",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/ru/options.json
+++ b/shared/locales/ru/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Параметры DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Поиск и просмотр Интернета без отслеживания.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "Чтобы защитить ваши данные в Интернете, DuckDuckGo предлагает конфиденциальный поиск, блокировку трекеров и шифрование соединения с сайтами.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Отправить отзыв",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Сообщить о неработающем сайте",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Показывать встроенные твиты",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Глобальный контроль конфиденциальности (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Личные данные не должны продаваться. Мы, сотрудники DuckDuckGo, с этим полностью согласны.\nАктивируйте настройку «Глобальный контроль конфиденциальности» (Global Privacy Control или GPC), и мы передадим сайтам ваши предпочтения:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Не продавать ваши личные данные.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "ограничить передачу ваших личных данных другим компаниям",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Поскольку глобальный контроль конфиденциальности (GPC) — новый стандарт, пока что он не признается на большинстве сайтов, но мы прилагаем все усилия, чтобы он был принят во всем мире.</b> Также хотим подчеркнуть, что сайты обязаны реагировать на сигнал только в той мере, в какой это требует применимое законодательство.",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Защита электронной почты",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Автозаполнение отключено",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Включено автозаполнение для <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Незащищенные сайты не добавлены",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Незащищенные сайты",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Сайты без защиты конфиденциальности.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Добавить незащищенный сайт",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Введите URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Неправильный URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/ru/shared.json
+++ b/shared/locales/ru/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Параметры",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Подробнее",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Включить",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Выключить",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Добавить",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/sk/options.json
+++ b/shared/locales/sk/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Možnosti DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Vyhľadávajte a prehliadajte web bez toho, aby vás sledovali.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo chráni vaše súkromie online pomocou\nsúkromného vyhľadávania,\n blokovania sledovania \na šifrovania lokalít.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Zdieľať spätnú väzbu",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Nahlásiť nefunkčnú lokalitu",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Zobraziť vložené tweety",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globálna kontrola súkromia (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Vaše údaje nesmú byť na predaj. V DuckDuckGo s tým súhlasíme.Aktivujte nastavenia „Globálne ovládanie ochrany súkromia” (GPC) a my budeme\nsignalizovať webovým lokalitám vaše preferencie, aby:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "nepredávali vaše osobné údaje,",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "obmedzili zdieľanie vašich osobných údajov s inými spoločnosťami.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Pretože „Globálne ovládanie ochrany súkromia” (GPC) je novým štandardom,\nväčšina webových stránok ho ešte nerozpozná, ale usilovne pracujeme na tom,\naby sa stal celosvetovo akceptovaným.</b> Od webových stránok sa však vyžaduje, aby konali na základe signálu\niba v rozsahu, v akom to od nich vyžadujú príslušné zákony.",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Ochrana e-mailu",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatické vypĺňanie je vypnuté",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automatické vypĺňanie je povolené pre <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Neboli pridané žiadne nechránené lokality",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Nezabezpečené webové stránky",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Tieto webové stránky nebudú rozšírené o ochranu súkromia.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Pridanie nechránenej lokality",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Zadajte adresu URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Neplatná adresa URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/sk/shared.json
+++ b/shared/locales/sk/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Možnosti",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Zistite viac",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Povoliť",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Zakázať",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Pridať",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/sl/options.json
+++ b/shared/locales/sl/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Možnosti DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Iščite in brskajte po spletu brez sledenja.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo varuje vašo zasebnost na spletu z\nzasebnim iskanjem,\nblokiranjem sledilnikov\nin šifriranjem spletnih mest.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Deli povratne informacije",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Prijavite poškodovano spletno mesto",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Prikaži vdelane tvite",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Globalni nadzor zasebnosti (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Vaši podatki ne bi smeli biti naprodaj. Pri DuckDuckGo se strinjamo.\nAktivirajte nastavitve »Global Privacy Control« (GPC) in spletnim mestom bomo\nsporočili vaše želje:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Ne prodajajte svojih osebnih podatkov.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "• Omejite skupno rabo svojih osebnih podatkov z drugimi podjetji.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Ker je globalni nadzor zasebnosti (Global Privacy Control (GPC)) nov standard, ga \n\nvečina spletnih mest še ne prepozna, vendar si močno \nprizadevamo, da bi bil sprejet po vsem svetu.</b> Vendar morajo spletna mesta na podlagi signala ukrepati le v \nskladu z veljavnimi zakoni. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "Zaščita e-pošte",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Samodejno izpolnjevanje je onemogočeno",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Omogočeno samodejno izpolnjevanje za uporabnika <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Ni dodanih nezaščitenih spletnih mest",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Nezaščitene strani",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Varnost teh strani se z zaščito zasebnosti ne bo izboljšala.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Dodajte nezaščiteno spletno mesto",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Vnesite URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Neveljaven URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/sl/shared.json
+++ b/shared/locales/sl/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Možnosti",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Več",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Omogoči",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Onemogoči",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Dodaj",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/sv/options.json
+++ b/shared/locales/sv/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "Alternativ för DuckDuckGo",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Sök och surfa på webben utan att bli spårad.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo skyddar din integritet på nätet med\nprivat sökning,\nblockering av spårare\noch kryptering av webbplatser.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Berätta vad du tycker",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Rapportera skadad webbplats",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Visa inbäddade tweets",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Global Privacy Control (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Dina uppgifter ska inte vara till salu. Vi på DuckDuckGo håller med.\nAktivera inställningarna för Global Privacy Control (GPC) så signalerar vi\ntill webbplatser att du föredrar att de:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Inte säljer dina personuppgifter.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "Begränsar delning av dina personuppgifter med andra företag.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Eftersom Global Privacy Control (GPC) är en ny standard\nföljer de flesta webbplatser inte den ännu, men vi arbetar hårt\npå att se till att den blir accepterad i hela världen.</b> Webbplatser är dock skyldiga att rätta sig efter signalen endast\ni den utsträckning som gällande lagstiftning kräver det. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-postskydd",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Automatisk ifyllning inaktiverad",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "Automatisk ifyllning aktiverad för <strong class=\"js-userdata-container\">{userName}</strong>",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Inga oskyddade webbplatser har lagts till",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Oskyddade webbplatser",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Dessa webbplatser kommer inte att förbättras av integritetsskydd.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Lägg till oskyddad webbplats",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "Ange URL",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Ogiltig URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/sv/shared.json
+++ b/shared/locales/sv/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Alternativ",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Läs mer",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Aktivera",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Inaktivera",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Lägg till",
+    "note" : "To add something to a list"
+  }
+}

--- a/shared/locales/tr/options.json
+++ b/shared/locales/tr/options.json
@@ -1,0 +1,91 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "optionsHeader" : {
+    "title" : "DuckDuckGo Seçenekleri",
+    "note" : "Header for options (settings) page"
+  },
+  "optionsSubHeader" : {
+    "title" : "Web'de hiç kimse sizi takip edemeden arama yapın ve gezinin.",
+    "note" : "We allow the user to browse the web without being followed by trackers"
+  },
+  "optionsDesc" : {
+    "title" : "DuckDuckGo,\nözel arama,\nizleyici engelleme,\nve site şifreleme ile internette gizliliğinizi korur.",
+    "note" : "This describes how we protect the user from being tracked online"
+  },
+  "shareFeedback" : {
+    "title" : "Geri bildirim paylaş",
+    "note" : "Click here to share your opinions about this product"
+  },
+  "reportBrokenSite" : {
+    "title" : "Hatalı siteyi bildir",
+    "note" : "Click here to report an issue with a specific site you are trying to use"
+  },
+  "showEmbeddedTweets" : {
+    "title" : "Gömülü Tweet'leri göster",
+    "note" : "Whether the user wants to see Tweets embedded in various webpages or should they be hidden util clicked on"
+  },
+  "globalPrivacyControlAbbr" : {
+    "title" : "Küresel Gizlilik Kontrolü (GPC)",
+    "note" : "Global Privacy Control is the name of the feature that lets users set a preference to not have their information sold"
+  },
+  "globalPrivacyControlDesc" : {
+    "title" : "Verileriniz satılık olmamalı. DuckDuckGo'da aynı fikirdeyiz.\n\"Global Gizlilik Kontrolü\" (GPC) ayarlarını etkinleştirdiğinizde\nweb sitelerine tercihinizi iletiriz:",
+    "note" : "This describes the GPC feature, which lets the user set a preference to not have their personal information sold by websites to other parties. The string is followed by a list of actions like 'Not sell your personal data'. These are translated separately."
+  },
+  "notSellYourPersonalData" : {
+    "title" : "Kişisel verilerinizin satılmamasını istediğinizi.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SELL their personal data"
+  },
+  "limitSharingOfPersonalData" : {
+    "title" : "• Kişisel verilerinizin diğer şirketlerle paylaşımının sınırlandırılmasını istediğinizi.",
+    "note" : "Part of the GPC description, this communicates that the user would signal to not SHARE their personal data"
+  },
+  "globalPrivacyControlDisclaimer" : {
+    "title" : "<b>Küresel Gizlilik Kontrolü (GPC) yeni bir standart olduğundan,\nçoğu web sitesi tarafından henüz tanınmayacaktır. Ancak, dünya çapında\nbenimsenmesini sağlamak için elimizden geleni yapıyoruz.</b> Bununla birlikte, web sitelerinin onlara bildirilen tercihleri yalnızca geçerli yasaların zorunlu\nkıldığı ölçüde dikkate almaları gerekmektedir. ",
+    "note" : "Explains to the user that we can communiate their choice to the website, but the website needs to choose to support this signal"
+  },
+  "emailProtection" : {
+    "title" : "E-posta Koruması",
+    "note" : "Email protection is a feature that lets the user pick private email addresses for different websites"
+  },
+  "autofillDisabled" : {
+    "title" : "Otomatik doldurma devre dışı",
+    "note" : "When we don't automatically help populate email fields with a private address"
+  },
+  "autofillEnabled" : {
+    "title" : "<strong class=\"js-userdata-container\">{userName}</strong> için otomatik doldurma etkinleştirildi",
+    "note" : "When we do help populate email addresses for (your email address here)"
+  },
+  "noUnprotectedSitesAdded" : {
+    "title" : "Eklenen korumasız site yok",
+    "note" : "Currently there are no websites on the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSites" : {
+    "title" : "Korumasız Siteler",
+    "note" : "Header for the list of websites where our privacy protections are disabled"
+  },
+  "unprotectedSitesDesc" : {
+    "title" : "Bu siteler için Gizlilik Koruması uygulanmayacaktır.",
+    "note" : "Describes that the user will not be protected by our privacy features when visiting these websites"
+  },
+  "addUnprotectedSite" : {
+    "title" : "Korumasız site ekle",
+    "note" : "Header for the user to add a site to the uprotected list"
+  },
+  "enterURL" : {
+    "title" : "URL Girin",
+    "note" : "Promopt to enter the website URL here"
+  },
+  "invalidURL" : {
+    "title" : "Geçersiz URL",
+    "note" : "The URL the user entered is not a valid website address"
+  }
+}

--- a/shared/locales/tr/shared.json
+++ b/shared/locales/tr/shared.json
@@ -1,0 +1,31 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "options" : {
+    "title" : "Seçenekler",
+    "note" : "Header for the interface where user can configure various options"
+  },
+  "learnMore" : {
+    "title" : "Daha fazla bilgi",
+    "note" : "Click here to learn more about how our services work"
+  },
+  "enable" : {
+    "title" : "Etkinleştir",
+    "note" : "Button prompt to turn something on, i.e. click on this to enable"
+  },
+  "disable" : {
+    "title" : "Devre dışı bırak",
+    "note" : "Button prompt to turn something off, i.e. click on this to disable"
+  },
+  "add" : {
+    "title" : "Ekle",
+    "note" : "To add something to a list"
+  }
+}


### PR DESCRIPTION
**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
https://app.asana.com/0/1202416379154655/1202467416438011
Adds strings for options view, for all supported locales.  
Also cleans up i18next init code to follow the pattern in the dashboard.

## Steps to test this PR:
<!-- List steps to test it manually 
1. Fallback language is EN, so ideally test in English
2. Switch to a different language, browser should switch UI and DDG options language should change
 (note: easiest to test in FF)
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
