### PR TITLE
Avoid using onBeforeNavigate timeStamp for onboarding banner

### DIFF
--- a/integration-test/background/onboarding.js
+++ b/integration-test/background/onboarding.js
@@ -7,9 +7,7 @@ let browser, bgPage, teardown
 describe('onboarding', () => {
     beforeEach(async () => {
         ({ browser, bgPage, teardown } = await harness.setup())
-
-        await backgroundWait.forSetting(bgPage, 'showWelcomeBanner')
-        await backgroundWait.forSetting(bgPage, 'showCounterMessaging')
+        await backgroundWait.forAllConfiguration(bgPage)
     })
 
     afterEach(async () => {


### PR DESCRIPTION
When the extension is installed some onboarding messaging is displayed
the first time the user performs a DDG search. The onCommitted event
listener required for that is sometimes triggered twice in quick
succession by the browser. To avoid the onboarding messaging being
displayed twice when that happens, there were two workarounds:

1. Adding an onBeforeNavigate listener that kept track of the event's
   timestamp in a local variable. onCommitted events fired before the
   most recent recorded timestamp are ignored.
2. The showWelcomeBanner and showCounterMessaging settings are checked
   and cleared immediately when the event is fired, so that the second
   time it is fired the onboarding messaging isn't displayed.

The first approach isn't compatible with manifest V3, since state can
no longer be persisted between event listeners with local
variables[1]. Luckily however, the approach isn't necessary since
checking and clearing the settings is enough.

So let's remove the onBeforeNavigate listener and timer
variable. While at it, let's also stop listening for the onCommitted
event once the onboarding messaging has been displayed.

1 - https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#state

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sballesteros 

## Steps to test this PR:
1. Install the extension (in Chrome) and perform a search from the navigation bar.
2. Ensure the onboarding banner is displayed.
3. Perform another search from the navigation bar.
4. Ensure the banner is no longer displayed.

- Ensure the integration tests still pass.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
