### PR TITLE
Store devMode flag in session storage

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -16,8 +16,6 @@ const ATB_FORMAT_RE = /(v\d+-\d(?:[a-z_]{2})?)$/
 // list of accepted params in ATB url
 const ACCEPTED_URL_PARAMS = ['natb', 'cp', 'npi']
 
-let dev = false
-
 const ATB = (() => {
     // regex to match ddg urls to add atb params to.
     // Matching subdomains, searches, and newsletter page
@@ -202,7 +200,7 @@ const ATB = (() => {
                 !domain.match(regExpSoftwarePage)
         },
 
-        getSurveyURL: () => {
+        async getSurveyURL () {
             let url = ddgAtbURL + Math.ceil(Math.random() * 1e7) + '&uninstall=1&action=survey'
             const atb = settings.getSetting('atb')
             const setAtb = settings.getSetting('set_atb')
@@ -218,19 +216,17 @@ const ATB = (() => {
             if (browserName) url += `&browser=${browserName}`
             if (browserVersion) url += `&bv=${browserVersion}`
             if (extensionVersion) url += `&v=${extensionVersion}`
-            if (dev) url += '&test=1'
+            if (await browserWrapper.getFromSessionStorage('dev')) {
+                url += '&test=1'
+            }
             return url
-        },
-
-        setDevMode: () => {
-            dev = true
         }
     }
 })()
 
-settings.ready().then(() => {
+settings.ready().then(async () => {
     // set initial uninstall url
-    browserWrapper.setUninstallURL(ATB.getSurveyURL())
+    browserWrapper.setUninstallURL(await ATB.getSurveyURL())
 })
 
 module.exports = ATB

--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -4,12 +4,11 @@
  */
 const settings = require('./settings.es6')
 const tabManager = require('./tab-manager.es6')
-const load = require('./load.es6')
 const atb = require('./atb.es6')
 const https = require('./https.es6')
 const tds = require('./storage/tds.es6')
-const messageHandlers = require('./message-handlers')
 const startup = require('./startup.es6')
+const browserWrapper = require('./wrapper.es6')
 
 self.dbg = {
     settings,
@@ -23,6 +22,4 @@ self.dbg = {
 // mark this as a dev build
 // when we request certain resources, this flag will prevent any
 // metrics from being thrown off
-load.setDevMode()
-atb.setDevMode()
-messageHandlers._setDevMode()
+browserWrapper.setToSessionStorage('dev', true)

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -314,7 +314,7 @@ browser.runtime.onMessage.addListener((req, sender) => {
         }
     }
 
-    if (req.messageType && req.messageType[0] !== '_' && req.messageType in messageHandlers) {
+    if (req.messageType && req.messageType in messageHandlers) {
         return Promise.resolve(messageHandlers[req.messageType](req.options, sender))
     }
     if (req.messageType === 'registeredContentScript' || req.registeredTempAutofillContentScript) {
@@ -452,7 +452,7 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
             console.log(e)
         }
     } else if (alarmEvent.name === 'updateUninstallURL') {
-        browser.runtime.setUninstallURL(ATB.getSurveyURL())
+        browser.runtime.setUninstallURL(await ATB.getSurveyURL())
     } else if (alarmEvent.name === 'updateLists') {
         await settings.ready()
         https.sendHttpsUpgradeTotals()

--- a/shared/js/background/load.es6.js
+++ b/shared/js/background/load.es6.js
@@ -1,7 +1,5 @@
 const browserWrapper = require('./wrapper.es6')
 
-let dev = false
-
 function JSONfromLocalFile (path) {
     return loadExtensionFile({ url: path, returnType: 'json' })
 }
@@ -20,12 +18,12 @@ function url (url) {
  *  - source: requests are internal by default. set source to 'external' for non-extension URLs
  *  - etag: set an if-none-match header
  */
-function loadExtensionFile (params) {
+async function loadExtensionFile (params) {
     const headers = new Headers()
     let url = params.url
 
     if (params.source === 'external') {
-        if (dev) {
+        if (await browserWrapper.getFromSessionStorage('dev')) {
             if (url.indexOf('?') > -1) {
                 url += '&'
             } else {
@@ -88,14 +86,9 @@ function loadExtensionFile (params) {
     return Promise.race([timeoutPromise, fetchResult])
 }
 
-function setDevMode () {
-    dev = true
-}
-
 module.exports = {
     loadExtensionFile: loadExtensionFile,
     JSONfromLocalFile: JSONfromLocalFile,
     JSONfromExternalFile: JSONfromExternalFile,
-    url: url,
-    setDevMode: setDevMode
+    url: url
 }

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -14,17 +14,9 @@ const devtools = require('./devtools.es6')
 const browserWrapper = require('./wrapper.es6')
 const startup = require('./startup.es6')
 
-let dev = false
-
-// Exported functions are used as message handlers for messages with a
-// matching type. That is except for functions with the '_' prefix.
-
-export function _setDevMode () {
-    dev = true
-}
-
-export function getDevMode () {
-    return dev
+export async function getDevMode () {
+    const dev = await browserWrapper.getFromSessionStorage('dev')
+    return dev || false
 }
 
 export function resetTrackersData () {


### PR DESCRIPTION
For the MV3 transition we need to move extension state that persists
for the session over to session storage. Otherwise it will be lost
when the background ServiceWorker restarts. Let's start with the
devMode flag.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Ensure that you can still access the `dbg` Object from the extension background page when dev build of the extension is installed.
2. Ensure that Click to Load placeholders are created with an open shadowRoot when dev build of extension is installed, but closed shadowRoot when release build of extension is installed. (You can use [the test page here](https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/).)
3. Ensure that the `test=1` parameter is added to the uninstall URL when the a dev build of the extension is installed, but not when a release build is installed.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
