### PR TITLE
Reland "Properly handle requests initiated by ServiceWorkers"

### DIFF
--- a/integration-test/background/request-blocking.js
+++ b/integration-test/background/request-blocking.js
@@ -1,0 +1,61 @@
+const harness = require('../helpers/harness')
+const { logPageRequests } = require('../helpers/requests')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
+
+const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/'
+
+let browser
+let bgPage
+let teardown
+
+describe('Test request blocking', () => {
+    beforeAll(async () => {
+        ({ browser, bgPage, teardown } = await harness.setup())
+        await backgroundWait.forAllConfiguration(bgPage)
+    })
+
+    afterAll(async () => {
+        await teardown()
+    })
+
+    it('Should block all the test tracking requests', async () => {
+        // Load the test page.
+        const page = await browser.newPage()
+        await pageWait.forGoto(page, testSite)
+
+        // Start logging network requests.
+        const pageRequests = []
+        logPageRequests(page, pageRequests)
+
+        // Initiate the test requests and wait until they have all completed.
+        // Note: Waiting for network idle here does not work for some reason.
+        await page.click('#start')
+        await page.waitForFunction(
+            // eslint-disable-next-line no-undef
+            () => results.results.length >= tests.length
+        )
+
+        // Verify that no requests were allowed.
+        for (const { url, method, type, status } of pageRequests) {
+            const { hostname } = new URL(url)
+            if (hostname !== 'bad.third-party.site') {
+                continue
+            }
+            const description = `URL: ${url}, Method: ${method}, Type: ${type}`
+            expect(status).withContext(description).toEqual('blocked')
+        }
+
+        // Also check that the test page itself agrees that no requests were
+        // allowed.
+        const pageResults = await page.evaluate(
+            () => results.results // eslint-disable-line no-undef
+        )
+        for (const { id, category, status } of pageResults) {
+            const description = `ID: ${id}, Category: ${category}`
+            expect(status).withContext(description).not.toEqual('loaded')
+        }
+
+        await page.close()
+    })
+})

--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -48,7 +48,17 @@ class Tab {
         this.cleanAmpUrl = null
         this.requestId = tabData.requestId
         this.status = tabData.status
-        this.site = new Site(this.url)
+
+        // Consider the site URL to be the request initiator for requests fired
+        // inside opaque 'tabs' (e.g. via ServiceWorkers). Otherwise, consider
+        // the site URL to be the request URL.
+        const requestInitiator = tabData.initiator || tabData.originUrl
+        if (this.id === -1 && requestInitiator) {
+            this.site = new Site(requestInitiator)
+        } else {
+            this.site = new Site(this.url)
+        }
+
         this.httpsRedirects = new HttpsRedirects()
         this.statusCode = null // statusCode is set when headers are recieved in tabManager.js
         this.stopwatch = {
@@ -56,7 +66,13 @@ class Tab {
             end: null,
             completeMs: null
         }
-        this.resetBadgeIcon()
+
+        // Set the default extension icon for the new tab, assuming it's really
+        // a tab (e.g. not a ServiceWorker).
+        if (this.id !== -1) {
+            this.resetBadgeIcon()
+        }
+
         this.webResourceAccess = []
         this.surrogates = {}
     };

--- a/shared/js/background/events/3p-tracking-cookie-blocking.js
+++ b/shared/js/background/events/3p-tracking-cookie-blocking.js
@@ -29,6 +29,10 @@ function shouldBlockHeaders (request, tab, requestIsTracker) {
  * @returns {responseHeaders: Array<{name: string, value:string}>?}
  */
 function dropTracking3pCookiesFromResponse (request) {
+    // Skip requests not associated with tabs (e.g. requests initiated by
+    // ServiceWorkers) for now.
+    if (request.tabId === -1) { return }
+
     const tab = tabManager.get({ tabId: request.tabId })
     let responseHeaders = request.responseHeaders
 
@@ -61,6 +65,10 @@ function dropTracking3pCookiesFromResponse (request) {
  * @returns {requestHeaders: Array<{name: string, value:string}>?}
  */
 function dropTracking3pCookiesFromRequest (request) {
+    // Skip requests not associated with tabs (e.g. requests initiated by
+    // ServiceWorkers) for now.
+    if (request.tabId === -1) { return }
+
     const tab = tabManager.get({ tabId: request.tabId })
     let requestHeaders = request.requestHeaders
 

--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -84,9 +84,6 @@ function handleAmpRedirect (thisTab, url) {
 
 function handleRequest (requestData) {
     const tabId = requestData.tabId
-    // Skip requests to background tabs
-    if (tabId === -1) { return }
-
     let thisTab = tabManager.get(requestData)
 
     // control access to web accessible resources

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -9,6 +9,11 @@ class TabManager {
         this.tabContainer = {}
     };
 
+    _createInternal (tabData) {
+        const normalizedData = browserWrapper.normalizeTabData(tabData)
+        return new Tab(normalizedData)
+    }
+
     /* This overwrites the current tab data for a given
      * id and is only called in three cases:
      * 1. When we rebuild saved tabs when the browser is restarted
@@ -16,8 +21,7 @@ class TabManager {
      * 3. When we get a new main_frame request
      */
     create (tabData) {
-        const normalizedData = browserWrapper.normalizeTabData(tabData)
-        const newTab = new Tab(normalizedData)
+        const newTab = this._createInternal(tabData)
 
         const oldTab = this.tabContainer[newTab.id]
         if (oldTab) {
@@ -39,6 +43,12 @@ class TabManager {
      * @returns {Tab}
      */
     get (tabData) {
+        // Opaque 'tab' (e.g. ServiceWorker). Create the Tab Object, but don't
+        // store it for later lookup.
+        if (tabData.tabId === -1) {
+            return this._createInternal(tabData)
+        }
+
         return this.tabContainer[tabData.tabId]
     };
 

--- a/unit-test/background/3p-cookie-serviceworker-workaround.js
+++ b/unit-test/background/3p-cookie-serviceworker-workaround.js
@@ -1,0 +1,49 @@
+require('../helpers/mock-browser-api')
+
+const {
+    dropTracking3pCookiesFromResponse,
+    dropTracking3pCookiesFromRequest
+} = require('../../shared/js/background/events/3p-tracking-cookie-blocking')
+const tabManager = require('../../shared/js/background/tab-manager.es6')
+
+// Note: Enabling tracker blocking for requests initiated by ServiceWorkers
+//       ('tabs' with tabId of -1) caused a lot of breakage due to third party
+//       cookie blocking. For now, cookies created by ServiceWorkers are ignored
+//       therefore and this unit test ensures that workaround is implemented
+//       correctly. In the future, it would be desirable to remove the
+//       workaround and these tests entirely, if that's possible without causing
+//       website breakage.
+
+describe('3p cookie ServiceWorker workaround', () => {
+    let tabManagerGetObserver
+
+    beforeAll(() => {
+        tabManagerGetObserver = spyOn(tabManager, 'get').and.callFake(() => { })
+    })
+
+    beforeEach(() => {
+        tabManagerGetObserver.calls.reset()
+    })
+
+    it('Should attempt to proceed for requests initiated by tabs', () => {
+        let expectedCallCount = 0
+        expect(tabManagerGetObserver.calls.count()).toEqual(expectedCallCount)
+
+        for (let tabId = 1; tabId <= 10; tabId++) {
+            dropTracking3pCookiesFromResponse({ tabId })
+            expect(tabManagerGetObserver.calls.count()).toEqual(++expectedCallCount)
+            dropTracking3pCookiesFromRequest({ tabId })
+            expect(tabManagerGetObserver.calls.count()).toEqual(++expectedCallCount)
+        }
+    })
+
+    it('Should ignore requests initiated by ServiceWorkers', () => {
+        const expectedCallCount = 0
+        expect(tabManagerGetObserver.calls.count()).toEqual(expectedCallCount)
+
+        const tabId = -1
+        dropTracking3pCookiesFromResponse({ tabId })
+        dropTracking3pCookiesFromRequest({ tabId })
+        expect(tabManagerGetObserver.calls.count()).toEqual(expectedCallCount)
+    })
+})


### PR DESCRIPTION
Requests initiated by ServiceWorkers are given a tabId of -1, but we
still want to block tracking requests that they might make. So let's:
 - Stop ignoring requests with a tabId of -1.
 - Create an opaque Tab Object for those requests, but skip storing it
   for later lookup (since by definition we aren't sure which tab the
   request originated from).
 - Consider the site URL for such requests to be the request
   initiator, when available. Otherwise, the request will always be
   considered to have originated from its own URL and will therefore
   always be considered a first party request.
 - Disable 3p cookie protections for such requests for now, since that
   led to breakage (e.g. prevented Twitter users from logging out of
   their accounts). That breakage led to this change being reverted
   originally.
 - Add a unit test to ensure that 3p cookie protections are disabled
   for such requests, but not otherwise.
 - Add an integration test that verifies all tracking requests on our
   request blocking page[1] are blocked as expected.

1 - https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/

**Reviewer:** @sammacbeth 
**CC:** @SlayterDev, @jonathanKingston 

## Steps to test this PR:
1. Check that ServiceWorker initiated requests can be blocked, e.g. by using the test page https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/
2. Check that you can still log out of Twitter, go to https://twitter.com/ , log in, click to log out, confirm you are logged out.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
