### PR TITLE
Avoid executing the CTL content script for the new tab page

### DIFF
--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -422,10 +422,15 @@ if (manifestVersion === 2) {
     browser.webRequest.onBeforeSendHeaders.addListener(dropTracking3pCookiesFromRequest, { urls: ['<all_urls>'] }, extraInfoSpecSendHeaders)
 }
 
-// Inject our content script to overwite FB elements
+// Inject the Click to Load content script to display placeholders.
 browser.webNavigation.onCommitted.addListener(details => {
     const tab = tabManager.get({ tabId: details.tabId })
-    if (tab && tab.site.isBroken) {
+
+    if (!tab || tab.site.specialDomainName) {
+        return
+    }
+
+    if (tab.site.isBroken) {
         console.log('temporarily skip embedded object replacements for site: ' + details.url +
           'more info: https://github.com/duckduckgo/privacy-configuration')
         return

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -18,6 +18,12 @@ export async function sendTabMessage (id, message, details) {
 export function extractHostFromURL (url, shouldKeepWWW) {
     if (!url) return ''
 
+    // Tweak the URL for Firefox about:* pages to ensure that they are parsed
+    // correctly. For example, 'about:example' becomes 'about://example'.
+    if (url.startsWith('about:') && url[6] !== '/') {
+        url = 'about://' + url.substr(6)
+    }
+
     const urlObj = tldts.parse(url)
     let hostname = urlObj.hostname || ''
 

--- a/unit-test/background/classes/site.es6.js
+++ b/unit-test/background/classes/site.es6.js
@@ -38,7 +38,10 @@ describe('Site', () => {
             { url: `moz-extension://${EXT_ID}/feedback.html`, expected: 'extension page' },
             { url: 'chrome-extension://asdfasdfasdfasdf/page.html', expected: 'extension page' },
             // vivaldi's start page - not trying to handle that specifically because it may change its ID
-            { url: 'chrome-extension://mpognobbkildjkofajifpdfhcoklimli/components/startpage/startpage.html?section=Speed-dials&activeSpeedDialIndex=0', expected: 'extension page' }
+            { url: 'chrome-extension://mpognobbkildjkofajifpdfhcoklimli/components/startpage/startpage.html?section=Speed-dials&activeSpeedDialIndex=0', expected: 'extension page' },
+            { url: 'file://example', expected: 'local file' },
+            { url: 'https://duckduckgo.com/chrome_newtab', expected: 'new tab' },
+            { url: 'about:newtab', expected: 'new tab' }
         ]
 
         tests.forEach((test) => {


### PR DESCRIPTION
The executeScript APIs do not allow scripts to be injected into the
new tab page. This required some improvements to the code that
determines if a URL is for a new tab page, since neither
'about:newtab' nor 'https://duckduckgo.com/chrome_newtab' were being
handled correctly.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
1. Open a new tab and ensure an exception about executeScript not being possible for the new tab page aren't shown.
2. Navigate to https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/ and ensure the placeholder elements are still shown and work correctly.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
