### PR TITLE
Maintain devtools connections for MV3 builds of the extension

### DIFF
--- a/shared/js/background/devtools.es6.js
+++ b/shared/js/background/devtools.es6.js
@@ -7,6 +7,12 @@ const trackers = require('./trackers.es6')
 const tdsStorage = require('./storage/tds.es6')
 const { removeBroken } = require('./utils.es6')
 
+// Note: It is not necessary to use session storage to store the tabId -> port
+//       mapping for MV3 compatibility. That is because when the background
+//       ServiceWoker becomes inactive, any open connections will be closed and
+//       the devtools pages will reopen their connections. At that point, the
+//       background ServiceWorker will become active again and the onConnect
+//       event will fire again.
 const ports = new Map()
 
 function init () {

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -11,7 +11,16 @@ function sendMessage (messageType, options, callback) {
 }
 
 let tabId = chrome.devtools?.inspectedWindow?.tabId || parseInt(0 + new URL(document.location.href).searchParams.get('tabId'))
-const port = chrome.runtime.connect()
+
+// Open the messaging port and re-open if disconnected. The connection will
+// disconnect for MV3 builds when the background ServiceWorker becomes inactive.
+let port
+function openPort () {
+    port = chrome.runtime.connect()
+    port.onDisconnect.addListener(openPort)
+}
+openPort()
+
 // fetch the list of configurable features from the config and create toggles for them.
 const loadConfigurableFeatures = new Promise((resolve) => {
     sendMessage('getListContents', 'config', ({ data: config }) => {


### PR DESCRIPTION
With Chrome MV3, the background ServiceWorker becomes inactive
periodically and any open messaging connections are
disconnected. Let's take care to reopen connections from our devtools
page when this happens, to stop the devtools page from breaking. Also,
let's  add a comment to explain why maintain the port to tabId mapping
outside of session storage is acceptable.

**Reviewer:** @sammacbeth 

## Steps to test this PR:
MV2
- Install the extension, open the options page and change URL to `devtools-panel.html`.
- Navigate to a website with trackers (e.g. news website) in a new tab, point our devtools page to the website and ensure blocked trackers etc are listed as expected.

MV3
- Build a MV3 version of the extension: `npm run dev-chrome-mv3`
- Install the extension, open the options page and change URL to `devtools-panel.html`.
- Wait 30 minutes. (Important to not use the extension or open any consoles for the extension.)
- Navigate to any website in a new tab.
- Ensure the new tab is now listed in the tab selection drop-down menu in the devtools page.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
