### PR TITLE
Add comment about session storage for tracking parameter protection

### DIFF
--- a/shared/js/background/url-parameters.es6.js
+++ b/shared/js/background/url-parameters.es6.js
@@ -9,6 +9,9 @@ const tdsStorage = require('./storage/tds.es6')
 // contain one of the following characters: * + ? { } [ ]
 const regexpParameterTest = /[*+?{}[\]]/
 
+// Note: These lists of parameters would need to be stored in session storage if
+//       this code was used by MV3 builds of the extension.
+//       See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#state
 let plainTextTrackingParameters = null
 let regexpTrackingParameters = null
 


### PR DESCRIPTION
The tracking parameter protection feature processes the list of known
tracking parameters when the are updated and stores them in more
efficient data structures ready for use. They are so far stored in
local variables, which is not MV3 compatible[1].

Luckily however, the code is not required for the MV3 extension, since
tracking parameter protection will need to use the
declarativeNetRequest API there. Let's just add a comment to mention
this, to avoid setting a bad example.

1 - https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#state

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Steps to test this PR:
N/A

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
