### PR TITLE
Adjust Facebook SDK "surrogate script" to return valid login status

### DIFF
--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -140,7 +140,7 @@
                 return { status: '' }
             },
             // eslint-disable-next-line node/no-callback-literal
-            getLoginStatus: function (callback) { callback({ status: '' }) },
+            getLoginStatus: function (callback) { callback({ status: 'unknown' }) },
             getUserID: function () {},
             login: function (cb, params) {
                 fbLogin.callback = cb


### PR DESCRIPTION
Some websites that use the Facebook SDK check that the login status is
valid before proceeding. Let's start returning the "unknown" status
instead of just an empty string.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Navigate to https://nextdoor.co.uk/login/
2. Ensure the Facebook button is not greyed out and works when you click on it.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
