### PR TITLE
Fix the Facebook SDK schema test

### DIFF
--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -1,3 +1,4 @@
+const puppeteer = require('puppeteer')
 const { getDomain } = require('tldts')
 
 const harness = require('../helpers/harness')
@@ -159,7 +160,15 @@ describe('Facebook SDK schema', () => {
 
     it('CTL: Facebook SDK schema hasn\'t changed', async () => {
         const page = await browser.newPage()
-        await pageWait.forGoto(page, testSite)
+        try {
+            await page.goto(testSite)
+        } catch (e) {
+            // So much content is loaded by the page that timeout is common.
+            // Ignore that here, since the SDK should have loaded anyway.
+            if (!(e instanceof puppeteer.errors.TimeoutError)) {
+                throw e
+            }
+        }
 
         // Note: If these tests fail, update the
         //       /integration-test/data/api_schemas/facebook-sdk.json file


### PR DESCRIPTION
The Facebook Click to Load test page has recently been updated to fix
much of the broken content. That has had the knock on effect of
meaning the page takes longer to finish loading. When testing the
Facebook SDK schema, let's not wait for all requests to finish,
otherwise the chances are it will timeout.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @ladamski 

## Steps to test this PR:
1. Check that the Facebook Click to Load integration tests are passing (and not marked pending).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
