### PR TITLE
Add request-blocking integration tests

### DIFF
--- a/integration-test/background/request-blocking.js
+++ b/integration-test/background/request-blocking.js
@@ -1,0 +1,77 @@
+const harness = require('../helpers/harness')
+const { logPageRequests } = require('../helpers/requests')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
+
+const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/'
+
+let browser
+let bgPage
+let teardown
+
+describe('Test request blocking', () => {
+    beforeAll(async () => {
+        ({ browser, bgPage, teardown } = await harness.setup())
+        await backgroundWait.forAllConfiguration(bgPage)
+    })
+
+    afterAll(async () => {
+        await teardown()
+    })
+
+    it('Should block all the test tracking requests', async () => {
+        // Load the test page.
+        const page = await browser.newPage()
+        await pageWait.forGoto(page, testSite)
+
+        // Start logging network requests.
+        const pageRequests = []
+        logPageRequests(
+            page,
+            pageRequests,
+            ({ url }) => url.hostname === 'bad.third-party.site'
+        )
+
+        // Initiate the test requests and wait until they have all completed.
+        // Note:
+        //  - Waiting for network idle here does not work for some reason.
+        //  - ServiceWorker + WebWorker initiated requests are not yet logged by
+        //    logPageRequests.
+        await page.click('#start')
+        const testCount = await page.evaluate(
+            // eslint-disable-next-line no-undef
+            () => tests.filter(({ id }) => !id.includes('worker')).length
+        )
+        while (pageRequests.length < testCount) {
+            await backgroundWait.forTimeout(bgPage, 100)
+        }
+
+        // Verify that no logged requests were allowed.
+        for (const { url, method, type, status } of pageRequests) {
+            const description = `URL: ${url}, Method: ${method}, Type: ${type}`
+            expect(status).withContext(description).toEqual('blocked')
+        }
+
+        // Wait an additional second to ensure that the WebWorker +
+        // ServiceWorker initiated requests have finished. This can be removed
+        // once logPageRequests can intercept those requests.
+        await backgroundWait.forTimeout(bgPage, 1000)
+
+        // Also check that the test page itself agrees that no requests were
+        // allowed.
+        const pageResults = await page.evaluate(
+            () => results.results // eslint-disable-line no-undef
+        )
+        for (const { id, category, status } of pageResults) {
+            // ServiceWorker initiated request blocking is not yet supported.
+            if (id === 'serviceworker-fetch') {
+                continue
+            }
+
+            const description = `ID: ${id}, Category: ${category}`
+            expect(status).withContext(description).not.toEqual('loaded')
+        }
+
+        await page.close()
+    })
+})


### PR DESCRIPTION
Add an integration test runner for the request blocking test page. To
facilitate that, add support for request filtering and WebSocket
connections to the logPageRequests helper.

1 - https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Ensure integration tests pass.
2. Try disabling webrequest or other tracker blocking, and the ServiceWorker blocking test exception to verify that the respective test cases fail.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
