### PR TITLE
Increase minimum supported Chrome and Firefox versions

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -3,6 +3,7 @@
     "description": "__MSG_appDesc__",
     "default_locale": "en",
     "version": "2022.8.25",
+    "minimum_chrome_version": "92.0",
     "icons": {
         "16": "img/icon_16.png",
         "48": "img/icon_48.png",

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -3,7 +3,7 @@
     "applications": {
         "gecko": {
             "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
-            "strict_min_version": "65.0"
+            "strict_min_version": "91.0"
         }
     },
     "version": "2022.8.25",


### PR DESCRIPTION
We agreed to support back to the previous ESR Firefox
release[1] (currently 91) and Chrome releases for the past
year[2] (currently back to 92). We will bump these minimum version
numbers periodically in line with that policy.

1 - https://endoflife.date/firefox
2 - https://chromiumdash.appspot.com/releases?platform=Windows

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @ladamski 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
