### PR TITLE
Properly check the request initiator for tracking parameters protection

### DIFF
--- a/shared/js/background/redirect.es6.js
+++ b/shared/js/background/redirect.es6.js
@@ -137,7 +137,7 @@ function handleRequest (requestData) {
             // Strip tracking parameters if 1. there are any and 2. the feature
             // is enabled for both the request URL and the initiator URL.
             trackingParametersStrippingEnabled(
-                thisTab.site, requestData.initiatorUrl
+                thisTab.site, (requestData.initiator || requestData.originUrl)
             ) && stripTrackingParameters(mainFrameRequestURL)
         )
 


### PR DESCRIPTION
We strip known tracking parameters for navigations. Sometimes it is
necessary to disable that if breakage occurs, or if the user has
chosen to disable protections for a website. Both the request URL and
the initiator URL are checked, to see if the feature is disabled, but
a typo prevented the initiator URL from being checked correctly.

For Chrome, the request initiator is in the `initiator`
property[1] (not `initiatorUrl`) and for Firefox it is in the
`originUrl` property[2]. Let's correct that here.

1 - https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onBeforeRequest
2 - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest#details_2

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
