### PR TITLE
Add tracker blocking support to Chrome MV3 extension

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -1,6 +1,7 @@
 {
     "spec_dir": "integration-test",
     "spec_files": [
-        "background/onboarding.js"
+        "background/onboarding.js",
+        "background/request-blocking.js"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.1",
+                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.1.4",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.0",
                 "bel": "6.0.0",
@@ -35,6 +36,7 @@
                 "@babel/polyfill": "^7.10.4",
                 "@babel/preset-env": "^7.18.10",
                 "@fingerprintjs/fingerprintjs": "^3.3.4",
+                "@types/chrome": "0.0.193",
                 "@types/webextension-polyfill": "^0.9.0",
                 "asana": "github:Asana/node-asana",
                 "babelify": "10.0.0",
@@ -1833,6 +1835,11 @@
                 "sjcl": "^1.0.8"
             }
         },
+        "node_modules/@duckduckgo/ddg2dnr": {
+            "version": "0.1.3",
+            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#3a892d750c8aed925ea0176867975902d7ca8914",
+            "license": "Apache-2.0"
+        },
         "node_modules/@duckduckgo/jsbloom": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@duckduckgo/jsbloom/-/jsbloom-1.0.2.tgz",
@@ -2138,6 +2145,16 @@
                 "@types/responselike": "*"
             }
         },
+        "node_modules/@types/chrome": {
+            "version": "0.0.193",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.193.tgz",
+            "integrity": "sha512-R8C84oqvk8A8C8G1viBd8qLpDr86Y/jwD+KLgzUekbIT9RGds6a9GnlQyg8P7ltnGogTMHkiEQK0ZlcrvTeo3Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/filesystem": "*",
+                "@types/har-format": "*"
+            }
+        },
         "node_modules/@types/component-emitter": {
             "version": "1.2.11",
             "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -2154,6 +2171,27 @@
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
             "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+            "dev": true
+        },
+        "node_modules/@types/filesystem": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+            "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/filewriter": "*"
+            }
+        },
+        "node_modules/@types/filewriter": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+            "dev": true
+        },
+        "node_modules/@types/har-format": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+            "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
             "dev": true
         },
         "node_modules/@types/http-cache-semantics": {
@@ -16314,6 +16352,10 @@
                 "sjcl": "^1.0.8"
             }
         },
+        "@duckduckgo/ddg2dnr": {
+            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#3a892d750c8aed925ea0176867975902d7ca8914",
+            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.1.4"
+        },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@duckduckgo/jsbloom/-/jsbloom-1.0.2.tgz",
@@ -16559,6 +16601,16 @@
                 "@types/responselike": "*"
             }
         },
+        "@types/chrome": {
+            "version": "0.0.193",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.193.tgz",
+            "integrity": "sha512-R8C84oqvk8A8C8G1viBd8qLpDr86Y/jwD+KLgzUekbIT9RGds6a9GnlQyg8P7ltnGogTMHkiEQK0ZlcrvTeo3Q==",
+            "dev": true,
+            "requires": {
+                "@types/filesystem": "*",
+                "@types/har-format": "*"
+            }
+        },
         "@types/component-emitter": {
             "version": "1.2.11",
             "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -16575,6 +16627,27 @@
             "version": "2.8.12",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
             "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+            "dev": true
+        },
+        "@types/filesystem": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+            "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+            "dev": true,
+            "requires": {
+                "@types/filewriter": "*"
+            }
+        },
+        "@types/filewriter": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+            "dev": true
+        },
+        "@types/har-format": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+            "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
             "dev": true
         },
         "@types/http-cache-semantics": {
@@ -17232,7 +17305,7 @@
             "version": "git+ssh://git@github.com/Asana/node-asana.git#bebf5f20394d797c5c38af02bedd127a171eb7de",
             "integrity": "sha512-Flpks0U2e4bnnV5XSCLCyAISGU8TPpBWbgG8W99/g5IpzEZs92+2S7oSnsC9yXp0OBfFruqaWAx3c3djkkf73g==",
             "dev": true,
-            "from": "asana@github:Asana/node-asana#bebf5f20394d797c5c38af02bedd127a171eb7de",
+            "from": "asana@github:Asana/node-asana",
             "requires": {
                 "bluebird": "^3.7.2",
                 "browser-request": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@babel/polyfill": "^7.10.4",
         "@babel/preset-env": "^7.18.10",
         "@fingerprintjs/fingerprintjs": "^3.3.4",
+        "@types/chrome": "0.0.193",
         "@types/webextension-polyfill": "^0.9.0",
         "asana": "github:Asana/node-asana",
         "babelify": "10.0.0",
@@ -77,6 +78,7 @@
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.1",
+        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.1.4",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.0",
         "bel": "6.0.0",

--- a/shared/js/background/background.es6.js
+++ b/shared/js/background/background.es6.js
@@ -19,6 +19,7 @@
 require('./events.es6')
 const settings = require('./settings.es6')
 const { onStartup } = require('./startup.es6')
+require('./declarative-net-request')
 
 settings.ready().then(() => {
     onStartup()

--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -1,0 +1,207 @@
+import * as browserWrapper from './wrapper.es6'
+import settings from './settings.es6'
+import tdsStorage from './storage/tds.es6'
+
+import {
+    generateExtensionConfigurationRuleset
+} from '@duckduckgo/ddg2dnr/lib/extensionConfiguration'
+import {
+    generateTrackerBlockingRuleset
+} from '@duckduckgo/ddg2dnr/lib/trackerBlocking'
+
+export const SETTING_PREFIX = 'declarative_net_request-'
+
+// Allocate blocks of rule IDs for the different configurations. That way, the
+// rules associated with a configuration can be safely cleared without the risk
+// of removing rules associated with different configurations.
+const ruleIdRangeByConfigName = {
+    tds: [1, 10000],
+    config: [10001, 20000]
+}
+
+// A dummy etag rule is saved with the declarativeNetRequest rules generated for
+// each configuration. That way, a consistent extension state (between tds
+// configurations, extension settings and declarativeNetRequest rules) can be
+// ensured.
+function generateEtagRule (id, etag) {
+    return {
+        id,
+        priority: 1,
+        condition: {
+            urlFilter: etag,
+            requestDomains: ['etag.invalid']
+        },
+        action: { type: 'allow' }
+    }
+}
+
+/**
+ * tdsStorage.onUpdate listener which is called when the configurations are
+ * updated and when the background ServiceWorker is restarted.
+ * @param {'config'|'tds'} configName
+ * @param {string} etag
+ * @param {object} configValue
+ */
+async function onUpdate (configName, etag, configValue) {
+    await settings.ready()
+
+    const [ruleIdStart, ruleIdEnd] = ruleIdRangeByConfigName[configName]
+    const etagRuleId = ruleIdStart
+    const maxNumberOfRules = ruleIdEnd - ruleIdStart
+
+    const settingName = SETTING_PREFIX + configName
+    const settingValue = settings.getSetting(settingName)
+
+    const extensionVersion = browserWrapper.getExtensionVersion()
+    const previousSettingEtag = settingValue?.etag
+    const previousExtensionVersion = settingValue?.extensionVersion
+
+    // If both the settings entry and declarativeNetRequest rules are present
+    // and the etags all match, everything is already up to date.
+    // Note: We also check the extension version here, so that if the extension
+    //       is updated and the ddg2dnr dependency was updated, we have the
+    //       opportunity to regenerate the rulesets with the latest code.
+    if (previousSettingEtag &&
+        previousSettingEtag === etag &&
+        previousExtensionVersion &&
+        previousExtensionVersion === extensionVersion) {
+        const existingRules =
+              await chrome.declarativeNetRequest.getDynamicRules()
+        let previousRuleEtag = null
+        for (const rule of existingRules) {
+            if (rule.id === etagRuleId) {
+                previousRuleEtag = rule.condition.urlFilter
+                break
+            }
+        }
+
+        // No change, rules are already current.
+        if (previousRuleEtag && previousRuleEtag === etag) {
+            return
+        }
+    }
+
+    // Otherwise, it is necessary to update the declarativeNetRequest rules and
+    // settings again.
+
+    let addRules
+    let lookup
+
+    // Tracker blocking.
+    if (configName === 'tds') {
+        const {
+            ruleset, trackerDomainByRuleId
+        } = await generateTrackerBlockingRuleset(
+            configValue,
+            chrome.declarativeNetRequest.isRegexSupported,
+            ruleIdStart + 1
+        )
+        addRules = ruleset
+        lookup = trackerDomainByRuleId
+    // Extension configuration.
+    } else if (configName === 'config') {
+        const {
+            ruleset, matchDetailsByRuleId
+        } = await generateExtensionConfigurationRuleset(
+            configValue,
+            chrome.declarativeNetRequest.isRegexSupported,
+            ruleIdStart + 1
+        )
+        addRules = ruleset
+        lookup = matchDetailsByRuleId
+    }
+
+    if (!addRules) {
+        console.error(
+            'No declarativeNetRequest rules generated for configuration: ',
+            configName, '(Etag: ', etag, ')'
+        )
+        return
+    }
+
+    // Add the new etag rule.
+    addRules.push(generateEtagRule(etagRuleId, etag))
+
+    if (addRules.length > maxNumberOfRules) {
+        console.error(
+            'Too many declarativeNetRequest rules generated for configuration: ',
+            configName,
+            '(Etag: ', etag, ', Rules generated: ', addRules.length, ')'
+        )
+        return
+    }
+
+    // Ensure any existing rules for the configuration are removed.
+    const removeRuleIds = []
+    for (let i = ruleIdStart; i <= ruleIdEnd; i++) {
+        removeRuleIds.push(i)
+    }
+
+    // Install the updated rules and then update the setting entry.
+    await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds, addRules
+    })
+    settings.updateSetting(settingName, { etag, lookup, extensionVersion })
+}
+
+/**
+ * @typedef {object} getMatchDetailsTrackerBlockingResult
+ * @property {string} type
+ *   The match type 'trackerBlocking'.
+ * @property {string[]} possibleTrackerDomains
+ *   The list of possible tracking domains associated with this match.
+ */
+
+/**
+ * @typedef {object} getMatchDetailsExtensionConfigurationResult
+ * @property {string} type
+ *   The match type, for example 'trackerAllowlist'.
+ * @property {string} domain
+ *   The matching tracker domain.
+ * @property {string} reason
+ *   The reason for the match.
+ */
+
+/**
+ * @typedef {object} getMatchDetailsUnknownResult
+ * @property {string} type
+ *   The match type 'unknown'.
+ */
+
+/**
+ * Find the match details (if any) associated with the given
+ * declarativeNetRequest rule ID.
+ * @param {number} ruleId
+ * @return {Promise<getMatchDetailsUnknownResult |
+ *                  getMatchDetailsExtensionConfigurationResult |
+ *                  getMatchDetailsTrackerBlockingResult>}
+ */
+export async function getMatchDetails (ruleId) {
+    await settings.ready()
+
+    for (const [configName, [ruleIdStart, ruleIdEnd]]
+        of Object.entries(ruleIdRangeByConfigName)) {
+        if (ruleId >= ruleIdStart && ruleId <= ruleIdEnd) {
+            const settingName = SETTING_PREFIX + configName
+            const settingValue = settings.getSetting(settingName)
+            const matchDetails = settingValue?.lookup?.[ruleId]
+            if (matchDetails) {
+                if (configName === 'tds') {
+                    return {
+                        type: 'trackerBlocking',
+                        possibleTrackerDomains: matchDetails.split(',')
+                    }
+                }
+
+                return JSON.parse(JSON.stringify(matchDetails))
+            }
+        }
+    }
+
+    return { type: 'unknown' }
+}
+
+if (browserWrapper.getManifestVersion() === 3) {
+    tdsStorage.onUpdate('config', onUpdate)
+    tdsStorage.onUpdate('tds', onUpdate)
+}

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -70,7 +70,7 @@ class TDSStorage {
         }
     }
 
-    _internalOnListUpdate (configName) {
+    _internalOnListUpdate (configName, configValue) {
         self.setTimeout(() => {
             // Ensure the onReady promise for this configuration is resolved.
             const resolve = this._onReadyResolvers.get(configName)
@@ -79,11 +79,15 @@ class TDSStorage {
                 this._onReadyResolvers.delete(configName)
             }
 
+            // Check the current etag for this configuration, so that can be
+            // passed to the listeners.
+            const etag = settings.getSetting(`${configName}-etag`) || ''
+
             // Notify any listeners that this list has updated.
             const listeners = this._onUpdatedListeners.get(configName)
             if (listeners) {
                 for (const listener of listeners.slice()) {
-                    listener(configName)
+                    listener(configName, etag, configValue)
                 }
             }
         }, 0)
@@ -176,7 +180,7 @@ class TDSStorage {
                     // store tds in memory so we can access it later if needed
                     this[listCopy.name] = resultData
 
-                    this._internalOnListUpdate(listCopy.name)
+                    this._internalOnListUpdate(listCopy.name, resultData)
 
                     return { name: listCopy.name, data: resultData }
                 } else {
@@ -218,7 +222,7 @@ class TDSStorage {
 
         if (list && list.data) {
             this[name] = list.data
-            this._internalOnListUpdate(name)
+            this._internalOnListUpdate(name, list.data)
             return { name, data: list.data }
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,8 @@
       "shared/js/background/storage/https.es6.js",
       "shared/js/devtools/list-editor.es6.js",
       "shared/js/devtools/panel.es6.js"
-  ]
+  ],
+    "types": [
+        "chrome"
+    ]
 }

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -1,0 +1,376 @@
+import '../helpers/mock-browser-api'
+import * as allowlistedTrackers from '../data/reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_reference.json'
+import * as tds from '../data/tds.json'
+import * as browserWrapper from '../../shared/js/background/wrapper.es6'
+import * as testConfig from '../data/extension-config.json'
+import * as tdsStorageStub from '../helpers/tds.es6'
+import settings from '../../shared/js/background/settings.es6'
+
+const TEST_ETAGS = ['flib', 'flob', 'cabbage']
+const TEST_EXTENION_VERSIONS = ['0.1', '0.2', '0.3']
+
+let SETTING_PREFIX
+let getMatchDetails
+let onUpdateListeners
+
+// Set up the extension configuration to ensure that tracker allowlisting is
+// enabled for the right domains.
+const config = JSON.parse(JSON.stringify(testConfig))
+config.features.trackerAllowlist = {
+    state: 'enabled',
+    settings: { allowlistedTrackers }
+}
+
+const expectedRuleIdsByConfigName = {
+    tds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    config: [10001, 10002, 10003, 10004, 10005, 10006]
+}
+
+const expectedLookupByConfigName = {
+    tds: [
+        undefined, undefined, 'facebook.com,facebook.net',
+        'google-analytics.com', 'google-analytics.com', 'google-analytics.com',
+        'google-analytics.com', 'google-analytics.com', 'google-analytics.com',
+        'google-analytics.com', 'yahoo.com'
+    ],
+    config: {
+        10002: {
+            type: 'trackerAllowlist',
+            domain: 'allowlist-tracker-1.com',
+            reason: 'match single resource on single site'
+        },
+        10003: {
+            type: 'trackerAllowlist',
+            domain: 'allowlist-tracker-2.com',
+            reason: 'match single resource on all sites'
+        },
+        10004: {
+            type: 'trackerAllowlist',
+            domain: 'allowlist-tracker-2.com',
+            reason: 'match all sites and all paths'
+        },
+        10005: {
+            type: 'trackerAllowlist',
+            domain: 'allowlist-tracker-2.com',
+            reason: 'specific subdomain rule'
+        },
+        10006: {
+            type: 'trackerAllowlist',
+            domain: 'allowlist-tracker-3.com',
+            reason: 'match all requests'
+        }
+    }
+}
+
+async function updateConfiguration (configName, etag) {
+    const configValue = { config, tds }[configName]
+    const listeners = onUpdateListeners.get(configName)
+    if (listeners) {
+        await Promise.all(
+            listeners.map(listener => listener(configName, etag, configValue))
+        )
+    }
+}
+
+describe('declarativeNetRequest', () => {
+    let updateSettingObserver
+    let updateDynamicRulesObserver
+
+    let extensionVersion
+    let settingsStorage
+    let dynamicRulesByRuleId
+
+    const expectState = (expectedSettings, expectedUpdateCallCount) => {
+        const expectedRuleIds = new Set()
+        for (const [configName, {
+            etag: expectedEtag,
+            extensionVersion: expectedExtensionVersion
+        }] of Object.entries(expectedSettings)) {
+            if (!expectedEtag) {
+                continue
+            }
+
+            const setting =
+                  settingsStorage.get(SETTING_PREFIX + configName) || {}
+
+            const {
+                etag: actualLookupEtag,
+                lookup: actualLookup,
+                extensionVersion: actualLookupExtensionVersion
+            } = setting
+            const etagRuleId = expectedRuleIdsByConfigName[configName][0]
+            const etagRule = dynamicRulesByRuleId.get(etagRuleId)
+            const actualRuleEtag = etagRule?.condition?.urlFilter
+
+            expect(actualLookup).toEqual(expectedLookupByConfigName[configName])
+            expect(actualRuleEtag).toEqual(expectedEtag)
+            expect(actualLookupEtag).toEqual(expectedEtag)
+            expect(actualLookupExtensionVersion)
+                .toEqual(expectedExtensionVersion)
+
+            for (const ruleId of expectedRuleIdsByConfigName[configName]) {
+                expectedRuleIds.add(ruleId)
+            }
+        }
+
+        expect(new Set(dynamicRulesByRuleId.keys())).toEqual(expectedRuleIds)
+
+        expect(updateDynamicRulesObserver.calls.count())
+            .toEqual(expectedUpdateCallCount)
+        expect(updateSettingObserver.calls.count())
+            .toEqual(expectedUpdateCallCount)
+    }
+
+    beforeAll(async () => {
+        extensionVersion = TEST_EXTENION_VERSIONS[0]
+        settingsStorage = new Map()
+        dynamicRulesByRuleId = new Map()
+
+        onUpdateListeners = tdsStorageStub.stub({ config }).onUpdateListeners
+
+        spyOn(settings, 'getSetting').and.callFake(
+            name => settingsStorage.get(name)
+        )
+        updateSettingObserver =
+            spyOn(settings, 'updateSetting').and.callFake(
+                (name, value) => {
+                    settingsStorage.set(name, value)
+                }
+            )
+        updateDynamicRulesObserver =
+            spyOn(
+                chrome.declarativeNetRequest,
+                'updateDynamicRules'
+            ).and.callFake(
+                ({ removeRuleIds, addRules }) => {
+                    if (removeRuleIds) {
+                        for (const id of removeRuleIds) {
+                            dynamicRulesByRuleId.delete(id)
+                        }
+                    }
+                    if (addRules) {
+                        for (const rule of addRules) {
+                            if (dynamicRulesByRuleId.has(rule.id)) {
+                                throw new Error('Duplicate rule ID: ' + rule.id)
+                            }
+                            dynamicRulesByRuleId.set(rule.id, rule)
+                        }
+                    }
+                    return Promise.resolve()
+                }
+            )
+        spyOn(chrome.declarativeNetRequest, 'getDynamicRules').and.callFake(
+            () => Array.from(dynamicRulesByRuleId.values())
+        )
+
+        spyOn(browserWrapper, 'getExtensionVersion').and.callFake(
+            () => extensionVersion
+        )
+
+        // Force manifest version to '3' before requiring the
+        // declarativeNetRequest code to prevent the MV3 code paths from being
+        // skipped.
+        // Note: It would be better to use destructuring to assign
+        //       getMatchDetails and SETTING_PREFIX, but that confuses ESLint.
+        spyOn(browserWrapper, 'getManifestVersion').and.callFake(() => 3)
+        const declarativeNetRequest =
+              await import('../../shared/js/background/declarative-net-request')
+        getMatchDetails = declarativeNetRequest.getMatchDetails
+        SETTING_PREFIX = declarativeNetRequest.SETTING_PREFIX
+    })
+
+    beforeEach(() => {
+        updateSettingObserver.calls.reset()
+        updateDynamicRulesObserver.calls.reset()
+        settingsStorage.clear()
+        dynamicRulesByRuleId.clear()
+    })
+
+    it('Rule updates', async () => {
+        expectState({
+            tds: { etag: null, extensionVersion: null },
+            config: { etag: null, extensionVersion: null }
+        }, 0)
+
+        // Nothing saved, tracker blocking rules should be added.
+        await updateConfiguration('tds', TEST_ETAGS[0])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[0], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: null, extensionVersion: null
+            }
+        }, 1)
+
+        // Rules for that ruleset are already present, skip.
+        await updateConfiguration('tds', TEST_ETAGS[0])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[0], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: null, extensionVersion: null
+            }
+        }, 1)
+
+        // Add configuration ruleset.
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[0], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 2)
+
+        // Tracker blocking rules are outdated, replace with new ones.
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 3)
+
+        // Configuration ruleset already present, skip.
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 3)
+
+        // Settings missing, add rules again.
+        settingsStorage.clear()
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 5)
+
+        // Rules missing, add tracker blocking rules again.
+        dynamicRulesByRuleId.clear()
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 7)
+
+        // All good again, skip.
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 7)
+
+        // Extension has been updated, refresh rules again
+        extensionVersion = TEST_EXTENION_VERSIONS[1]
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[1]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[0]
+            }
+        }, 8)
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[1]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[1]
+            }
+        }, 9)
+
+        // All good again, skip.
+        await updateConfiguration('tds', TEST_ETAGS[1])
+        await updateConfiguration('config', TEST_ETAGS[2])
+        expectState({
+            tds: {
+                etag: TEST_ETAGS[1], extensionVersion: TEST_EXTENION_VERSIONS[1]
+            },
+            config: {
+                etag: TEST_ETAGS[2], extensionVersion: TEST_EXTENION_VERSIONS[1]
+            }
+        }, 9)
+    })
+
+    it('getMatchDetails', async () => {
+        // No rules, so no match details.
+        // - Tracker blocking:
+        for (let i = 0; i < expectedLookupByConfigName.tds.length; i++) {
+            if (!expectedLookupByConfigName.tds[i]) continue
+            expect(await getMatchDetails(i)).toEqual({ type: 'unknown' })
+        }
+        // - Extension configuration:
+        for (let i in expectedLookupByConfigName.config) {
+            i = parseInt(i, 10)
+            expect(await getMatchDetails(i)).toEqual({ type: 'unknown' })
+        }
+
+        // Add the tracker blocking rules.
+        await updateConfiguration('tds', TEST_ETAGS[0])
+
+        // Still should not be any match details for the extension configuration
+        // yet.
+        for (let i in expectedLookupByConfigName.config) {
+            i = parseInt(i, 10)
+            expect(await getMatchDetails(i)).toEqual({ type: 'unknown' })
+        }
+
+        // But there should be tracker blocking match details now.
+        for (let i = 0; i < expectedLookupByConfigName.tds.length; i++) {
+            if (!expectedLookupByConfigName.tds[i]) continue
+            expect(await getMatchDetails(i)).toEqual({
+                type: 'trackerBlocking',
+                possibleTrackerDomains:
+                    expectedLookupByConfigName.tds[i].split(',')
+            })
+        }
+
+        // Add the extension configuration rules.
+        await updateConfiguration('config', TEST_ETAGS[1])
+
+        // Extension configuration match details should now show up.
+        for (let i in expectedLookupByConfigName.config) {
+            i = parseInt(i, 10)
+            expect(await getMatchDetails(i)).toEqual(
+                expectedLookupByConfigName.config[i]
+            )
+        }
+
+        // Tracker blocking match details should still be there too.
+        for (let i = 0; i < expectedLookupByConfigName.tds.length; i++) {
+            if (!expectedLookupByConfigName.tds[i]) continue
+            expect(await getMatchDetails(i)).toEqual({
+                type: 'trackerBlocking',
+                possibleTrackerDomains:
+                    expectedLookupByConfigName.tds[i].split(',')
+            })
+        }
+    })
+})

--- a/unit-test/data/tds.json
+++ b/unit-test/data/tds.json
@@ -88,6 +88,12 @@
         }
     },
     "entities": {
+        "Facebook": {
+            "domains": [
+                "facebook.com",
+                "facebook.net"
+            ]
+        },
         "Google LLC": {
             "domains": [
                 "googleapis.com",
@@ -1336,5 +1342,7 @@
         "enow.com": "Verizon Media",
         "aolsearch.com": "Verizon Media",
         "searchjam.com": "Verizon Media"
+    },
+    "cnames": {
     }
 }

--- a/unit-test/helpers/mock-browser-api.js
+++ b/unit-test/helpers/mock-browser-api.js
@@ -19,6 +19,11 @@ globalThis.browser = {
     },
     tabs: {
         sendMessage: () => {}
+    },
+    declarativeNetRequest: {
+        isRegexSupported () { return { isSupported: true } },
+        getDynamicRules () { },
+        updateDynamicRules () { }
     }
 }
 globalThis.chrome = globalThis.browser

--- a/unit-test/helpers/tds.es6.js
+++ b/unit-test/helpers/tds.es6.js
@@ -5,6 +5,7 @@
 const tdsStorage = require('../../shared/js/background/storage/tds.es6')
 
 const stub = (arg) => {
+    const onUpdateListeners = new Map()
     const tdsData = {
         tds: require('./../data/tds.json'),
         surrogates: require('./../data/surrogates.js').surrogates,
@@ -28,6 +29,18 @@ const stub = (arg) => {
 
     spyOn(tdsStorage, 'getDataXHR')
         .and.callFake((list, etag, source) => Promise.resolve({ response: 200, data: tdsData[list.name] }))
+
+    spyOn(tdsStorage, 'onUpdate')
+        .and.callFake((configName, listener) => {
+            let listeners = onUpdateListeners.get(configName)
+            if (!listeners) {
+                listeners = []
+                onUpdateListeners.set(configName, listeners)
+            }
+            listeners.push(listener)
+        })
+
+    return { onUpdateListeners, tdsData }
 }
 module.exports = {
     stub


### PR DESCRIPTION
Add Chrome MV3 tracker blocking support using the declarativeNetRequest
API and the ddg2dnr ruleset generation library[1].

Note that blocked trackers are not yet reported properly in the popup
UI or our devtools panel, though the necessary getMatchDetails API +
ruleId -> match details lookups are in place.

1 - https://github.com/duckduckgo/ddg2dnr

**Reviewer:** @ladamski 

## Steps to test this PR:
1. Build the Chrome MV3 extension: `npm run dev-chrome-mv3`
2. Install that in Chrome.
3. Ensure tracker blocking works (e.g. browse to a news website or [our test page](https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/) and ensure requests are blocked).
4. Ensure the unit tests and MV3 integration tests pass: `npm run test` and `npm run test-int-mv3`

Note: It is expected that blocked trackers are not listed in developer tools panel nor the popup UI yet.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
