### PR TITLE
Avoid errors when clicking on the Settings link

### DIFF
--- a/shared/js/ui/base/ui-wrapper.es6.js
+++ b/shared/js/ui/base/ui-wrapper.es6.js
@@ -55,13 +55,9 @@ const openExtensionPage = (path) => {
     browser.tabs.create({ url: getExtensionURL(path) })
 }
 
-const openOptionsPage = (browser) => {
-    if (browser === 'moz') {
-        openExtensionPage('/html/options.html')
-        window.close()
-    } else {
-        browser.runtime.openOptionsPage()
-    }
+const openOptionsPage = () => {
+    openExtensionPage('/html/options.html')
+    window.close()
 }
 
 const reloadTab = (id) => {


### PR DESCRIPTION
**Reviewer:** @kzar 

## Description:
Fix the link to the Settings page from the cog dropdown.


## Steps to test this PR:
Just check that the link to the settings in the cog dropdown works opens the Settings page and there are no errors in the console. Check both Chrome and Firefox.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
