### PR TITLE
Fix the settings button in the popup UI for Chrome users

### DIFF
--- a/shared/js/ui/base/ui-wrapper.es6.js
+++ b/shared/js/ui/base/ui-wrapper.es6.js
@@ -55,8 +55,8 @@ const openExtensionPage = (path) => {
     browser.tabs.create({ url: getExtensionURL(path) })
 }
 
-const openOptionsPage = (browser) => {
-    if (browser === 'moz') {
+const openOptionsPage = (browserName) => {
+    if (browserName === 'moz') {
         openExtensionPage('/html/options.html')
         window.close()
     } else {


### PR DESCRIPTION
There was a typo in the UI code, which caused the settings button not
to work for Chrome users. The openOptionsPage function took a
parameter named `browser` which contained a string name of the browser
(e.g. "chrome"), but then later attempted to use the
`browser.runtime.openOptionsPage()` API.

Credit to @GioSensation for finding this bug and proposing an initial
fix.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @GioSensation 

## Steps to test this PR:
1. Install the extension on Chrome.
2. Ensure the "Settings" button in the popup UI works.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
