### PR TITLE
Improve devtools panel filters

### DIFF
--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -208,6 +208,8 @@
     </label>
     <label class="canvas">
       <input data-filter-toggle="apiCanvas" type="checkbox" checked><span>Canvas API</span>
+    <label class="none">
+      <input data-filter-toggle="noneRequest" type="checkbox" checked><span>none</span>
     </label>
     <label for="search-box">Filter: </label>
     <input type="text" name="search-box" id="search-box" />

--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -211,6 +211,9 @@
     <label class="none">
       <input data-filter-toggle="noneRequest" type="checkbox" checked><span>none</span>
     </label>
+    <label class="ignore-user">
+      <input data-filter-toggle="ignoreUser" type="checkbox" checked><span>ignore-user</span>
+    </label>
     <label for="search-box">Filter: </label>
     <input type="text" name="search-box" id="search-box" />
   </div>

--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -151,7 +151,7 @@
     <tr>
       <td></td>
       <td></td>
-      <td></td>
+      <td class="request-action"></td>
       <td></td>
       <td></td>
     </tr>
@@ -161,7 +161,7 @@
     <tr>
       <td><a href="" class="block-toggle">I</a></td>
       <td></td>
-      <td></td>
+      <td class="request-action"></td>
       <td></td>
       <td></td>
     </tr>
@@ -189,22 +189,25 @@
   <div id="table-filter">
     Display options:
     <label class="block">
-      <input id="display-block" type="checkbox" checked><span>Blocked</span>
-   </label>
-   <label class="ignore">
-      <input id="display-ignore" type="checkbox" checked><span>Ignored</span>
+      <input data-filter-toggle="blocked" type="checkbox" checked><span>Blocked</span>
+    </label>
+    <label class="ignore">
+      <input data-filter-toggle="ignored" type="checkbox" checked><span>Ignored</span>
+    </label>
+    <label class="ignore">
+      <input data-filter-toggle="ignoredFirstParty" type="checkbox" checked><span>Ignored (1P)</span>
     </label>
     <label class="redirect">
-      <input id="display-redirect" type="checkbox" checked><span>Redirected</span>
+      <input data-filter-toggle="redirected" type="checkbox" checked><span>Redirected</span>
     </label>
     <label class="cookie-tracker">
-      <input id="display-cookie-tracker" type="checkbox" checked><span>HTTP Cookies</span>
+      <input data-filter-toggle="cookieHTTP" type="checkbox" checked><span>HTTP Cookies</span>
     </label>
     <label class="jscookie">
-      <input id="display-jscookie" type="checkbox" checked><span>JS Cookies</span>
+      <input data-filter-toggle="cookieJS" type="checkbox" checked><span>JS Cookies</span>
     </label>
     <label class="canvas">
-      <input id="display-canvas" type="checkbox" checked><span>Canvas API</span>
+      <input data-filter-toggle="apiCanvas" type="checkbox" checked><span>Canvas API</span>
     </label>
     <label for="search-box">Filter: </label>
     <input type="text" name="search-box" id="search-box" />

--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -206,6 +206,8 @@
     <label class="canvas">
       <input id="display-canvas" type="checkbox" checked><span>Canvas API</span>
     </label>
+    <label for="search-box">Filter: </label>
+    <input type="text" name="search-box" id="search-box" />
   </div>
   </div>
   <table>

--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -70,7 +70,7 @@
       background-color: #CACACA;
     }
 
-    .cookie {
+    .cookie-tracker {
       background-color: #9CB8FF
     }
 
@@ -197,7 +197,7 @@
     <label class="redirect">
       <input id="display-redirect" type="checkbox" checked><span>Redirected</span>
     </label>
-    <label class="cookie">
+    <label class="cookie-tracker">
       <input id="display-cookie-tracker" type="checkbox" checked><span>HTTP Cookies</span>
     </label>
     <label class="jscookie">

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -185,7 +185,8 @@ const panelConfig = {
         cookieHTTP: true,
         cookieJS: true,
         apiCanvas: true,
-        noneRequest: true
+        noneRequest: true,
+        ignoreUser: true
     },
     rowFilter: ''
 }
@@ -218,6 +219,8 @@ function shouldShowRow (row) {
         return panelConfig.rowVisibility.apiCanvas
     case 'none':
         return panelConfig.rowVisibility.noneRequest
+    case 'ignore-user':
+        return panelConfig.rowVisibility.ignoreUser
     }
     // always show if we don't have an appropriate toggle
     return true

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -279,7 +279,7 @@ tdsOption.addEventListener('change', (e) => {
 
 displayFilters.forEach((input) => {
     input.addEventListener('change', () => {
-        document.querySelectorAll('tr').forEach(setRowVisible)
+        document.querySelectorAll('tbody > tr').forEach(setRowVisible)
     })
 })
 

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -219,6 +219,8 @@ function shouldShowRow (row) {
     case 'none':
         return panelConfig.rowVisibility.noneRequest
     }
+    // always show if we don't have an appropriate toggle
+    return true
 }
 
 function setRowVisible (row) {

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -184,7 +184,8 @@ const panelConfig = {
         redirected: true,
         cookieHTTP: true,
         cookieJS: true,
-        apiCanvas: true
+        apiCanvas: true,
+        noneRequest: true
     },
     rowFilter: ''
 }
@@ -215,6 +216,8 @@ function shouldShowRow (row) {
         return panelConfig.rowVisibility.cookieJS
     case 'canvas':
         return panelConfig.rowVisibility.apiCanvas
+    case 'none':
+        return panelConfig.rowVisibility.noneRequest
     }
 }
 

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -316,6 +316,14 @@ tdsOption.addEventListener('change', (e) => {
 const displayFilters = document.querySelector('#table-filter').querySelectorAll('input')
 
 displayFilters.forEach((input) => {
+    // initialise filters to default values
+    if (input.id === 'search-box') {
+        input.value = panelConfig.rowFilter
+    } else {
+        input.checked = panelConfig.rowVisibility[input.dataset.filterToggle]
+    }
+
+    // register listeners to update row visibility when filters are changed
     input.addEventListener('change', () => {
         if (input.id === 'search-box') {
             panelConfig.rowFilter = input.value

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -172,13 +172,18 @@ function appendCallStack (cell, stack) {
     }
 }
 
-function shouldShowRow (className) {
+function shouldShowRow (row) {
+    const className = row.classList[0]
     const filter = document.getElementById(`display-${className}`)
-    return !filter || filter.checked
+    const searchBoxValue = document.getElementById('search-box').value
+    // empty search box is considered to be no filter
+    // search box matches on the URL of the request
+    const searchFilter = searchBoxValue === '' || row.cells[1].textContent.match(searchBoxValue)
+    return searchFilter && (!filter || filter.checked)
 }
 
 function setRowVisible (row) {
-    row.hidden = !shouldShowRow(row.classList[0])
+    row.hidden = !shouldShowRow(row)
 }
 
 port.onMessage.addListener((message) => {

--- a/shared/js/devtools/panel.es6.js
+++ b/shared/js/devtools/panel.es6.js
@@ -212,6 +212,7 @@ function shouldShowRow (row) {
     case 'redirect':
         return panelConfig.rowVisibility.redirected
     case 'cookie-tracker':
+    case 'set-cookie-tracker':
         return panelConfig.rowVisibility.cookieHTTP
     case 'jscookie':
         return panelConfig.rowVisibility.cookieJS


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

https://app.asana.com/0/312629933896096/1202714468322468/f

This:
- adds support for filtering requests on URL
- adds support for hiding _only_ 1P requests
- fixes cookie rows not being hidden by toggle

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

Test search filter:

1. Open http://privacy-test-pages.glitch.me/privacy-protections/request-blocking/ ("the site")
2. Open devtools panel, set target to the opened site
3. On the site, click "Start the test"
4. Switch back to the panel
5. A bunch of requests should show (about 19)
6. In the filter box, type "img" and hit enter
7. One request should now show
8. Empty the filter box and hit enter
9. All previous requests should now show

Test 1P filter:

1. Open https://www.tumblr.com/explore/trending
2. Open the devpanel and set target to opened site (note, you may need to disable `contentBlocking`, reload, and scroll a bit to get appropriate requests)
3. You should see some 1P requests and some blocked requests
4. On one of the blocked requests (e.g., `id5-sync.com/g/v2/102.json`) hit the "I" to the left of the request and hit "Reload page" at the top
5. You should now see some ignored 1P requests and ignored 3P requests (and some blocked requests)
6. Untick the "Ignored (1P)" filter
7. You should see some ignored and blocked requests, but all the 1P ignored requests should be hidden
8. Tick the "Ignored (1P)" filter - now all the ignored requests should be visible again
9. Untick the "Ignored" filter
10. No ignored requests should be visible
11. Untick the "Ignored (1P)" filter
12. Nothing should change
13. Tick the "Ignored" filter
14. Now only 1P ignored requests should show out of all the ignores

Test HTTP Cookie filter:

1. Navigate to http://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/ (the site)
2. Open devpanel and set target to the site
3. Go back to the site and click "Store data"
4. In the devpanel you should see some requests with action `🍪 block`
5. Untick the HTTP Cookies filter
6. The `🍪 block` requests should vanish
7. Tick the HTTP Cookies filter
8. The `🍪 block` requests should reappear

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
