### PR TITLE
Fix failing privacy grade integration test case

### DIFF
--- a/integration-test/background/grades.js
+++ b/integration-test/background/grades.js
@@ -4,7 +4,7 @@ const pageWait = require('../helpers/pageWait')
 
 const tests = [
     { url: 'duckduckgo.com', siteGrade: 'A', enhancedGrade: 'A' },
-    { url: 'www.independent.co.uk', siteGrade: ['D', 'D-'], enhancedGrade: 'B+' },
+    { url: 'www.independent.co.uk', siteGrade: ['D', 'D-'], enhancedGrade: 'B' },
     { url: 'google.com', siteGrade: 'D', enhancedGrade: 'D' },
     { url: 'reddit.com', siteGrade: ['D', 'D-', 'C'], enhancedGrade: 'B' },
     { url: 'facebook.com', siteGrade: ['D', 'C+'], enhancedGrade: 'C+' },


### PR DESCRIPTION
The privacy grade integration test for independent.co.uk was failing
since the enhanced privacy grade has changed. Adjust the expected
privacy grade to get the test passing again.

**Reviewer:** @shakyShane 

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
