### PR TITLE
Bump autofill to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#4.7.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.0",
@@ -17366,7 +17366,7 @@
         },
         "@duckduckgo/autofill": {
             "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#403a731aa5eee65b7ca833bfad5890360e0dfcd7",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#4.7.0",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#5.0.1",
             "requires": {
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
             }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "yargs": "^17.5.1"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#4.7.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.1.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.0",


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana:** https://app.asana.com/0/312629933896096/1202778915747370/f

## Description:
Bump the autofill version to 5.0.1. No visible changes in the extensions. Most changes are for other platforms and there are also a bunch of minor improvements to form detection accuracy.


## Steps to test this PR:
The changes have been tested extensively on other platforms and smoke tested on extensions as well. Email autofill testing steps are in https://app.asana.com/0/1198964220583541/1200583647142330/f.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

