### PR TITLE
Remove CheckboxPlugin interface from Facebook surrogate

### DIFF
--- a/integration-test/data/api_schemas/facebook-sdk.json
+++ b/integration-test/data/api_schemas/facebook-sdk.json
@@ -366,19 +366,6 @@
             },
             "writable": "true"
         },
-        "CheckboxPlugin": {
-            "configurable": "true",
-            "enumerable": "true",
-            "value": {
-                "confirm": {
-                    "configurable": "true",
-                    "enumerable": "true",
-                    "value": "function(0)",
-                    "writable": "true"
-                }
-            },
-            "writable": "true"
-        },
         "Event": {
             "configurable": "true",
             "enumerable": "true",

--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -155,9 +155,6 @@
                 logEvent: function (a, b, c) {},
                 logPageView: function () {}
             },
-            CheckboxPlugin: {
-                confirm: function () {}
-            },
             Event: {
                 subscribe: function (event, callback) {
                     if (event === 'xfbml.render') {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @ladamski, @kzar or @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

It seems like this API has been removed and I can't see it in the documentation: https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin/

🛑  This is currently permanently failing so breaking ci.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
