### PR TITLE
Remove parameterName and parameterValue from ad-attribution feature to simplify code

### DIFF
--- a/shared/data/bundled/extension-config.json
+++ b/shared/data/bundled/extension-config.json
@@ -1,6 +1,6 @@
 {
     "readme": "https://github.com/duckduckgo/privacy-configuration",
-    "version": 1661422548137,
+    "version": 1663586301491,
     "features": {
         "adClickAttribution": {
             "readme": "https://help.duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/#3rd-party-tracker-loading-protection",
@@ -10,40 +10,31 @@
                 "linkFormats": [
                     {
                         "url": "duckduckgo.com/y.js",
-                        "parameterName": "u3",
                         "adDomainParameterName": "ad_domain",
                         "desc": "SERP Ads"
                     },
                     {
                         "url": "www.search-company.site/y.js",
-                        "parameterName": "u3",
                         "adDomainParameterName": "ad_domain",
                         "desc": "Test Domain"
                     },
                     {
                         "url": "www.search-company.example/y.js",
-                        "parameterName": "u3",
                         "adDomainParameterName": "ad_domain",
                         "desc": "Test Domain"
                     },
                     {
                         "url": "links.duckduckgo.com/m.js",
-                        "parameterName": "dsl",
-                        "parameterValue": "1",
                         "adDomainParameterName": "ad_domain",
                         "desc": "Shopping Ads"
                     },
                     {
                         "url": "www.search-company.site/m.js",
-                        "parameterName": "dsl",
-                        "parameterValue": "1",
                         "adDomainParameterName": "ad_domain",
                         "desc": "Test Domain"
                     },
                     {
                         "url": "www.search-company.example/m.js",
-                        "parameterName": "dsl",
-                        "parameterValue": "1",
                         "adDomainParameterName": "ad_domain",
                         "desc": "Test Domain"
                     }
@@ -390,10 +381,32 @@
             "state": "enabled",
             "settings": {
                 "allowlistedTrackers": {
+                    "3lift.com": {
+                        "rules": [
+                            {
+                                "rule": "tlx.3lift.com/header/auction",
+                                "domains": [
+                                    "aternos.org"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/328"
+                            }
+                        ]
+                    },
                     "4dex.io": {
                         "rules": [
                             {
                                 "rule": "mp.4dex.io/prebid",
+                                "domains": [
+                                    "aternos.org"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/328"
+                            }
+                        ]
+                    },
+                    "a-mo.net": {
+                        "rules": [
+                            {
+                                "rule": "prebid.a-mo.net/a/c",
                                 "domains": [
                                     "aternos.org"
                                 ],
@@ -576,6 +589,17 @@
                             }
                         ]
                     },
+                    "computerworld.com": {
+                        "rules": [
+                            {
+                                "rule": "cmpv2.computerworld.com/",
+                                "domains": [
+                                    "computerworld.com"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/344"
+                            }
+                        ]
+                    },
                     "criteo.com": {
                         "rules": [
                             {
@@ -613,6 +637,28 @@
                                     "wsj.com"
                                 ],
                                 "reason": "Opinion section article elements do not render. Note that Firefox Enhanced Tracking Protection may prevent mitigation from succeeding on Firefox."
+                            }
+                        ]
+                    },
+                    "demdex.net": {
+                        "rules": [
+                            {
+                                "rule": "dpm.demdex.net/id",
+                                "domains": [
+                                    "homedepot.com"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/393"
+                            }
+                        ]
+                    },
+                    "derstandard.de": {
+                        "rules": [
+                            {
+                                "rule": "spcmp.r53.derstandard.de/",
+                                "domains": [
+                                    "derstandard.de"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/344"
                             }
                         ]
                     },
@@ -703,6 +749,20 @@
                     },
                     "gemius.pl": {
                         "rules": [
+                            {
+                                "rule": "gapl.hit.gemius.pl/gplayer.js",
+                                "domains": [
+                                    "tvp.pl"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/376"
+                            },
+                            {
+                                "rule": "pro.hit.gemius.pl/gstream.js",
+                                "domains": [
+                                    "tvp.pl"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/376"
+                            },
                             {
                                 "rule": "wp.hit.gemius.pl/xgemius.js",
                                 "domains": [
@@ -809,6 +869,18 @@
                             }
                         ]
                     },
+                    "klaviyo.com": {
+                        "rules": [
+                            {
+                                "rule": "www.klaviyo.com/media/js/public/klaviyo_subscribe.js",
+                                "domains": [
+                                    "fearofgod.com",
+                                    "shopyalehome.com"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/362"
+                            }
+                        ]
+                    },
                     "liveperson.net": {
                         "rules": [
                             {
@@ -865,6 +937,17 @@
                             }
                         ]
                     },
+                    "omnitagjs.com": {
+                        "rules": [
+                            {
+                                "rule": "hb-api.omnitagjs.com/hb-api/prebid/v1",
+                                "domains": [
+                                    "aternos.org"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/328"
+                            }
+                        ]
+                    },
                     "openx.net": {
                         "rules": [
                             {
@@ -914,6 +997,17 @@
                                     "primaryarms.com"
                                 ],
                                 "reason": "Images in the large scrolling image banner on main page do not render.,Note that this CNAMEs to marvel-b4-cdn.bc0a.com at time of mitigation."
+                            }
+                        ]
+                    },
+                    "privacy-mgmt.com": {
+                        "rules": [
+                            {
+                                "rule": "privacy-mgmt.com/",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/344"
                             }
                         ]
                     },
@@ -1016,13 +1110,20 @@
                                     "<all>"
                                 ],
                                 "reason": "https://github.com/duckduckgo/privacy-configuration/issues/334"
+                            },
+                            {
+                                "rule": "vendors.privacymanager.io/vendor-list.json",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/334"
                             }
                         ]
                     },
                     "pubmatic.com": {
                         "rules": [
                             {
-                                "rule": "hpopenbid.pubmatic.com/translator",
+                                "rule": "hbopenbid.pubmatic.com/translator",
                                 "domains": [
                                     "aternos.org"
                                 ],
@@ -1102,6 +1203,17 @@
                             }
                         ]
                     },
+                    "spiegel.de": {
+                        "rules": [
+                            {
+                                "rule": "sp-spiegel-de.spiegel.de/",
+                                "domains": [
+                                    "spiegel.de"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/344"
+                            }
+                        ]
+                    },
                     "theplatform.com": {
                         "rules": [
                             {
@@ -1146,11 +1258,25 @@
                     "yandex.ru": {
                         "rules": [
                             {
-                                "rule": "yandex.ru",
+                                "rule": "frontend.vh.yandex.ru/player/",
                                 "domains": [
-                                    "tvrain.ru"
+                                    "<all>"
                                 ],
-                                "reason": "Adwall renders over video and video does not play."
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"
+                            },
+                            {
+                                "rule": "strm.yandex.ru/get/",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"
+                            },
+                            {
+                                "rule": "strm.yandex.ru/vh-special-converted/vod-content/",
+                                "domains": [
+                                    "<all>"
+                                ],
+                                "reason": "https://github.com/duckduckgo/privacy-configuration/issues/366"
                             }
                         ]
                     },

--- a/shared/data/etags.json
+++ b/shared/data/etags.json
@@ -1,1 +1,1 @@
-{"config-etag":"W/\"e963bd2f7e43493868dc8197b13fc4d0\""}
+{"config-etag":"W/\"9ffe4594bd66c680da61ad9ac47be5fa\""}

--- a/shared/js/background/classes/ad-click-attribution-policy.js
+++ b/shared/js/background/classes/ad-click-attribution-policy.js
@@ -3,8 +3,6 @@ const { getFeatureSettings, getBaseDomain } = require('../utils.es6')
 /**
  * @typedef AdClickAttributionLinkFormat
  * @property {string} url
- * @property {string} [parameterName]
- * @property {string|number} [parameterValue]
  * @property {string} [adDomainParameterName]
  **/
 
@@ -41,13 +39,6 @@ export class AdClickAttributionPolicy {
 
         for (const linkFormat of this.linkFormats) {
             if (hostnameAndPath === linkFormat.url) {
-                if (linkFormat.parameterName) {
-                    const parameterValue = resourceURL.searchParams.get(linkFormat.parameterName)
-                    if (parameterValue !== null && (!linkFormat.parameterValue || parameterValue === linkFormat.parameterValue)) {
-                        return linkFormat
-                    }
-                }
-
                 if (linkFormat.adDomainParameterName) {
                     const parameterDomain = resourceURL.searchParams.get(linkFormat.adDomainParameterName)
                     if (parameterDomain !== null) {


### PR DESCRIPTION
**Reviewer:** @englehardt 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Marking draft as CI should fail if working correcly; testCases still need amending.

This is to simplify the parsing logic as we already verify an ad click based on the adDomainParameterName parameter name in the link click.

https://app.asana.com/0/0/1202808108652811/f


Corresponding config change should probably land first so we can just run bundle-config instead of hand hacking it: https://github.com/duckduckgo/privacy-configuration/pull/345


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
