### PR TITLE
Allow body to scroll vertically to reach email alias button

### DIFF
--- a/shared/js/ui/views/email-alias.es6.js
+++ b/shared/js/ui/views/email-alias.es6.js
@@ -17,7 +17,8 @@ function EmailAliasView (ops) {
 EmailAliasView.prototype = window.$.extend({},
     Parent.prototype,
     {
-        _copyAliasToClipboard: function () {
+        _copyAliasToClipboard: function (e) {
+            e.preventDefault()
             const alias = this.model.userData.nextAlias
             navigator.clipboard.writeText(formatAddress(alias))
             this.$el.addClass('show-copied-label')

--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -9,6 +9,7 @@ html, body {
 
 body {
     overflow: hidden;
+    overflow-y: scroll;
 }
 
 #popup-container {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @GioSensation

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

Task: https://app.asana.com/0/0/1202815012139664/f

Update to allow popover to scroll vertically, which will allow access to the email alias button when both it and top blocked are disabled.

## Steps to test this PR:
1. Load extension 
1. Make sure to browse until "Top Tracking Offenders" button shows (if not already)
1. Log into email protection account
1. "Create new Duck Address" button is below the fold, but can now be scrolled to

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
