### PR TITLE
Enable autofill when protections are disabled

### DIFF
--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -371,21 +371,9 @@ browser.runtime.onMessage.addListener((req, sender) => {
             return
         }
 
-        // FIXME - Autofill code expects the response, even if protections are
-        //         disabled, but content-scope code expects response to be
-        //         falsey when protections are disabled. Also, the autofill code
-        //         does not check if the site is allowlisted before enabling
-        //         autofill.
-        //           Once the content-scope and autofill code check for
-        //         `response.site.allowlisted === true`, this code path can be
-        //         removed and argumentsObject can be returned consistently.
-        if (argumentsObject.site.allowlisted) {
-            if (req.messageType === 'registeredContentScript') {
-                return
-            }
-            if (req.registeredTempAutofillContentScript) {
-                return Promise.resolve({ site: { allowlisted: true, enabledFeatures: [] } })
-            }
+        // Disable content scripts when site protections are disabled
+        if (argumentsObject.site.allowlisted && req.messageType === 'registeredContentScript') {
+            return
         }
 
         return Promise.resolve(argumentsObject)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

Task: https://app.asana.com/0/1162895505193104/1202817610595239/f

Allow autofill to run when site is allowlisted

## Steps to test this PR:
1. Load this extension branch in Firefox and enable Email Protection
1. Go to https://duckduckgo.com/newsletter
1. Confirm autofill is showing and working, confirm right click context menu is showing and working
1. Disable tracking protections, page refreshes
1. Confirm autofill is showing and working, confirm right click context menu is showing and working

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
