### PR TITLE
Inform website that Facebook login failed when user rejects it

### DIFF
--- a/shared/data/web_accessible_resources/fb-sdk.js
+++ b/shared/data/web_accessible_resources/fb-sdk.js
@@ -107,6 +107,11 @@
             runFacebookLogin()
         }
     })
+    window.addEventListener('ddg-ctp-cancel-modal', event => {
+        if (event.detail.entity === 'Facebook') {
+            fbLogin.callback({ })
+        }
+    })
 
     function init () {
         if (window.fbAsyncInit) {

--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -898,6 +898,16 @@
         )
     }
 
+    function cancelModal (entity) {
+        window.dispatchEvent(
+            createCustomEvent('ddg-ctp-cancel-modal', {
+                detail: {
+                    entity
+                }
+            })
+        )
+    }
+
     /*********************************************************
      *  Widget building blocks
      *********************************************************/
@@ -1072,6 +1082,7 @@
         rejectButton.style.cssText += styles.modalButton + 'float: right;'
         rejectButton.addEventListener('click', function cancelLogin () {
             document.body.removeChild(modalContainer)
+            cancelModal(entity)
         })
 
         buttonRow.appendChild(allowButton)


### PR DESCRIPTION
We warn the user about the privacy implications before they click to
login a website via Facebook. The modal has a "Go back" button, but so
far the website wasn't informed that the login process was
aborted. With this change, we're performing the proper callback and
since the `authResponse` property isn't provided, the website knows
the login wasn't completed[1].

1 - https://developers.facebook.com/docs/reference/javascript/FB.login/v14.0

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
1. Navigate to https://www.duolingo.com/?isLoggingIn=true
2. Click "I already have an account"
3. Select "Facebook"
4. Click "Go back"
5. Ensure the "Facebook" button works when clicked again (and does not display a spinner animation forever).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
