### PR TITLE
Add debugging to menu if built locally

### DIFF
--- a/shared/js/ui/views/hamburger-menu.es6.js
+++ b/shared/js/ui/views/hamburger-menu.es6.js
@@ -8,6 +8,7 @@ function HamburgerMenu (ops) {
     this.template = ops.template
     this.pageView = ops.pageView
     Parent.call(this, ops)
+    this.devModePromise = browserUIWrapper.sendMessage('getDevMode')
 
     this._setup()
 }
@@ -34,9 +35,19 @@ HamburgerMenu.prototype = window.$.extend({},
                 [this.model.store.subscribe, 'change:site', this._handleSiteUpdate],
                 [this.$debuggerpanellink, 'click', this._handleDebuggerClick]
             ])
+            this.devModePromise.then((devMode) => {
+                if (devMode) {
+                    this.showDebugerPanel()
+                }
+            })
+
             if (IS_BETA) {
-                this.$('#debugger-panel').removeClass('is-hidden')
+                this.showDebugerPanel()
             }
+        },
+
+        showDebugerPanel: function () {
+            this.$('#debugger-panel').removeClass('is-hidden')
         },
 
         _handleAction: function (notification) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Adds the debugging menu when built locally; this works already for Chrome as we match against known store id's but the randomised IDs makes this impossible in Firefox.

<img width="368" alt="image" src="https://user-images.githubusercontent.com/338988/186455081-9e964f2f-3041-4739-84bf-7181b78dd4db.png">

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
