### PR TITLE
WIP - Get script injection working for Chrome MV3 builds of the extension

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -2,6 +2,8 @@
     "spec_dir": "integration-test",
     "spec_files": [
         "background/onboarding.js",
-        "background/request-blocking.js"
+        "background/request-blocking.js",
+        "background/test-fingerprint.js",
+        "background/storage.js"
     ]
 }

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -25,9 +25,12 @@ const setup = async (ops) => {
         `--user-data-dir=${dataDir}`
     ]
 
+    const manifestVersion =
+        process.env.npm_lifecycle_event === 'test-int-mv3' ? 3 : 2
+
     if (loadExtension) {
         let extensionPath = 'build/chrome/dev'
-        if (process.env.npm_lifecycle_event === 'test-int-mv3') {
+        if (manifestVersion === 3) {
             extensionPath = extensionPath.replace('chrome', 'chrome-mv3')
         }
         args.push('--disable-extensions-except=' + extensionPath)
@@ -90,7 +93,7 @@ const setup = async (ops) => {
         spawnSync('rm', ['-rf', dataDir])
     }
 
-    return { browser, bgPage, requests, teardown }
+    return { browser, bgPage, requests, teardown, manifestVersion }
 }
 
 module.exports = {

--- a/shared/js/background/background.es6.js
+++ b/shared/js/background/background.es6.js
@@ -20,6 +20,7 @@ require('./events.es6')
 const settings = require('./settings.es6')
 const { onStartup } = require('./startup.es6')
 require('./declarative-net-request')
+require('./script-injection')
 
 settings.ready().then(() => {
     onStartup()

--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -57,6 +57,9 @@ class Tab {
 
         /** @type {null | import('./ad-click-attribution-policy').AdClick} */
         this.adClick = null
+
+        /** @type {null | import('../events/referrer-trimming').Referrer} */
+        this.referrer = null
     }
 
     /**

--- a/shared/js/background/devtools.es6.js
+++ b/shared/js/background/devtools.es6.js
@@ -14,7 +14,7 @@ const { removeBroken } = require('./utils.es6')
 //       event will fire again.
 const ports = new Map()
 
-function init () {
+export function init () {
     browser.runtime.onConnect.addListener(connected)
 }
 
@@ -106,18 +106,12 @@ function connected (port) {
     })
 }
 
-function postMessage (tabId, action, message) {
+export function postMessage (tabId, action, message) {
     if (ports.has(tabId)) {
         ports.get(tabId).postMessage(JSON.stringify({ tabId, action, message }))
     }
 }
 
-function isActive (tabId) {
+export function isActive (tabId) {
     return ports.has(tabId)
-}
-
-module.exports = {
-    init,
-    postMessage,
-    isActive
 }

--- a/shared/js/background/events/referrer-trimming.js
+++ b/shared/js/background/events/referrer-trimming.js
@@ -4,17 +4,23 @@ const utils = require('../utils.es6')
 const browserName = utils.getBrowserName()
 
 /**
+ * @typedef Referrer
+ * @property {string} site
+ *   The referrer URL.
+ * @property {string} referrerHost
+ *   The referrer host.
+ * @property {string} referrer
+ *   The truncated referrer.
+ */
+
+/**
  * @param {{tabId: number, url: string, requestHeaders: Array<{name: string, value:string}>}} e
  *
  * @returns {{requestHeaders: Array<{name: string, value:string}>} | { redirectUrl: URL } | undefined}
  */
 module.exports = function limitReferrerData (e) {
-    let referrer = e.requestHeaders.find(header => header.name.toLowerCase() === 'referer')
-    if (referrer) {
-        referrer = referrer.value
-    } else {
-        return
-    }
+    const referrer = e.requestHeaders.find(header => header.name.toLowerCase() === 'referer')?.value
+    if (!referrer) return
 
     const tab = tabManager.get({ tabId: e.tabId })
 

--- a/shared/js/background/helpers/arguments-object.js
+++ b/shared/js/background/helpers/arguments-object.js
@@ -3,7 +3,7 @@ const utils = require('../utils.es6')
 const tabManager = require('../tab-manager.es6')
 const trackerutils = require('../tracker-utils')
 const settings = require('../settings.es6')
-const devtools = require('../devtools.es6')
+const { isActive } = require('../devtools.es6')
 const constants = require('../../../data/constants')
 
 function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
@@ -60,7 +60,7 @@ function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
     }
     return {
         featureSettings,
-        debug: devtools.isActive(tabId),
+        debug: isActive(tabId),
         cookie,
         globalPrivacyControlValue: settings.getSetting('GPC'),
         stringExemptionLists: utils.getBrokenScriptLists(),

--- a/shared/js/background/script-injection.js
+++ b/shared/js/background/script-injection.js
@@ -1,0 +1,45 @@
+const utils = require('./utils.es6')
+const browserWrapper = require('./wrapper.es6')
+const getArgumentsObject = require('./helpers/arguments-object')
+const {
+    isolatedWorld,
+    mainWorld
+} = require('@duckduckgo/content-scope-scripts/build/chrome-mv3/inject')
+
+/**
+ * Inject the content-scope-scripts protections into a page.
+ * Note: This is only intended for use in MV3, since targetting execution world
+ *       is not supported in MV2.
+ * @param {import('webextension-polyfill').WebNavigation.OnCommittedDetailsType} details
+ */
+export async function injectContentScopeScripts ({ url, frameId, tabId }) {
+    const argumentsObject = getArgumentsObject(
+        tabId,
+        { frameId, tab: { id: tabId }, url },
+        url,
+        await utils.getSessionKey()
+    )
+
+    // This should not be possible, since the caller has already checked these.
+    if (!argumentsObject ||
+        argumentsObject.site.isBroken ||
+        argumentsObject.site.allowlisted ||
+        argumentsObject.site.specialDomainName) {
+        return
+    }
+
+    browserWrapper.executeScript({
+        target: { tabId, frameIds: [frameId] },
+        world: 'ISOLATED',
+        func: isolatedWorld,
+        injectImmediately: true,
+        args: [argumentsObject]
+    })
+    browserWrapper.executeScript({
+        target: { tabId, frameIds: [frameId] },
+        world: 'MAIN',
+        func: mainWorld,
+        injectImmediately: true,
+        args: [argumentsObject]
+    })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,6 @@
       "shared/js/background/debug.es6.js",
       "shared/js/background/events.es6.js",
       "shared/js/background/events/3p-tracking-cookie-blocking.js",
-      "shared/js/background/events/referrer-trimming.js",
-      "shared/js/background/helpers/arguments-object.js",
       "shared/js/background/message-handlers.js",
       "shared/js/background/onboarding.es6.js",
       "shared/js/background/startup.es6.js",


### PR DESCRIPTION
Chrome Manifest V3 introduces the new scripting API[1] that can inject
scripts directly into the "main world" of a website. Along with that,
Manifest V3 prevents the old pattern of injecting a script element
into the DOM. Adjust to those changes here, to get our injected
protections working again.

1 - https://developer.chrome.com/docs/extensions/reference/scripting

## Steps to test this PR:
1. Navigate to the [storage blocking test page](https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/).
2. Click "Store data", then "Retrieve data", expand the results, and note which are blocked.
3. Build MV3 extension: `npm install && npm run dev-chrome-mv3`
4. Install that in Chrome.
5. Load the test page again and retry the test in step 2.
6. Ensure that more third party cookies are blocked.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
