### PR TITLE
Correct some type checking issues with referrer trimming

### DIFF
--- a/shared/js/background/classes/tab.es6.js
+++ b/shared/js/background/classes/tab.es6.js
@@ -57,6 +57,9 @@ class Tab {
 
         /** @type {null | import('./ad-click-attribution-policy').AdClick} */
         this.adClick = null
+
+        /** @type {null | import('../events/referrer-trimming').Referrer} */
+        this.referrer = null
     }
 
     /**

--- a/shared/js/background/devtools.es6.js
+++ b/shared/js/background/devtools.es6.js
@@ -14,7 +14,7 @@ const { removeBroken } = require('./utils.es6')
 //       event will fire again.
 const ports = new Map()
 
-function init () {
+export function init () {
     browser.runtime.onConnect.addListener(connected)
 }
 
@@ -106,18 +106,12 @@ function connected (port) {
     })
 }
 
-function postMessage (tabId, action, message) {
+export function postMessage (tabId, action, message) {
     if (ports.has(tabId)) {
         ports.get(tabId).postMessage(JSON.stringify({ tabId, action, message }))
     }
 }
 
-function isActive (tabId) {
+export function isActive (tabId) {
     return ports.has(tabId)
-}
-
-module.exports = {
-    init,
-    postMessage,
-    isActive
 }

--- a/shared/js/background/events/referrer-trimming.js
+++ b/shared/js/background/events/referrer-trimming.js
@@ -4,17 +4,23 @@ const utils = require('../utils.es6')
 const browserName = utils.getBrowserName()
 
 /**
+ * @typedef Referrer
+ * @property {string} site
+ *   The referrer URL.
+ * @property {string} referrerHost
+ *   The referrer host.
+ * @property {string} referrer
+ *   The truncated referrer.
+ */
+
+/**
  * @param {{tabId: number, url: string, requestHeaders: Array<{name: string, value:string}>}} e
  *
  * @returns {{requestHeaders: Array<{name: string, value:string}>} | { redirectUrl: URL } | undefined}
  */
 module.exports = function limitReferrerData (e) {
-    let referrer = e.requestHeaders.find(header => header.name.toLowerCase() === 'referer')
-    if (referrer) {
-        referrer = referrer.value
-    } else {
-        return
-    }
+    const referrer = e.requestHeaders.find(header => header.name.toLowerCase() === 'referer')?.value
+    if (!referrer) return
 
     const tab = tabManager.get({ tabId: e.tabId })
 

--- a/shared/js/background/helpers/arguments-object.js
+++ b/shared/js/background/helpers/arguments-object.js
@@ -3,7 +3,7 @@ const utils = require('../utils.es6')
 const tabManager = require('../tab-manager.es6')
 const trackerutils = require('../tracker-utils')
 const settings = require('../settings.es6')
-const devtools = require('../devtools.es6')
+const { isActive } = require('../devtools.es6')
 const constants = require('../../../data/constants')
 
 function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
@@ -60,7 +60,7 @@ function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
     }
     return {
         featureSettings,
-        debug: devtools.isActive(tabId),
+        debug: isActive(tabId),
         cookie,
         globalPrivacyControlValue: settings.getSetting('GPC'),
         stringExemptionLists: utils.getBrokenScriptLists(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,6 @@
       "shared/js/background/debug.es6.js",
       "shared/js/background/events.es6.js",
       "shared/js/background/events/3p-tracking-cookie-blocking.js",
-      "shared/js/background/events/referrer-trimming.js",
-      "shared/js/background/helpers/arguments-object.js",
       "shared/js/background/message-handlers.js",
       "shared/js/background/onboarding.es6.js",
       "shared/js/background/startup.es6.js",


### PR DESCRIPTION
The argumentsObject and referrer trimming code were failing TypeScript
linting, so linting was disabled for those files. Let's fix the
problems and enable TypeScript linting again for them.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
