### PR TITLE
Add Chrome MV3 support for "surrogate script" redirections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.6.0",
-                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.1.4",
+                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests",
@@ -1854,7 +1854,7 @@
         },
         "node_modules/@duckduckgo/ddg2dnr": {
             "version": "0.1.4",
-            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#1ffb628d594cbac8d063840deee1999a63b093f0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#51536e6e1676475e2088f23f65f0452bfa714169",
             "integrity": "sha512-biN5Dzow+37DxhVuCMf5bO76WMrXXha7Pgc1J/TxezJ6wUl/3R69r8j+0AC4bP+4qW+XcqsN2cQqMz34im4CSQ==",
             "license": "Apache-2.0"
         },
@@ -15978,9 +15978,9 @@
             }
         },
         "@duckduckgo/ddg2dnr": {
-            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#1ffb628d594cbac8d063840deee1999a63b093f0",
+            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#51536e6e1676475e2088f23f65f0452bfa714169",
             "integrity": "sha512-biN5Dzow+37DxhVuCMf5bO76WMrXXha7Pgc1J/TxezJ6wUl/3R69r8j+0AC4bP+4qW+XcqsN2cQqMz34im4CSQ==",
-            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.1.4"
+            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.2.0"
         },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.6.0",
-        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.1.4",
+        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.0",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
       "shared/js/background/broken-site-report.js",
       "shared/js/background/csp-blocking.es6.js",
       "shared/js/background/debug.es6.js",
+      "shared/js/background/declarative-net-request.js",
       "shared/js/background/events.es6.js",
       "shared/js/background/events/3p-tracking-cookie-blocking.js",
       "shared/js/background/message-handlers.js",

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -4,6 +4,7 @@ import * as tds from '../data/tds.json'
 import * as browserWrapper from '../../shared/js/background/wrapper.es6'
 import * as testConfig from '../data/extension-config.json'
 import * as tdsStorageStub from '../helpers/tds.es6'
+import startup from '../../shared/js/background/startup.es6'
 import settings from '../../shared/js/background/settings.es6'
 
 const TEST_ETAGS = ['flib', 'flob', 'cabbage']
@@ -27,12 +28,44 @@ const expectedRuleIdsByConfigName = {
 }
 
 const expectedLookupByConfigName = {
-    tds: [
-        undefined, undefined, 'facebook.com,facebook.net',
-        'google-analytics.com', 'google-analytics.com', 'google-analytics.com',
-        'google-analytics.com', 'google-analytics.com', 'google-analytics.com',
-        'google-analytics.com', 'yahoo.com'
-    ],
+    tds: {
+        2: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['facebook.com', 'facebook.net']
+        },
+        3: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        4: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        5: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        6: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        7: {
+            type: 'surrogateScript',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        8: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        9: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['google-analytics.com']
+        },
+        10: {
+            type: 'trackerBlocking',
+            possibleTrackerDomains: ['yahoo.com']
+        }
+    },
     config: {
         10002: {
             type: 'trackerAllowlist',
@@ -127,6 +160,10 @@ describe('declarativeNetRequest', () => {
         dynamicRulesByRuleId = new Map()
 
         onUpdateListeners = tdsStorageStub.stub({ config }).onUpdateListeners
+
+        spyOn(startup, 'ready').and.callFake(
+            () => Promise.resolve()
+        )
 
         spyOn(settings, 'getSetting').and.callFake(
             name => settingsStorage.get(name)

--- a/unit-test/helpers/mock-browser-api.js
+++ b/unit-test/helpers/mock-browser-api.js
@@ -10,6 +10,12 @@ globalThis.browser = {
     browserAction: {
         setIcon: () => {}
     },
+    contextMenus: {
+        create: () => {},
+        onClicked: {
+            addListener: () => {}
+        }
+    },
     runtime: {
         id: '577dc9b9-c381-115a-2246-3f95fe0e6ffe',
         sendMessage: () => {},


### PR DESCRIPTION
The extension redirects requests to common third-party scripts to subbed out "surrogate scripts". We do that instead of simply blocking the third-party scripts since this way, we avoid breaking websites that assume the APIs provided by the third-party scripts will always be present.

**Reviewer:** @jonathanKingston 

## Steps to test this PR:
1. Build the chrome-mv3 extension: `npm install && npm run dev-chrome-mv3`
2. Install that
3. Browse to https://www.theguardian.com/
4. Open the developer tools, switch to the "Network" panel and ensure that the following surrogate scripts are redirected: `gpt.js` and `analytics.js`.

Note: It is expected that some redirections will fail with an "net::ERR_UNSAFE_REDIRECT" error. See https://crbug.com/1361350

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
