### PR TITLE
Bugfix: getBaseDomain should return null when invalid

### DIFF
--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -44,7 +44,10 @@ export async function sendTabMessage (id, message, details) {
  */
 export function getBaseDomain (urlString) {
     const parsedUrl = tldts.parse(urlString, { allowPrivateDomains: true })
-    return parsedUrl.domain || parsedUrl.hostname
+    if (parsedUrl.hostname === 'localhost' || parsedUrl.hostname?.endsWith('.localhost') || parsedUrl.isIp) {
+        return parsedUrl.hostname
+    }
+    return parsedUrl.domain
 }
 
 export function extractHostFromURL (url, shouldKeepWWW) {

--- a/unit-test/background/trackers.es6.js
+++ b/unit-test/background/trackers.es6.js
@@ -24,7 +24,7 @@ describe('tracker blocking', () => {
             const result = tds.getTrackerData(test.tracker, test.site, test.req)
             expect(result.action).toBe(test.result.action)
             expect(result.reason).toBe(test.result.reason)
-            expect(result.firstParty).toBe(test.result.firstParty)
+            expect(result.sameEntity).toBe(test.result.sameEntity)
         })
     })
 })

--- a/unit-test/background/utils.es6.js
+++ b/unit-test/background/utils.es6.js
@@ -156,6 +156,32 @@ describe('utils.isSameTopLevelDomain()', () => {
     })
 })
 
+describe('utils.getBaseDomain()', () => {
+    [
+        ['com', null],
+        ['.com', null],
+        ['example.com', 'example.com'],
+        ['www.example.com', 'example.com'],
+        ['foo.www.example.com', 'example.com'],
+        ['foo.www.example.com:8000', 'example.com'],
+        ['www.example.app', 'example.app'],
+        ['foo.apps.fbsbx.com', 'foo.apps.fbsbx.com'],
+        ['bar.foo.apps.fbsbx.com', 'foo.apps.fbsbx.com'],
+        ['apps.fbsbx.com', null],
+        ['1.2.3.4', '1.2.3.4'],
+        ['127.0.0.1', '127.0.0.1'],
+        ['localhost', 'localhost'],
+        ['ddg.localhost', 'ddg.localhost'],
+        ['sub.ddg.local', 'ddg.local'],
+        ['abcefg', null],
+        ['1234', null]
+    ].forEach(([hostname, baseDomain]) => {
+        it(`returns ${baseDomain} for ${hostname}`, () => {
+            expect(utils.getBaseDomain(hostname)).toBe(baseDomain)
+        })
+    })
+})
+
 describe('utils.parseVersionString', () => {
     const cases = [
         ['12', { major: 12, minor: 0, patch: 0 }],


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

This fixes a regression in the ad domain detection where we expect getBaseDomain to return null when a domain provided by SERP is unparsable, but getBaseDomain will always return the hostname (even if it's nonsensical).

This is Ad 11 and Add 12 in https://www.search-company.site/

I also fixed a no-op test that we forgot to update when we first merged the bat.js work. I only detected it because I had an outdated privacy grade reference that was still returning `firstParty` when running the tests locally.

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
