### PR TITLE
Fix Facebook videos if protocol isn't specified in data-href

### DIFF
--- a/shared/js/content-scripts/click-to-load.js
+++ b/shared/js/content-scripts/click-to-load.js
@@ -470,10 +470,24 @@
             }
 
             for (const key of Object.keys(this.dataElements)) {
-                const attrValue = encodeURIComponent(this.dataElements[key])
-                if (attrValue) {
-                    this.clickAction.targetURL = this.clickAction.targetURL.replace(key, attrValue)
+                let attrValue = this.dataElements[key]
+
+                if (!attrValue) {
+                    continue
                 }
+
+                // The URL for Facebook videos are specified as the data-href
+                // attribute on a div, that is then used to create the iframe.
+                // Some websites omit the protocol part of the URL when doing
+                // that, which then prevents the iframe from loading correctly.
+                if (key === 'data-href' && attrValue.startsWith('//')) {
+                    attrValue = window.location.protocol + attrValue
+                }
+
+                this.clickAction.targetURL =
+                    this.clickAction.targetURL.replace(
+                        key, encodeURIComponent(attrValue)
+                    )
             }
         }
 


### PR DESCRIPTION
Embedded Facebook videos are created by having a div element in the page that has (amongst other attributes) a data-href attribute that specifies the video's URL. The Facebook SDK then uses that to create the video iframe. Our "surrogate script" does the same.

It turns out that when the protocol prefix of that URL isn't specified (e.g. the URL starts '//'), then the SDK and our surrogate script need to take care to add the correct protocol to the URL (e.g. 'http:' or 'https:') based on the window location. Otherwise, the video fails to load.

**Reviewer:** @ladamski 

## Steps to test this PR:
1. Navigate to https://forums.spacebattles.com/threads/ace-combat-7-discussion-thread.366416/page-160?post=61183897#post-61183897
2. Click to load the Facebook video.
3. Ensure it loads and can be played.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
