### PR TITLE
Disable reddit test as constant flaking

### DIFF
--- a/integration-test/background/grades.js
+++ b/integration-test/background/grades.js
@@ -7,7 +7,8 @@ const tests = [
     // Fixme flaking
     // { url: 'www.independent.co.uk', siteGrade: ['D', 'D-'], enhancedGrade: 'B' },
     { url: 'google.com', siteGrade: 'D', enhancedGrade: 'D' },
-    { url: 'reddit.com', siteGrade: ['D', 'D-', 'C', 'B'], enhancedGrade: 'B' },
+    // FIXME - This case is flaking.
+    // { url: 'reddit.com', siteGrade: ['D', 'D-', 'C', 'B'], enhancedGrade: 'B' },
     { url: 'facebook.com', siteGrade: ['D', 'C+'], enhancedGrade: 'C+' },
     // FIXME - This case is flaking.
     //         Enhanced grade is something B and sometimes C.


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

Reddit.com grading test is constantly failing, we're allowing all grades other than 'C+'; we should just disable as removing soon anyway.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
