### PR TITLE
Reduce the number of files ignored by tsc linting

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -2,7 +2,7 @@
  * DuckDuckGo's ATB pipeline to facilitate various experiments.
  * Please see https://duck.co/help/privacy/atb for more information.
  */
-import browser from 'webextension-polyfill'
+const browser = require('webextension-polyfill')
 
 const settings = require('./settings.es6')
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es6')

--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -1,4 +1,4 @@
-import browser from 'webextension-polyfill'
+const browser = require('webextension-polyfill')
 const tldts = require('tldts')
 
 const utils = require('./utils.es6')

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -52,7 +52,7 @@ export function getURL (pixelName) {
  */
 function getAdditionalParams () {
     const browserInfo = parseUserAgentString()
-    const browser = browserInfo.browser
+    const browser = browserInfo?.browser
     const extensionVersion = browserWrapper.getExtensionVersion()
     const atb = settings.getSetting('atb')
     const queryStringParams = {}

--- a/shared/js/background/csp-blocking.es6.js
+++ b/shared/js/background/csp-blocking.es6.js
@@ -1,4 +1,4 @@
-import browser from 'webextension-polyfill'
+const browser = require('webextension-polyfill')
 
 function init () {
     browser.webRequest.onBeforeRequest.addListener((details) => {

--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -14,6 +14,7 @@ const Tab = require('./classes/tab.es6')
 const { TabState } = require('./classes/tab-state')
 const Wrapper = require('./wrapper.es6.js')
 
+// @ts-ignore - dbg is not a standard property of self.
 self.dbg = {
     settings,
     startup,

--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -92,6 +92,8 @@ async function onUpdate (configName, etag, configValue) {
     // TDS.
     if (configName === 'tds') {
         await startup.ready()
+        // @ts-ignore: Once startup.ready() has finished, surrogateList will be
+        //             assigned.
         const supportedSurrogates = new Set(Object.keys(trackers.surrogateList))
 
         const {

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -1,4 +1,4 @@
-import browser from 'webextension-polyfill'
+const browser = require('webextension-polyfill')
 const { getSetting, updateSetting } = require('./settings.es6')
 const browserWrapper = require('./wrapper.es6')
 const REFETCH_ALIAS_ALARM = 'refetchAlias'

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -4,8 +4,8 @@
  * on FF, we might actually miss the onInstalled event
  * if we do too much before adding it
  */
-import browser from 'webextension-polyfill'
-import * as messageHandlers from './message-handlers'
+const browser = require('webextension-polyfill')
+const messageHandlers = require('./message-handlers')
 const ATB = require('./atb.es6')
 const utils = require('./utils.es6')
 const experiment = require('./experiments.es6')

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -277,7 +277,10 @@ export async function addUserData (userData, sender) {
         settings.updateSetting('userData', userData)
         // Once user is set, fetch the alias and notify all tabs
         const response = await fetchAlias()
+        // @ts-ignore - Response might not have error property, but since we're
+        //              checking that it does... there's not a problem.
         if (response && response.error) {
+            // @ts-ignore
             return { error: response.error.message }
         }
 
@@ -321,10 +324,9 @@ export function setListContents ({ name, value }) {
 }
 
 export async function reloadList (listName) {
-    let list = constants.tdsLists.find(l => l.name === listName)
+    const list = constants.tdsLists.find(l => l.name === listName)
     if (list) {
-        list = await tdsStorage.getList(list)
-        trackers.setLists([list])
+        trackers.setLists([await tdsStorage.getList(list)])
     }
 }
 

--- a/shared/js/background/startup.es6.js
+++ b/shared/js/background/startup.es6.js
@@ -1,4 +1,4 @@
-import browser from 'webextension-polyfill'
+const browser = require('webextension-polyfill')
 const { getCurrentTab } = require('./utils.es6')
 const browserUIWrapper = require('../ui/base/ui-wrapper.es6')
 const Companies = require('./companies.es6')
@@ -67,13 +67,15 @@ function ready () {
  */
 function registerUnloadHandler () {
     let timeout
-    /** @param {string[]} userActions */
+    // @ts-ignore - popupUnloaded is not a standard property of self.
     self.popupUnloaded = (userActions) => {
         clearTimeout(timeout)
         if (userActions.includes('toggleAllowlist')) {
             timeout = setTimeout(() => {
                 getCurrentTab().then(tab => {
-                    browserUIWrapper.reloadTab(tab.id)
+                    if (tab) {
+                        browserUIWrapper.reloadTab(tab.id)
+                    }
                 })
             }, 500)
         }

--- a/shared/js/background/storage/https.es6.js
+++ b/shared/js/background/storage/https.es6.js
@@ -5,6 +5,7 @@ const settings = require('./../settings.es6')
 
 class HTTPSStorage {
     constructor () {
+        // @ts-ignore - TypeScript is not following the Dexie import property.
         this.dbc = new Dexie(constants.httpsDBName)
         this.dbc.version(1).stores({
             httpsStorage: 'name,type,data,checksum'

--- a/shared/js/background/storage/tds.es6.js
+++ b/shared/js/background/storage/tds.es6.js
@@ -18,7 +18,7 @@ const configNames = constants.tdsLists.map(({ name }) => name)
 
 class TDSStorage {
     constructor () {
-        // @ts-ignore
+        // @ts-ignore - TypeScript is not following the Dexie import property.
         this.dbc = new Dexie('tdsStorage')
         this.dbc.version(1).stores({
             tdsStorage: 'name,data'

--- a/shared/js/ui/base/ui-wrapper.es6.js
+++ b/shared/js/ui/base/ui-wrapper.es6.js
@@ -1,5 +1,5 @@
-import parseUserAgentString from '../../shared-utils/parse-user-agent-string.es6'
-import browser from 'webextension-polyfill'
+const parseUserAgentString = require('../../shared-utils/parse-user-agent-string.es6')
+const browser = require('webextension-polyfill')
 const browserInfo = parseUserAgentString()
 
 const sendMessage = async (messageType, options) => {
@@ -21,7 +21,7 @@ const backgroundMessage = (thisModel) => {
 /** @typedef {ReturnType<import('../../background/message-handlers.js').getTab>} TabState */
 
 /**
- * @returns {Promise<Tab|undefined>}
+ * @returns {Promise<TabState|undefined>}
  */
 async function getBackgroundTabData () {
     const url = new URL(window.location.href)
@@ -45,7 +45,7 @@ async function getBackgroundTabData () {
 }
 
 const search = (url) => {
-    browser.tabs.create({ url: `https://duckduckgo.com/?q=${url}&bext=${browserInfo.os}cr` })
+    browser.tabs.create({ url: `https://duckduckgo.com/?q=${url}&bext=${browserInfo?.os}cr` })
 }
 
 const getExtensionURL = (path) => {
@@ -80,6 +80,7 @@ const closePopup = () => {
  */
 const popupUnloaded = (userActions) => {
     const bg = chrome.extension.getBackgroundPage()
+    // @ts-ignore - popupUnloaded is not a standard property of self.
     bg?.popupUnloaded?.(userActions)
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,16 +26,9 @@
   ],
   "exclude": [
       "shared/js/background/background.es6.js",
-      "shared/js/background/broken-site-report.js",
       "shared/js/background/csp-blocking.es6.js",
-      "shared/js/background/debug.es6.js",
-      "shared/js/background/declarative-net-request.js",
       "shared/js/background/events.es6.js",
-      "shared/js/background/events/3p-tracking-cookie-blocking.js",
-      "shared/js/background/message-handlers.js",
       "shared/js/background/onboarding.es6.js",
-      "shared/js/background/startup.es6.js",
-      "shared/js/background/storage/https.es6.js",
       "shared/js/devtools/list-editor.es6.js",
       "shared/js/devtools/panel.es6.js"
   ],


### PR DESCRIPTION
The TypeScript linter tsc is set to ignore some modules, since there
are some linting errors in those files. The problem with that (other
than missing out on the benefits of type checking), is that when one
of the ignored modules is later imported by a non-ignored module, the
previously-ignored module will start being checked again. This results
in a kind of trap where importing the wrong module suddenly results in
dozens of linting errors!

Let's improve the situation by reducing the number of ignored
modules.

One interesting linting error I hit was:

    Module '"X"' declares 'Y' locally, but it is not exported.

It turned out, that was caused by modules that used CommonJS exports,
but that started with an ES import. To fix those errors, I switched
back to CommonJS imports in those situations. We should obviously
switch to ES modules generally in the future.

**Reviewer:** @jonathanKingston 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
