### PR TITLE
Export for tsc as well as be CJS whilst we transition imports

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -2,7 +2,7 @@
  * DuckDuckGo's ATB pipeline to facilitate various experiments.
  * Please see https://duck.co/help/privacy/atb for more information.
  */
-const browser = require('webextension-polyfill')
+import browser from 'webextension-polyfill'
 
 const settings = require('./settings.es6')
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es6')

--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -1,4 +1,4 @@
-const browser = require('webextension-polyfill')
+import browser from 'webextension-polyfill'
 const tldts = require('tldts')
 
 const utils = require('./utils.es6')

--- a/shared/js/background/csp-blocking.es6.js
+++ b/shared/js/background/csp-blocking.es6.js
@@ -1,4 +1,4 @@
-const browser = require('webextension-polyfill')
+import browser from 'webextension-polyfill'
 
 function init () {
     browser.webRequest.onBeforeRequest.addListener((details) => {

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -1,10 +1,10 @@
-const browser = require('webextension-polyfill')
+import browser from 'webextension-polyfill'
 const { getSetting, updateSetting } = require('./settings.es6')
 const browserWrapper = require('./wrapper.es6')
-const REFETCH_ALIAS_ALARM = 'refetchAlias'
+export const REFETCH_ALIAS_ALARM = 'refetchAlias'
 const REFETCH_ALIAS_ATTEMPT = 'refetchAliasAttempt'
 
-const fetchAlias = () => {
+export const fetchAlias = () => {
     // if another fetch was previously scheduled, clear that and execute now
     browser.alarms.clear(REFETCH_ALIAS_ALARM)
 
@@ -71,11 +71,11 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
     }
 })
 
-const showContextMenuAction = () => browser.contextMenus.update(MENU_ITEM_ID, { visible: true })
+export const showContextMenuAction = () => browser.contextMenus.update(MENU_ITEM_ID, { visible: true })
 
-const hideContextMenuAction = () => browser.contextMenus.update(MENU_ITEM_ID, { visible: false })
+export const hideContextMenuAction = () => browser.contextMenus.update(MENU_ITEM_ID, { visible: false })
 
-const getAddresses = () => {
+export const getAddresses = () => {
     const userData = getSetting('userData')
     return {
         personalAddress: userData?.userName,
@@ -88,21 +88,21 @@ const getAddresses = () => {
  * @param {string} address
  * @returns {string}
  */
-const formatAddress = (address) => address + '@duck.com'
+export const formatAddress = (address) => address + '@duck.com'
 
 /**
  * Checks formal username validity
  * @param {string} userName
  * @returns {boolean}
  */
-const isValidUsername = (userName) => /^[a-z0-9_]+$/.test(userName)
+export const isValidUsername = (userName) => /^[a-z0-9_]+$/.test(userName)
 
 /**
  * Checks formal token validity
  * @param {string} token
  * @returns {boolean}
  */
-const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
+export const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
 
 module.exports = {
     REFETCH_ALIAS_ALARM,

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -4,8 +4,8 @@
  * on FF, we might actually miss the onInstalled event
  * if we do too much before adding it
  */
-const browser = require('webextension-polyfill')
-const messageHandlers = require('./message-handlers')
+import browser from 'webextension-polyfill'
+import * as messageHandlers from './message-handlers'
 const ATB = require('./atb.es6')
 const utils = require('./utils.es6')
 const experiment = require('./experiments.es6')

--- a/shared/js/background/startup.es6.js
+++ b/shared/js/background/startup.es6.js
@@ -1,4 +1,4 @@
-const browser = require('webextension-polyfill')
+import browser from 'webextension-polyfill'
 const { getCurrentTab } = require('./utils.es6')
 const browserUIWrapper = require('../ui/base/ui-wrapper.es6')
 const Companies = require('./companies.es6')
@@ -16,7 +16,7 @@ const { fetchAlias, showContextMenuAction } = require('./email-utils.es6')
 let resolveReadyPromise
 const readyPromise = new Promise(resolve => { resolveReadyPromise = resolve })
 
-async function onStartup () {
+export async function onStartup () {
     registerUnloadHandler()
     await settings.ready()
     experiment.setActiveExperiment()
@@ -55,7 +55,7 @@ async function onStartup () {
     }
 }
 
-function ready () {
+export function ready () {
     return readyPromise
 }
 

--- a/shared/js/ui/base/ui-wrapper.es6.js
+++ b/shared/js/ui/base/ui-wrapper.es6.js
@@ -1,12 +1,12 @@
-const parseUserAgentString = require('../../shared-utils/parse-user-agent-string.es6')
-const browser = require('webextension-polyfill')
+import parseUserAgentString from '../../shared-utils/parse-user-agent-string.es6'
+import browser from 'webextension-polyfill'
 const browserInfo = parseUserAgentString()
 
-const sendMessage = async (messageType, options) => {
+export const sendMessage = async (messageType, options) => {
     return await browser.runtime.sendMessage({ messageType, options })
 }
 
-const backgroundMessage = (thisModel) => {
+export const backgroundMessage = (thisModel) => {
     // listen for messages from background and
     // // notify subscribers
     browser.runtime.onMessage.addListener((req, sender) => {
@@ -23,7 +23,7 @@ const backgroundMessage = (thisModel) => {
 /**
  * @returns {Promise<TabState|undefined>}
  */
-async function getBackgroundTabData () {
+export async function getBackgroundTabData () {
     const url = new URL(window.location.href)
     let tabId
     // Used for ui debugging to open the dashboard in a new tab and set the tabId manually.
@@ -44,19 +44,19 @@ async function getBackgroundTabData () {
     }
 }
 
-const search = (url) => {
+export const search = (url) => {
     browser.tabs.create({ url: `https://duckduckgo.com/?q=${url}&bext=${browserInfo?.os}cr` })
 }
 
-const getExtensionURL = (path) => {
+export const getExtensionURL = (path) => {
     return browser.runtime.getURL(path)
 }
 
-const openExtensionPage = (path) => {
+export const openExtensionPage = (path) => {
     browser.tabs.create({ url: getExtensionURL(path) })
 }
 
-const openOptionsPage = (browserName) => {
+export const openOptionsPage = (browserName) => {
     if (browserName === 'moz') {
         openExtensionPage('/html/options.html')
         window.close()
@@ -65,11 +65,11 @@ const openOptionsPage = (browserName) => {
     }
 }
 
-const reloadTab = (id) => {
+export const reloadTab = (id) => {
     browser.tabs.reload(id)
 }
 
-const closePopup = () => {
+export const closePopup = () => {
     const w = browser.extension.getViews({ type: 'popup' })[0]
     w.close()
 }
@@ -78,7 +78,7 @@ const closePopup = () => {
  * Notify the background script that the popup was closed.
  * @param {string[]} userActions - a list of string indicating what actions a user may have taken
  */
-const popupUnloaded = (userActions) => {
+export const popupUnloaded = (userActions) => {
     const bg = chrome.extension.getBackgroundPage()
     // @ts-ignore - popupUnloaded is not a standard property of self.
     bg?.popupUnloaded?.(userActions)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

This partial reverts the changes in https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/1452 by instead exporting the CJS module.exports for TSC; this should assist our migration to ESM without having an impact.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
