### PR TITLE
Add Chrome MV3 support for user allowlisting

### DIFF
--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -10,6 +10,12 @@ import {
 import {
     generateTdsRuleset
 } from '@duckduckgo/ddg2dnr/lib/tds'
+import {
+    generateDNRRule
+} from '@duckduckgo/ddg2dnr/lib/utils'
+import {
+    USER_ALLOWLISTED_PRIORITY
+} from '@duckduckgo/ddg2dnr/lib/rulePriorities'
 
 export const SETTING_PREFIX = 'declarative_net_request-'
 
@@ -21,30 +27,57 @@ const ruleIdRangeByConfigName = {
     config: [10001, 20000]
 }
 
-// A dummy etag rule is saved with the declarativeNetRequest rules generated for
-// each configuration. That way, a consistent extension state (between tds
-// configurations, extension settings and declarativeNetRequest rules) can be
-// ensured.
+// User allowlisting only requires one declarativeNetRequest rule, so hardcode
+// the rule ID here.
+export const USER_ALLOWLIST_RULE_ID = 20001
+
+/**
+ * A dummy etag rule is saved with the declarativeNetRequest rules generated for
+ * each configuration. That way, a consistent extension state (between tds
+ * configurations, extension settings and declarativeNetRequest rules) can be
+ * ensured.
+ * @param {number} id
+ * @param {string} etag
+ * @returns {import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule}
+ */
 function generateEtagRule (id, etag) {
-    return {
+    return generateDNRRule({
         id,
         priority: 1,
-        condition: {
-            urlFilter: etag,
-            requestDomains: ['etag.invalid']
-        },
-        action: { type: 'allow' }
+        actionType: 'allow',
+        urlFilter: etag,
+        requestDomains: ['etag.invalid']
+    })
+}
+
+/**
+ * Find an existing dynamic declarativeNetRequest rule with the given rule ID
+ * and return it.
+ * @param {number} desiredRuleId
+ * @returns {Promise<import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule|null>}
+ */
+async function findExistingDynamicRule (desiredRuleId) {
+    const existingRules = await chrome.declarativeNetRequest.getDynamicRules()
+
+    for (const rule of existingRules) {
+        if (rule.id === desiredRuleId) {
+            return rule
+        }
     }
+
+    return null
 }
 
 /**
  * tdsStorage.onUpdate listener which is called when the configurations are
  * updated and when the background ServiceWorker is restarted.
+ * Note: Only exported for use by unit tests, do not call manually.
  * @param {'config'|'tds'} configName
  * @param {string} etag
  * @param {object} configValue
+ * @returns {Promise}
  */
-async function onUpdate (configName, etag, configValue) {
+export async function onConfigUpdate (configName, etag, configValue) {
     await settings.ready()
 
     const [ruleIdStart, ruleIdEnd] = ruleIdRangeByConfigName[configName]
@@ -67,15 +100,9 @@ async function onUpdate (configName, etag, configValue) {
         previousSettingEtag === etag &&
         previousExtensionVersion &&
         previousExtensionVersion === extensionVersion) {
-        const existingRules =
-              await chrome.declarativeNetRequest.getDynamicRules()
-        let previousRuleEtag = null
-        for (const rule of existingRules) {
-            if (rule.id === etagRuleId) {
-                previousRuleEtag = rule.condition.urlFilter
-                break
-            }
-        }
+        const existingEtagRule = await findExistingDynamicRule(etagRuleId)
+        const previousRuleEtag =
+            existingEtagRule && existingEtagRule.condition.urlFilter
 
         // No change, rules are already current.
         if (previousRuleEtag && previousRuleEtag === etag) {
@@ -172,21 +199,27 @@ async function onUpdate (configName, etag, configValue) {
  */
 
 /**
- * @typedef {object} getMatchDetailsUnknownResult
+ * @typedef {object} getMatchDetailsResult
  * @property {string} type
- *   The match type 'unknown'.
+ *   The match type, e.g. 'unknown' or 'userAllowlist'.
  */
 
 /**
  * Find the match details (if any) associated with the given
  * declarativeNetRequest rule ID.
  * @param {number} ruleId
- * @return {Promise<getMatchDetailsUnknownResult |
+ * @return {Promise<getMatchDetailsResult |
  *                  getMatchDetailsExtensionConfigurationResult |
  *                  getMatchDetailsTrackerBlockingResult>}
  */
 export async function getMatchDetails (ruleId) {
     await settings.ready()
+
+    if (ruleId === USER_ALLOWLIST_RULE_ID) {
+        return {
+            type: 'userAllowlist'
+        }
+    }
 
     for (const [configName, [ruleIdStart, ruleIdEnd]]
         of Object.entries(ruleIdRangeByConfigName)) {
@@ -210,7 +243,91 @@ export async function getMatchDetails (ruleId) {
     return { type: 'unknown' }
 }
 
+/**
+ * Normalize and validate the given untrusted domain (e.g. from user input).
+ * Returns the normalized domain, or null should the domain be considered
+ * invalid.
+ * @param {string} domain
+ * @return {null|string}
+ */
+function normalizeUntrustedDomain (domain) {
+    try {
+        return new URL('https://' + domain).hostname
+    } catch (e) {
+        return null
+    }
+}
+
+/**
+ * Update the user allowlisting declarativeNetRequest rule to ensure the correct
+ * domains are allowlisted.
+ * @param {string[]} allowlistedDomains
+ * @return {Promise}
+ */
+async function updateUserAllowlistRule (allowlistedDomains) {
+    const addRules = []
+    const removeRuleIds = [USER_ALLOWLIST_RULE_ID]
+
+    if (allowlistedDomains.length > 0) {
+        addRules.push(generateDNRRule({
+            id: USER_ALLOWLIST_RULE_ID,
+            priority: USER_ALLOWLISTED_PRIORITY,
+            actionType: 'allowAllRequests',
+            resourceTypes: ['main_frame'],
+            requestDomains: allowlistedDomains
+        }))
+    }
+
+    await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds, addRules
+    })
+}
+
+/**
+ * Update the user allowlisting declarativeNetRequest rule to enable/disable
+ * user allowlisting for the given domain.
+ * @param {string} domain
+ * @param {boolean} enable
+ *   True if the domain is being added to the allowlist, false if it is being
+ *   removed.
+ * @return {Promise}
+ */
+export async function toggleUserAllowlistDomain (domain, enable) {
+    const normalizedDomain = normalizeUntrustedDomain(domain)
+    if (typeof normalizedDomain !== 'string') {
+        return
+    }
+
+    // Figure out the correct set of allowlisted domains.
+    const existingRule = await findExistingDynamicRule(USER_ALLOWLIST_RULE_ID)
+    const allowlistedDomains = new Set(
+        existingRule ? existingRule.condition.requestDomains : []
+    )
+    allowlistedDomains[enable ? 'add' : 'delete'](normalizedDomain)
+
+    await updateUserAllowlistRule(Array.from(allowlistedDomains))
+}
+
+/**
+ * Reset the user allowlisting declarativeNetRequest rule to match the given
+ * array of user allowlisted domains.
+ * @param {string[]} allowlistedDomains
+ * @return {Promise}
+ */
+export async function refreshUserAllowlistRules (allowlistedDomains) {
+    // Normalise and validate the domains. We're passing the user provided
+    // domains through to the declarativeNetRequest API, so it's important to
+    // prevent invalid input sneaking through.
+    const normalizedAllowlistedDomains = /** @type {string[]} */ (
+        allowlistedDomains
+            .map(normalizeUntrustedDomain)
+            .filter(domain => typeof domain === 'string')
+    )
+
+    await updateUserAllowlistRule(normalizedAllowlistedDomains)
+}
+
 if (browserWrapper.getManifestVersion() === 3) {
-    tdsStorage.onUpdate('config', onUpdate)
-    tdsStorage.onUpdate('tds', onUpdate)
+    tdsStorage.onUpdate('config', onConfigUpdate)
+    tdsStorage.onUpdate('tds', onConfigUpdate)
 }

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -20,6 +20,7 @@ const tdsStorage = require('./storage/tds.es6')
 const browserWrapper = require('./wrapper.es6')
 const limitReferrerData = require('./events/referrer-trimming')
 const { dropTracking3pCookiesFromResponse, dropTracking3pCookiesFromRequest } = require('./events/3p-tracking-cookie-blocking')
+const { refreshUserAllowlistRules } = require('./declarative-net-request')
 
 const manifestVersion = browserWrapper.getManifestVersion()
 
@@ -54,6 +55,21 @@ async function onInstalled (details) {
                 files: ['public/js/content-scripts/autofill.js']
             })
         }
+    }
+
+    // Refresh the user allowlisting declarativeNetRequest rule.
+    if (manifestVersion === 3) {
+        await settings.ready()
+        const allowlist = settings.getSetting('allowlisted') || {}
+
+        const allowlistedDomains = []
+        for (const [domain, enabled] of Object.entries(allowlist)) {
+            if (enabled) {
+                allowlistedDomains.push(domain)
+            }
+        }
+
+        await refreshUserAllowlistRules(allowlistedDomains)
     }
 }
 


### PR DESCRIPTION
Users can allowlist (disable protections) for websites from the popup
UI and also from the options page. To make that work with Chrome MV3,
we need to add a declarativeNetRequest rule that ensures requests
initiated by domains that the user has allowlisted aren't blocked or
redirected.

**Reviewer:** @jdorweiler 
**CC:** @jonathanKingston 

## Steps to test this PR:
1. Produce a Chrome MV3 build of the extension (`npm install && npm run dev-chrome-mv3`).
2. Install that in Chrome.
3. Try allowlisting websites, both from the options page and the popup UI and ensure it works.
4. Click to reload the extension from the extensions page.
5. Make sure the websites you allowlisted are still allowlisted (try opening them in a new tab too).
6. Remove any allowlisted websites from the options page and ensure they are no longer allowlisted.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
