### PR TITLE
Fix circular dependencies resulting from importing startup.ready()

### DIFF
--- a/integration-test/helpers/backgroundWait.js
+++ b/integration-test/helpers/backgroundWait.js
@@ -83,14 +83,14 @@ async function forAllConfiguration (bgPage) {
         await forFunction(bgPage, async () => {
             if (!globalThis.dbg?.https?.isReady ||
                 !globalThis.dbg?.settings?.ready ||
-                !globalThis.dbg?.startupReady ||
+                !globalThis.dbg?.startupReady?.ready ||
                 !globalThis.dbg?.tds?.ready) {
                 return false
             }
 
             await Promise.all([
                 globalThis.dbg.settings.ready(),
-                globalThis.dbg.startupReady(),
+                globalThis.dbg.startupReady.ready(),
                 globalThis.dbg.tds.ready()
             ])
 

--- a/integration-test/helpers/backgroundWait.js
+++ b/integration-test/helpers/backgroundWait.js
@@ -83,14 +83,14 @@ async function forAllConfiguration (bgPage) {
         await forFunction(bgPage, async () => {
             if (!globalThis.dbg?.https?.isReady ||
                 !globalThis.dbg?.settings?.ready ||
-                !globalThis.dbg?.startup?.ready ||
+                !globalThis.dbg?.startupReady ||
                 !globalThis.dbg?.tds?.ready) {
                 return false
             }
 
             await Promise.all([
                 globalThis.dbg.settings.ready(),
-                globalThis.dbg.startup.ready(),
+                globalThis.dbg.startupReady(),
                 globalThis.dbg.tds.ready()
             ])
 

--- a/shared/js/background/debug.es6.js
+++ b/shared/js/background/debug.es6.js
@@ -7,7 +7,7 @@ const tabManager = require('./tab-manager.es6')
 const atb = require('./atb.es6')
 const https = require('./https.es6')
 const tds = require('./storage/tds.es6')
-const startup = require('./startup.es6')
+const { startupReady } = require('./ready.es6')
 const browserWrapper = require('./wrapper.es6')
 const utils = require('./utils.es6')
 const Tab = require('./classes/tab.es6')
@@ -17,7 +17,7 @@ const Wrapper = require('./wrapper.es6.js')
 // @ts-ignore - dbg is not a standard property of self.
 self.dbg = {
     settings,
-    startup,
+    startupReady,
     tabManager,
     Tab,
     TabState,

--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -91,7 +91,7 @@ async function onUpdate (configName, etag, configValue) {
 
     // TDS.
     if (configName === 'tds') {
-        await startupReady()
+        await startupReady.ready()
         // @ts-ignore: Once startup module has finished, surrogateList will be
         //             assigned.
         const supportedSurrogates = new Set(Object.keys(trackers.surrogateList))

--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -2,7 +2,7 @@ import * as browserWrapper from './wrapper.es6'
 import settings from './settings.es6'
 import tdsStorage from './storage/tds.es6'
 import trackers from './trackers.es6'
-import * as startup from './startup.es6'
+import { startupReady } from './ready.es6'
 
 import {
     generateExtensionConfigurationRuleset
@@ -91,8 +91,8 @@ async function onUpdate (configName, etag, configValue) {
 
     // TDS.
     if (configName === 'tds') {
-        await startup.ready()
-        // @ts-ignore: Once startup.ready() has finished, surrogateList will be
+        await startupReady()
+        // @ts-ignore: Once startup module has finished, surrogateList will be
         //             assigned.
         const supportedSurrogates = new Set(Object.keys(trackers.surrogateList))
 

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -242,7 +242,7 @@ browser.webRequest.onHeadersReceived.addListener(
 //       to be compatible with MV3. Registering the listener asynchronously
 //       is only possible here as this is a MV2-only event listener!
 // See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#event_listeners
-startupReady().then(() => {
+startupReady.ready().then(() => {
     browser.webRequest.onHeadersReceived.addListener(
         dropTracking3pCookiesFromResponse,
         { urls: ['<all_urls>'] },
@@ -415,7 +415,7 @@ if (manifestVersion === 2) {
     //       to be compatible with MV3. Registering the listener asynchronously
     //       is only possible here as this is a MV2-only event listener!
     // See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#event_listeners
-    startupReady().then(() => {
+    startupReady.ready().then(() => {
         browser.webRequest.onBeforeSendHeaders.addListener(
             dropTracking3pCookiesFromRequest,
             { urls: ['<all_urls>'] },

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -19,7 +19,7 @@ const tdsStorage = require('./storage/tds.es6')
 const browserWrapper = require('./wrapper.es6')
 const limitReferrerData = require('./events/referrer-trimming')
 const { dropTracking3pCookiesFromResponse, dropTracking3pCookiesFromRequest } = require('./events/3p-tracking-cookie-blocking')
-const startup = require('./startup.es6')
+const { startupReady } = require('./ready.es6')
 
 const manifestVersion = browserWrapper.getManifestVersion()
 
@@ -242,7 +242,7 @@ browser.webRequest.onHeadersReceived.addListener(
 //       to be compatible with MV3. Registering the listener asynchronously
 //       is only possible here as this is a MV2-only event listener!
 // See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#event_listeners
-startup.ready().then(() => {
+startupReady().then(() => {
     browser.webRequest.onHeadersReceived.addListener(
         dropTracking3pCookiesFromResponse,
         { urls: ['<all_urls>'] },
@@ -415,7 +415,7 @@ if (manifestVersion === 2) {
     //       to be compatible with MV3. Registering the listener asynchronously
     //       is only possible here as this is a MV2-only event listener!
     // See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#event_listeners
-    startup.ready().then(() => {
+    startupReady().then(() => {
         browser.webRequest.onBeforeSendHeaders.addListener(
             dropTracking3pCookiesFromRequest,
             { urls: ['<all_urls>'] },

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -12,7 +12,7 @@ const brokenSiteReport = require('./broken-site-report')
 const browserName = utils.getBrowserName()
 const devtools = require('./devtools.es6')
 const browserWrapper = require('./wrapper.es6')
-const startup = require('./startup.es6')
+const { startupReady } = require('./ready.es6')
 const { LegacyTabTransfer } = require('./classes/legacy-tab-transfer')
 const getArgumentsObject = require('./helpers/arguments-object')
 
@@ -101,7 +101,7 @@ export async function initClickToLoad (unused, sender) {
     const config = { ...tdsStorage.ClickToLoadConfig }
 
     // Remove first-party entries.
-    await startup.ready()
+    await startupReady()
     const siteUrlSplit = tab.site.domain.split('.')
     const websiteOwner = trackers.findWebsiteOwner({ siteUrlSplit })
     if (websiteOwner) {

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -101,7 +101,7 @@ export async function initClickToLoad (unused, sender) {
     const config = { ...tdsStorage.ClickToLoadConfig }
 
     // Remove first-party entries.
-    await startupReady()
+    await startupReady.ready()
     const siteUrlSplit = tab.site.domain.split('.')
     const websiteOwner = trackers.findWebsiteOwner({ siteUrlSplit })
     if (websiteOwner) {

--- a/shared/js/background/ready.es6.js
+++ b/shared/js/background/ready.es6.js
@@ -5,32 +5,33 @@
  * module.
  */
 
-/**
- * @typedef readyResolverResult
- * @property {function} ready
- * @property {function} resolve
- */
+class ReadyResolver {
+    constructor () {
+        /** @type {function|null} */
+        this._readyResolver = null
 
-/**
- * Create a new ready promise getter and resolver.
- * returns {readyResolverResult}
- */
-function createReadyResolver () {
-    let readyResolver = null
-    const readyPromise = new Promise(resolve => { readyResolver = resolve })
+        this._readyPromise = new Promise(
+            resolve => { this._readyResolver = resolve }
+        )
+    }
 
-    return {
-        ready () { return readyPromise },
-        resolve () {
-            if (readyResolver) {
-                readyResolver()
-                readyResolver = null
-            }
+    /**
+     * Returns a Promise which will resolve when the corresponding code-path is
+     * ready for use.
+     * @returns {Promise<>}
+     */
+    ready () { return this._readyPromise }
+
+    /**
+     * Resolves the Promise for the corresponding code-path, if it hasn't
+     * already been resolved.
+     */
+    resolve () {
+        if (this._readyResolver) {
+            this._readyResolver()
+            this._readyResolver = null
         }
     }
 }
 
-export const {
-    ready: startupReady,
-    resolve: startupReadyResolve
-} = createReadyResolver()
+export const startupReady = new ReadyResolver()

--- a/shared/js/background/ready.es6.js
+++ b/shared/js/background/ready.es6.js
@@ -1,0 +1,36 @@
+/**
+ * Module that exports an API for announcing that, or checking if, a part of the
+ * extension's code is ready for use. This helps to avoid circular dependencies
+ * that can otherwise result from exporting ready functions directly from each
+ * module.
+ */
+
+/**
+ * @typedef readyResolverResult
+ * @property {function} ready
+ * @property {function} resolve
+ */
+
+/**
+ * Create a new ready promise getter and resolver.
+ * returns {readyResolverResult}
+ */
+function createReadyResolver () {
+    let readyResolver = null
+    const readyPromise = new Promise(resolve => { readyResolver = resolve })
+
+    return {
+        ready () { return readyPromise },
+        resolve () {
+            if (readyResolver) {
+                readyResolver()
+                readyResolver = null
+            }
+        }
+    }
+}
+
+export const {
+    ready: startupReady,
+    resolve: startupReadyResolve
+} = createReadyResolver()

--- a/shared/js/background/startup.es6.js
+++ b/shared/js/background/startup.es6.js
@@ -12,7 +12,7 @@ const tdsStorage = require('./storage/tds.es6')
 const trackers = require('./trackers.es6')
 const dnrSessionId = require('./dnr-session-rule-id')
 const { fetchAlias, showContextMenuAction } = require('./email-utils.es6')
-const { startupReadyResolve } = require('./ready.es6')
+const { startupReady } = require('./ready.es6')
 
 const manifestVersion = browserWrapper.getManifestVersion()
 
@@ -54,7 +54,7 @@ export async function onStartup () {
         }
     }
 
-    startupReadyResolve()
+    startupReady.resolve()
 }
 
 /**

--- a/shared/js/background/startup.es6.js
+++ b/shared/js/background/startup.es6.js
@@ -12,11 +12,9 @@ const tdsStorage = require('./storage/tds.es6')
 const trackers = require('./trackers.es6')
 const dnrSessionId = require('./dnr-session-rule-id')
 const { fetchAlias, showContextMenuAction } = require('./email-utils.es6')
-const manifestVersion = browserWrapper.getManifestVersion()
-/** @module */
+const { startupReadyResolve } = require('./ready.es6')
 
-let resolveReadyPromise
-const readyPromise = new Promise(resolve => { resolveReadyPromise = resolve })
+const manifestVersion = browserWrapper.getManifestVersion()
 
 export async function onStartup () {
     if (manifestVersion === 3) {
@@ -56,14 +54,7 @@ export async function onStartup () {
         }
     }
 
-    if (resolveReadyPromise) {
-        resolveReadyPromise()
-        resolveReadyPromise = null
-    }
-}
-
-export function ready () {
-    return readyPromise
+    startupReadyResolve()
 }
 
 /**
@@ -90,6 +81,5 @@ function registerUnloadHandler () {
 }
 
 module.exports = {
-    onStartup,
-    ready
+    onStartup
 }

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -4,7 +4,7 @@ import * as tds from '../data/tds.json'
 import * as browserWrapper from '../../shared/js/background/wrapper.es6'
 import * as testConfig from '../data/extension-config.json'
 import * as tdsStorageStub from '../helpers/tds.es6'
-import startup from '../../shared/js/background/startup.es6'
+import * as ready from '../../shared/js/background/ready.es6'
 import settings from '../../shared/js/background/settings.es6'
 import tdsStorage from '../../shared/js/background/storage/tds.es6'
 import trackers from '../../shared/js/background/trackers.es6'
@@ -164,7 +164,7 @@ describe('declarativeNetRequest', () => {
         onUpdateListeners = tdsStorageStub.stub({ config }).onUpdateListeners
         tdsStorage.getLists().then(lists => trackers.setLists(lists))
 
-        spyOn(startup, 'ready').and.callFake(
+        spyOn(ready, 'startupReady').and.callFake(
             () => Promise.resolve()
         )
 

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -4,7 +4,7 @@ import * as tds from '../data/tds.json'
 import * as browserWrapper from '../../shared/js/background/wrapper.es6'
 import * as testConfig from '../data/extension-config.json'
 import * as tdsStorageStub from '../helpers/tds.es6'
-import * as ready from '../../shared/js/background/ready.es6'
+import { startupReady } from '../../shared/js/background/ready.es6'
 import settings from '../../shared/js/background/settings.es6'
 import tdsStorage from '../../shared/js/background/storage/tds.es6'
 import trackers from '../../shared/js/background/trackers.es6'
@@ -164,7 +164,7 @@ describe('declarativeNetRequest', () => {
         onUpdateListeners = tdsStorageStub.stub({ config }).onUpdateListeners
         tdsStorage.getLists().then(lists => trackers.setLists(lists))
 
-        spyOn(ready, 'startupReady').and.callFake(
+        spyOn(startupReady, 'ready').and.callFake(
             () => Promise.resolve()
         )
 


### PR DESCRIPTION
The startup module exported a ready() function that could be used to check if the extension's startup sequence had completed. That was useful to help prevent race conditions at startup. The problem with that though, was that the startup module itself imports quite a few other modules. That resulted in a trap, importing startup.ready() from the wrong module (one that startup itself needs to import) would result in a circular dependency and cause peculiar timeouts and failures.

Split out startup.ready() into the ready module (ready.startupReady() and ready.startupReadyResolve()). That module can be safely imported as it has no dependencies of its own. In the future, the ready module could be also used for other similar ready Promises.

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Ensure the tests still pass.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
