### PR TITLE
Fix constants when run from node.

### DIFF
--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -1,5 +1,4 @@
 const parseUserAgentString = require('../js/shared-utils/parse-user-agent-string.es6')
-const browserWrapper = require('../js/background/wrapper.es6')
 const browserInfo = parseUserAgentString()
 
 function getConfigFileName () {
@@ -9,9 +8,8 @@ function getConfigFileName () {
     if (!['chrome', 'firefox', 'brave', 'edg'].includes(browserName)) {
         browserName = ''
     } else {
-        browserName = '-' + browserName + (browserWrapper.getManifestVersion() === 3 ? 'mv3' : '')
+        browserName = '-' + browserName + (chrome?.runtime.getManifest().manifest_version === 3 ? 'mv3' : '')
     }
-
     return `https://staticcdn.duckduckgo.com/trackerblocking/config/v2/extension${browserName}-config.json`
 }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
In #1486 we added dynamic config URLs based on the extension manifest version. However, we used a helper function from `wrapper.es6.js`, which uses es6 imports. Because `constants.js` is also loaded from node for the `bundleConfig` script, this breaks because node can't mix require and import statements.

This PR fixes it by just using the `chrome.runtime` API directly with a null check, which works on both platforms.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
