### PR TITLE
Update autofill to 0.0.2_test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#0.0.2_test",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.2.0",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1823,8 +1823,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-            "integrity": "sha512-dZfnnYwjireNpbmqa56i4CHxdmei6TxZUjQr9W9lMbHKmm5A2agZH8NkKD08/Bhl6zeJvyKKpOquQTfp6MQssw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1c933e55a671022402f6cb0549a885b43b497b9b",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -15680,9 +15679,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-            "integrity": "sha512-dZfnnYwjireNpbmqa56i4CHxdmei6TxZUjQr9W9lMbHKmm5A2agZH8NkKD08/Bhl6zeJvyKKpOquQTfp6MQssw==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1c933e55a671022402f6cb0549a885b43b497b9b",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#0.0.2_test",
             "requires": {
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
             }
@@ -15690,7 +15688,7 @@
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a3c693cbc84a7221c56c11af5d2ed27613dc62c0",
             "integrity": "sha512-6kcRX9mX+CgmXLS+ydzKsdKEl0/yxuUMXlLQjcuUASLtuxOtxBFJXmwtM1vj8Hfb1d//SKrJ1s5T6cqBQgrRuw==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#a3c693cbc84a7221c56c11af5d2ed27613dc62c0",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#3.2.0",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -15716,12 +15714,12 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#331144c5e20629fadd4d067e15a318451a9d7b4a",
             "integrity": "sha512-eTz9rMar2Nk7hlrCrq1uiohbjhtY9W5EidnFcnFrV2xKfyAae6QpJT9lWDfaGBk+QnVRVv6dfVU/2KMGob+JGw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#331144c5e20629fadd4d067e15a318451a9d7b4a"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0fac349bf2f8e5974b81109955fca65aa4389a8c",
             "integrity": "sha512-BRgMVQgzEeT8F3wqnDcBJ8a4wRKvEUEDB3DBYynuUIm580AbqZnxwYvro2RyHAJoGv8p66i30wkIfSG2+RIwxQ==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#0fac349bf2f8e5974b81109955fca65aa4389a8c"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.1.0"
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "yargs": "^17.6.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#0.0.2_test",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.2.0",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
**Task/Issue URL:** https://app.asana.com/0/1203285453345810/1203285453345810
**Autofill Release:** https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.2_test


## Description
Updates Autofill to version [0.0.2_test](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.2_test).

### Autofill 0.0.2_test release notes
A new test release. Hopefully the last for this cycle 🙂.

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).