### PR TITLE
Simplify and improve Chrome MV3 user allowlisting implementation

### DIFF
--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -308,25 +308,6 @@ export async function toggleUserAllowlistDomain (domain, enable) {
     await updateUserAllowlistRule(Array.from(allowlistedDomains))
 }
 
-/**
- * Reset the user allowlisting declarativeNetRequest rule to match the given
- * array of user allowlisted domains.
- * @param {string[]} allowlistedDomains
- * @return {Promise}
- */
-export async function refreshUserAllowlistRules (allowlistedDomains) {
-    // Normalise and validate the domains. We're passing the user provided
-    // domains through to the declarativeNetRequest API, so it's important to
-    // prevent invalid input sneaking through.
-    const normalizedAllowlistedDomains = /** @type {string[]} */ (
-        allowlistedDomains
-            .map(normalizeUntrustedDomain)
-            .filter(domain => typeof domain === 'string')
-    )
-
-    await updateUserAllowlistRule(normalizedAllowlistedDomains)
-}
-
 if (browserWrapper.getManifestVersion() === 3) {
     tdsStorage.onUpdate('config', onConfigUpdate)
     tdsStorage.onUpdate('tds', onConfigUpdate)

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -20,7 +20,6 @@ const tdsStorage = require('./storage/tds.es6')
 const browserWrapper = require('./wrapper.es6')
 const limitReferrerData = require('./events/referrer-trimming')
 const { dropTracking3pCookiesFromResponse, dropTracking3pCookiesFromRequest } = require('./events/3p-tracking-cookie-blocking')
-const { refreshUserAllowlistRules } = require('./declarative-net-request')
 
 const manifestVersion = browserWrapper.getManifestVersion()
 
@@ -55,21 +54,6 @@ async function onInstalled (details) {
                 files: ['public/js/content-scripts/autofill.js']
             })
         }
-    }
-
-    // Refresh the user allowlisting declarativeNetRequest rule.
-    if (manifestVersion === 3) {
-        await settings.ready()
-        const allowlist = settings.getSetting('allowlisted') || {}
-
-        const allowlistedDomains = []
-        for (const [domain, enabled] of Object.entries(allowlist)) {
-            if (enabled) {
-                allowlistedDomains.push(domain)
-            }
-        }
-
-        await refreshUserAllowlistRules(allowlistedDomains)
     }
 }
 

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -99,18 +99,20 @@ class TabManager {
             }
         }
 
+        // Ensure that user allowlisting/denylisting is honoured for manifest v3
+        // builds of the extension, by adding/removing the necessary
+        // declarativeNetRequest rules.
         if (manifestVersion === 3) {
-            // Ensure that user allowlisting/denylisting is honoured for
-            // manifest v3 builds of the extension, by adding/removing the
-            // necessary declarativeNetRequest rules.
-            await toggleUserAllowlistDomain(data.domain, data.value)
+            if (data.list === 'allowlisted') {
+                await toggleUserAllowlistDomain(data.domain, data.value)
+            }
 
             // TODO - Once support for the temporary allowlist
             //        (the contentBlocking) section of extension-config.json is
             //        added, the "denylisted" event needs to be handled here to
             //        ensure that users are able to override the temporary
             //        allowlist manually be re-enabling protections for a
-            //        webiste.
+            //        website.
         }
 
         browserWrapper.notifyPopup({ allowlistChanged: true })

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -11,7 +11,6 @@ import trackers from '../../shared/js/background/trackers.es6'
 import {
     getMatchDetails,
     onConfigUpdate,
-    refreshUserAllowlistRules,
     toggleUserAllowlistDomain,
     SETTING_PREFIX,
     USER_ALLOWLIST_RULE_ID
@@ -396,15 +395,6 @@ describe('declarativeNetRequest', () => {
 
         // Domains should be normalized.
         await toggleUserAllowlistDomain('FOO.InVaLiD', true)
-        expectState(['foo.invalid', 'example.invalid'])
-
-        // Allowlisting rule should be restored by refresh.
-        expectState(['foo.invalid', 'example.invalid'])
-        refreshUserAllowlistRules(['foo.invalid', 'ExAmPlE.invalid'])
-        expectState(['foo.invalid', 'example.invalid'])
-        dynamicRulesByRuleId.clear()
-        expectState([])
-        refreshUserAllowlistRules(['foo.invalid', 'example.invalid'])
         expectState(['foo.invalid', 'example.invalid'])
 
         // Try removing domains from the allowlist.


### PR DESCRIPTION
Simplify and improve Chrome MV3 user allowlisting implementation

There was some room for improvement with the Chrome MV3 user
allowlisting implementation:
1. There was no need to recreate the user allowlisting
   declarativeNetRequest rule on extension update, since dynamic
   rules persist through extension updates[1].
2. The TabManager.setList() method can be called for the
   "allowlisted", "denylisted" and "allowlistOptIn" events. We should
   check the event is "allowlisted" before treating it as such.

1 - https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#dynamic-and-session-scoped-rules

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Try allowlisting a website from the popup UI or the options page.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
