### PR TITLE
Refactor declarativeNetRequest onConfigUpdate logic

### DIFF
--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -203,7 +203,7 @@ describe('declarativeNetRequest', () => {
 
                 const {
                     etag: actualLookupEtag,
-                    lookup: actualLookup,
+                    matchDetailsByRuleId: actualLookup,
                     extensionVersion: actualLookupExtensionVersion
                 } = setting
                 const etagRuleId = expectedRuleIdsByConfigName[configName][0]


### PR DESCRIPTION
The declarativeNetRequest onConfigUpdate listener was becoming
unwieldy. This was making future expansion tricky. For example user
"denylisting" support where the extension configuration rules also
need to be updated at the point the user denylists a website. Let's
split out some of the logic into helper functions, that can then be
reused more easily.

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Make sure tracker blocking and the tracker blocking allowlist still work for Chrome MV3 builds of the extension.
2. Ensure the unit tests + integration tests still pass.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
