### PR TITLE
Update autofill to 5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.0",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1820,8 +1820,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-            "integrity": "sha512-dZfnnYwjireNpbmqa56i4CHxdmei6TxZUjQr9W9lMbHKmm5A2agZH8NkKD08/Bhl6zeJvyKKpOquQTfp6MQssw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -15968,9 +15967,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
-            "integrity": "sha512-dZfnnYwjireNpbmqa56i4CHxdmei6TxZUjQr9W9lMbHKmm5A2agZH8NkKD08/Bhl6zeJvyKKpOquQTfp6MQssw==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#516209f9a0252c9795b51ca3c815cfbbf34ad0a0",
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#5.3.1",
             "requires": {
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
             }
@@ -15978,7 +15976,7 @@
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5f2f5e63d5149cc930afae91652d49bd432d021b",
             "integrity": "sha512-aRD+5Fjh1ut0OMlMbXD2OyrGCjDNC8cTN1T/zWoW8kscSfRU3hb++kP3TmbghFqc5eKyh4zDBezD+VYtgGqGoQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#5f2f5e63d5149cc930afae91652d49bd432d021b",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#3.3.0",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -16004,12 +16002,12 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#331144c5e20629fadd4d067e15a318451a9d7b4a",
             "integrity": "sha512-eTz9rMar2Nk7hlrCrq1uiohbjhtY9W5EidnFcnFrV2xKfyAae6QpJT9lWDfaGBk+QnVRVv6dfVU/2KMGob+JGw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#331144c5e20629fadd4d067e15a318451a9d7b4a"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0fac349bf2f8e5974b81109955fca65aa4389a8c",
             "integrity": "sha512-BRgMVQgzEeT8F3wqnDcBJ8a4wRKvEUEDB3DBYynuUIm580AbqZnxwYvro2RyHAJoGv8p66i30wkIfSG2+RIwxQ==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#0fac349bf2f8e5974b81109955fca65aa4389a8c"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.1.0"
         },
         "@eslint/eslintrc": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.0",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1203345478825225/f
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/5.3.1


## Description
Updates Autofill to version [5.3.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/5.3.1).

### Autofill 5.3.1 release notes
* Another round of fixes and improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/225
* feat: support Windows by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/215
* Improve release workflow by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/205
* Fix new release by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/230
* Dark mode tooltip by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/198
* New round of improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/231


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/5.2.0...5.3.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).