### PR TITLE
Chrome MV3 support for contentBlocking, unprotectedTemporary and denylisting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.0",
-                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
+                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.3",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
@@ -1839,8 +1839,8 @@
             }
         },
         "node_modules/@duckduckgo/ddg2dnr": {
-            "version": "0.2.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#838d9df3e6ee4b70b7172133f8fe24bde3d89e81",
+            "version": "0.2.3",
+            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#4c67938591ce9086febe5e4405e28c37016dc18f",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/jsbloom": {
@@ -15985,8 +15985,8 @@
             }
         },
         "@duckduckgo/ddg2dnr": {
-            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#838d9df3e6ee4b70b7172133f8fe24bde3d89e81",
-            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.2.2"
+            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#4c67938591ce9086febe5e4405e28c37016dc18f",
+            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.2.3"
         },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.0",
-        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.2",
+        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.3",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",

--- a/shared/js/background/tab-manager.es6.js
+++ b/shared/js/background/tab-manager.es6.js
@@ -3,9 +3,10 @@ const settings = require('./settings.es6')
 const Tab = require('./classes/tab.es6')
 const { TabState } = require('./classes/tab-state')
 const browserWrapper = require('./wrapper.es6')
-const { toggleUserAllowlistDomain } = require('./declarative-net-request.js')
-
-const manifestVersion = browserWrapper.getManifestVersion()
+const {
+    toggleUserAllowlistDomain,
+    updateUserDenylist
+} = require('./declarative-net-request.js')
 
 /**
  * @typedef {import('./classes/site.es6.js').allowlistName} allowlistName
@@ -102,17 +103,12 @@ class TabManager {
         // Ensure that user allowlisting/denylisting is honoured for manifest v3
         // builds of the extension, by adding/removing the necessary
         // declarativeNetRequest rules.
-        if (manifestVersion === 3) {
+        if (browserWrapper.getManifestVersion() === 3) {
             if (data.list === 'allowlisted') {
                 await toggleUserAllowlistDomain(data.domain, data.value)
+            } else if (data.list === 'denylisted') {
+                await updateUserDenylist()
             }
-
-            // TODO - Once support for the temporary allowlist
-            //        (the contentBlocking) section of extension-config.json is
-            //        added, the "denylisted" event needs to be handled here to
-            //        ensure that users are able to override the temporary
-            //        allowlist manually be re-enabling protections for a
-            //        website.
         }
 
         browserWrapper.notifyPopup({ allowlistChanged: true })

--- a/unit-test/data/extension-config.json
+++ b/unit-test/data/extension-config.json
@@ -4,7 +4,10 @@
     "features": {
         "contentBlocking": {
             "state": "enabled",
-            "exceptions": []
+            "exceptions": [{
+                "domain": "content-blocking.example",
+                "reason": "site breakage"
+            }]
         },
         "trackingCookies3p": {
             "state": "enabled",


### PR DESCRIPTION
Chrome MV3 support for contentBlocking, unprotectedTemporary and denylisting

We have added support for the contentBlocking[1] and
unprotectedTemporary[2] allowlists + and user "denylisting" in
ddg2dnr. Update the dependency, and set up the plumbing required to
pass the user denylisted domains through to the ruleset generation
code.

1 - https://github.com/duckduckgo/privacy-configuration/blob/main/features/content-blocking.json
2 - https://github.com/duckduckgo/privacy-configuration/blob/main/features/unprotected-temporary.json

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Open the developer tools for a new tab, switch to the Network pane.
2. Navigate to welt.de and verify that no requests are blocked.
3. Click the extension icon, verify that it warns the user that protections were disabled for the page due to breakage.
4. Click to enable protections.
5. After the page reloads, verify that requests are now being blocked for the page.
6. Try disabling protections for the page again, make sure that works too.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
