### PR TITLE
Get request blocking integration tests passing

### DIFF
--- a/integration-test/background/request-blocking.js
+++ b/integration-test/background/request-blocking.js
@@ -82,7 +82,7 @@ describe('Test request blocking', () => {
         })
         // TODO fix manifest v3 blocking service workers (https://app.asana.com/0/1200940319964997/1202895557146471/f)
         // The count is higher for MV2 as we permit a load that loads more requests.
-        const count = manifestVersion === 2 ? 20 : 19
+        const count = manifestVersion === 2 ? testCount + 1 : testCount
 
         // Test the tabs tracker objects match the expected snapshot.
         const trackerSnapshot = {


### PR DESCRIPTION
The number of expected blocked requests was hard-coded in the request
blocking integration tests, which meant that they started failing when
the page was updated to make more requests. Let's make use of the test
count that we already have instead, that gets them passing again +
will hopefully avoid the same thing happening next time.


**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Check integration tests pass.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
