### PR TITLE
Always send content scripts args - even when protections are disabled

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -24,17 +24,6 @@ export async function registeredContentScript (options, sender, req) {
         return
     }
 
-    if (argumentsObject.site.isBroken) {
-        console.log('temporarily skip protections for site: ' + sender.tab.url +
-    'more info: https://github.com/duckduckgo/privacy-configuration')
-        return
-    }
-
-    // Disable content scripts when site protections are disabled
-    if (argumentsObject.site.allowlisted && req.messageType === 'registeredContentScript') {
-        return
-    }
-
     return argumentsObject
 }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fixes an issue where cookie protections are active in iframes even when site protection is disabled. Requires consent-scope-scripts updated with https://github.com/duckduckgo/content-scope-scripts/pull/188.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
