### PR TITLE
Add test for non-blocking of iframe cookies when site allowlisted.

### DIFF
--- a/integration-test/background/storage.js
+++ b/integration-test/background/storage.js
@@ -143,5 +143,37 @@ describe('Storage blocking Tests', () => {
             await page.close()
             await teardown()
         })
+
+        it('does not block safe third party iframe JS cookies when protections are disabled', async () => {
+            // https://app.asana.com/0/1201614831475344/1203336793368587
+            const { page, bgPage, teardown } = await setup()
+            // add testPageDomain to the allowlist
+            await bgPage.evaluate(async (domain) => {
+                return new Promise((resolve, reject) => {
+                    chrome.storage.local.get('settings', ({ settings }) => {
+                        try {
+                            settings.allowlisted = {
+                                [domain]: true
+                            }
+                            chrome.storage.local.set({ settings }, resolve)
+                        } catch (e) {
+                            reject(e)
+                        }
+                    })
+                })
+            }, testPageDomain)
+            await pageWait.forGoto(page, `https://${testPageDomain}/privacy-protections/storage-blocking/?store`)
+            await page.bringToFront()
+            await waitForAllResults(page)
+            await page.click('#retrive')
+            await waitForAllResults(page)
+            const results = JSON.parse(await page.evaluate('JSON.stringify(results);'))
+            const savedResult = results.results.find(({ id }) => id === 'memory').value
+            const safeFrameCookieResult = results.results.find(({ id }) => id === 'safe third party iframe - JS cookie')?.value
+            expect(safeFrameCookieResult).toBeTruthy()
+            expect(safeFrameCookieResult).toEqual(savedResult)
+            await page.close()
+            await teardown()
+        })
     })
 })

--- a/integration-test/background/storage.js
+++ b/integration-test/background/storage.js
@@ -149,17 +149,9 @@ describe('Storage blocking Tests', () => {
             const { page, bgPage, teardown } = await setup()
             // add testPageDomain to the allowlist
             await bgPage.evaluate(async (domain) => {
-                return new Promise((resolve, reject) => {
-                    chrome.storage.local.get('settings', ({ settings }) => {
-                        try {
-                            settings.allowlisted = {
-                                [domain]: true
-                            }
-                            chrome.storage.local.set({ settings }, resolve)
-                        } catch (e) {
-                            reject(e)
-                        }
-                    })
+                /* global dbg */
+                dbg.settings.updateSetting('allowlisted', {
+                    [domain]: true
                 })
             }, testPageDomain)
             await pageWait.forGoto(page, `https://${testPageDomain}/privacy-protections/storage-blocking/?store`)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
A bug in JS cookie protection caused iframe cookies to be blocked when protections were disabled for a site. This was fixed in #1534. This PR adds a test for this case.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
