### PR TITLE
Avoid blocking ServiceWorker initiated requests for Chrome MV3

### DIFF
--- a/integration-test/background/request-blocking.js
+++ b/integration-test/background/request-blocking.js
@@ -31,9 +31,6 @@ describe('Test request blocking', () => {
             pageRequests,
             ({ url }) => url.hostname === 'bad.third-party.site'
         )
-        const manifestVersion = await bgPage.evaluate(() => {
-            return globalThis.dbg.browserWrapper.getManifestVersion()
-        })
 
         // Initiate the test requests and wait until they have all completed.
         // Note:
@@ -66,26 +63,29 @@ describe('Test request blocking', () => {
             () => results.results // eslint-disable-line no-undef
         )
         for (const { id, category, status } of pageResults) {
+            const description = `ID: ${id}, Category: ${category}`
+
             // ServiceWorker initiated request blocking is not yet supported.
+            // TODO: Remove this condition once they are blocked again.
             if (id === 'serviceworker-fetch') {
+                expect(status).withContext(description).toEqual('loaded')
                 continue
             }
 
-            const description = `ID: ${id}, Category: ${category}`
             expect(status).withContext(description).not.toEqual('loaded')
         }
 
-        // Test the tracker reporting matches the expected outcomes.
-        const trackers = await bgPage.evaluate(async () => {
+        // Test the extension's tracker reporting matches the expected outcomes.
+        const extensionTrackers = await bgPage.evaluate(async () => {
             const currentTab = await globalThis.dbg.utils.getCurrentTab()
             return globalThis.dbg.tabManager.get({ tabId: currentTab.id }).trackers
         })
-        // TODO fix manifest v3 blocking service workers (https://app.asana.com/0/1200940319964997/1202895557146471/f)
-        // The count is higher for MV2 as we permit a load that loads more requests.
-        const count = manifestVersion === 2 ? testCount + 1 : testCount
 
-        // Test the tabs tracker objects match the expected snapshot.
-        const trackerSnapshot = {
+        const extensionTrackersCount =
+              extensionTrackers['Test Site for Tracker Blocking'].count
+        expect(extensionTrackersCount).toBeGreaterThanOrEqual(testCount)
+
+        expect(extensionTrackers).toEqual({
             'Test Site for Tracker Blocking': {
                 displayName: 'Bad Third Party Site',
                 prevalence: 0.1,
@@ -101,10 +101,9 @@ describe('Test request blocking', () => {
                         }
                     }
                 },
-                count
+                count: extensionTrackersCount
             }
-        }
-        expect(trackers).toEqual(trackerSnapshot)
+        })
 
         await page.close()
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.1",
-                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.4",
+                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.5",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
@@ -1839,8 +1839,8 @@
             }
         },
         "node_modules/@duckduckgo/ddg2dnr": {
-            "version": "0.2.4",
-            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#1329b2150d060b38e4e7e59819af4936a698a07d",
+            "version": "0.2.5",
+            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#ba1b1b5a943a0d8223ea4adfa2293974734e6765",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/jsbloom": {
@@ -16004,8 +16004,8 @@
             }
         },
         "@duckduckgo/ddg2dnr": {
-            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#1329b2150d060b38e4e7e59819af4936a698a07d",
-            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.2.4"
+            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#ba1b1b5a943a0d8223ea4adfa2293974734e6765",
+            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.2.5"
         },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.3.1",
-        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.4",
+        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.2.5",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",

--- a/unit-test/helpers/mock-browser-api.js
+++ b/unit-test/helpers/mock-browser-api.js
@@ -29,7 +29,9 @@ globalThis.browser = {
     declarativeNetRequest: {
         isRegexSupported () { return { isSupported: true } },
         getDynamicRules () { },
-        updateDynamicRules () { }
+        getSessionRules () { },
+        updateDynamicRules () { },
+        updateSessionRules () { }
     }
 }
 globalThis.chrome = globalThis.browser


### PR DESCRIPTION
We already avoid blocking ServiceWorker initiated requests in the MV2
extension, since each time we enabled the blocking of those we saw
major website breakage. In the future, we'd like to start blocking
those requests again, but we'll have to do so carefully.

Anyway, it's important that request blocking is consistent between MV2
and MV3 builds of the extension. So for now, let's also avoid blocking
ServiceWorker initiated requests for Chrome MV3 builds too.

Note: The way we do this, is to ignore requests with a tabId of
      -1 (aka requests not associated with a tab). This could also
      lead to other requests being ignored, but since that's
      consistent with the MV2 code-path[1] it seems the right approach.

1 - https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/92222c85b04894a7f411cd844e2612b7a7d7c923/shared/js/background/before-request.es6.js#L85

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Navigate to https://privacy-test-pages.glitch.me/privacy-protections/request-blocking and ensure ServiceWorker initiated requests aren't blocked, but other requests still are.
2. Smoke test that tracker blocking is still working generally.
3. Ensure the integration and unit tests are passing.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
