### PR TITLE
Fix up service worker tab navigation issues

### DIFF
--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -93,8 +93,6 @@ function handleRequest (requestData) {
         }
     }
 
-    // For main_frame requests: create a new tab instance whenever we either
-    // don't have a tab instance for this tabId or this is a new requestId.
     if (requestData.type === 'main_frame') {
         let mainFrameRequestURL = new URL(requestData.url)
 

--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -96,16 +96,6 @@ function handleRequest (requestData) {
     // For main_frame requests: create a new tab instance whenever we either
     // don't have a tab instance for this tabId or this is a new requestId.
     if (requestData.type === 'main_frame') {
-        if (!thisTab || thisTab.requestId !== requestData.requestId) {
-            const newTab = tabManager.create(requestData)
-
-            // persist the last URL the tab was trying to upgrade to HTTPS
-            if (thisTab && thisTab.httpsRedirects) {
-                newTab.httpsRedirects.persistMainFrameRedirect(thisTab.httpsRedirects.getMainFrameRedirect())
-            }
-            thisTab = newTab
-        }
-
         let mainFrameRequestURL = new URL(requestData.url)
 
         // AMP protection

--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -84,7 +84,7 @@ function handleRequest (requestData) {
     // Skip requests to background tabs
     if (tabId === -1) { return }
 
-    let thisTab = tabManager.get(requestData)
+    const thisTab = tabManager.get(requestData)
 
     // control access to web accessible resources
     if (requestData.url.startsWith(browserWrapper.getExtensionURL('/web_accessible_resources'))) {

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -273,7 +273,14 @@ browser.webNavigation.onCommitted.addListener(details => {
     // ignore navigation on iframes
     if (details.frameId !== 0) return
 
-    const tab = tabManager.get({ tabId: details.tabId })
+    let tab = tabManager.get({ tabId: details.tabId })
+
+    const newTab = tabManager.create({ tabId: details.tabId, url: details.url })
+    // persist the last URL the tab was trying to upgrade to HTTPS
+    if (tab && tab.httpsRedirects) {
+        newTab.httpsRedirects.persistMainFrameRedirect(tab.httpsRedirects.getMainFrameRedirect())
+    }
+    tab = newTab
 
     if (!tab) return
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

On tab navigate we're losing navigations of pages that are fully served by service workers. We need to model the tab data from webNavigations instead.

See: https://app.asana.com/0/312629933896096/1203403741315745/f

## Steps to test this PR:

**STR**

1. Type into the address bar [browsersync.io](https://browsersync.io/) and enter
2. Type into the address bar [cnn.com](https://cnn.com/) and enter (in the same tab)
3. Type into the address bar [browsersync.io](https://browsersync.io/) and enter (in the same tab)

**Expected results**

- No trackers are loaded
- Some third parties

**Actual results**
- CNN trackers are shown

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
