### PR TITLE
shane/email-signout-bug

### DIFF
--- a/shared/js/background/classes/privacy-dashboard-data.js
+++ b/shared/js/background/classes/privacy-dashboard-data.js
@@ -11,7 +11,7 @@
  * The return type of this function comes from a schema defined in the Privacy Dashboard,
  *
  * @param {import("./tab.es6.js")} tab
- * @param {EmailProtectionUserData | undefined} userData
+ * @param {EmailProtectionUserData | undefined | {}} userData
  * @returns {ExtensionGetPrivacyDashboardData}
  */
 export function dashboardDataFromTab (tab, userData) {
@@ -37,6 +37,12 @@ export function dashboardDataFromTab (tab, userData) {
 
     const requests = convertToRequests(tab, protectionsEnabled)
 
+    // Only assign `emailProtectionUserData` if we're sure it is valid data - otherwise allow it to be undefined.
+    let emailProtectionUserData
+    if (userData && 'userName' in userData) {
+        emailProtectionUserData = userData
+    }
+
     return {
         tab: {
             id: tab.id,
@@ -49,7 +55,7 @@ export function dashboardDataFromTab (tab, userData) {
         requestData: {
             requests
         },
-        emailProtectionUserData: userData
+        emailProtectionUserData
     }
 }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

https://app.asana.com/0/0/1203425462517715/f

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When a user signs out, the `userData` setting is reverted to an empty object `{}` -> this gets sent to the dashboard and fails schema validation.

The schema states that the field `emailProtectionUserData ` is optional - so it needs to be null or absent instead of an empty object. see: https://duckduckgo.github.io/privacy-dashboard/interfaces/Generated_Schema_Definitions.GetPrivacyDashboardData.html


## Steps to test this PR:
<!-- List steps to test it manually 
1. Sign in to email protection
2. Sign out
3. Try to open the dashboard -> if it loads, it's working. If you see an error message, it is not.
-->

## Automated tests:
- [x] tsc -> I was able to enforce this through the types and `tsc` will now fail if we don't check the output.
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
