### PR TITLE
fix(mv3): fix reload+close following protections toggle

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -3,8 +3,8 @@ import * as startup from './startup'
 import { dashboardDataFromTab } from './classes/privacy-dashboard-data'
 import { breakageReportForTab } from './broken-site-report'
 import parseUserAgentString from '../shared-utils/parse-user-agent-string.es6'
-import { getExtensionURL } from './wrapper.es6'
-import { closePopup, reloadCurrentTab } from './utils.es6'
+import { getExtensionURL, notifyPopup } from './wrapper.es6'
+import { reloadCurrentTab } from './utils.es6'
 const { getDomain } = require('tldts')
 const utils = require('./utils.es6')
 const settings = require('./settings.es6')
@@ -62,8 +62,12 @@ export async function setLists (options) {
         tabManager.setList(listItem)
     }
 
-    closePopup()
-    reloadCurrentTab()
+    try {
+        notifyPopup({ closePopup: true })
+        reloadCurrentTab()
+    } catch (e) {
+        console.error('Error trying to reload+refresh following `setLists` message', e)
+    }
 }
 
 export function allowlistOptIn (optInData) {
@@ -78,7 +82,6 @@ export function getBrowser () {
 export function openOptions () {
     if (browserName === 'moz') {
         browser.tabs.create({ url: getExtensionURL('/html/options.html') })
-        window.close()
     } else {
         browser.runtime.openOptionsPage()
     }

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -428,11 +428,6 @@ export function getURLWithoutQueryString (urlString) {
     return urlString?.split('?')[0]
 }
 
-export function closePopup () {
-    const w = browser.extension.getViews({ type: 'popup' })[0]
-    w.close()
-}
-
 export async function reloadCurrentTab () {
     const tab = await getCurrentTab()
     if (tab && tab.id) {


### PR DESCRIPTION
`browser.extension.getViews` is not supported in MV3 https://app.asana.com/0/0/1203479085724011/f

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kzar @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When I updated the dashboard, I used `browser.extension.getViews()` to get access to the popup for closing it. 

This is not supported in MV3 - and actually we use the `notitfyPopup()` elsewhere already for closing, so this PR prevents us having 2 separate ways for doing the same thing 💪🏻 


## Steps to test this PR:
<!-- List steps to test it manually 
1. On any non-special page, toggle protections
2. You should see the popup auto close and the page behind should refresh
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
