### PR TITLE
Add AMP link protection integration test

### DIFF
--- a/integration-test/background/ampProtection.js
+++ b/integration-test/background/ampProtection.js
@@ -1,0 +1,92 @@
+const puppeteer = require('puppeteer')
+const harness = require('../helpers/harness')
+const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
+const backgroundWait = require('../helpers/backgroundWait')
+const pageWait = require('../helpers/pageWait')
+
+const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/amp/'
+
+describe('Test AMP link protection', () => {
+    let browser
+    let bgPage
+    let teardown
+
+    beforeAll(async () => {
+        ({ browser, bgPage, teardown } = await harness.setup())
+        await backgroundWait.forAllConfiguration(bgPage)
+
+        // Overwrite the parts of the configuration needed for our tests.
+        await loadTestConfig(bgPage, 'amp-protection.json')
+    })
+
+    afterAll(async () => {
+        // Restore the original configuration.
+        await unloadTestConfig(bgPage)
+
+        try {
+            await teardown()
+        } catch (e) {}
+    })
+
+    it('Strips tracking parameters correctly', async () => {
+        // Load the test page.
+        const page = await browser.newPage()
+        await pageWait.forGoto(page, testSite)
+
+        // Scrape the list of test cases.
+        const testCases = []
+
+        const testGroups = await page.$$('#demo ul')
+        const testGroupTitles = await page.$$('#demo > p')
+        for (let i = 0; i < testGroups.length; i++) {
+            const groupTitle =
+                  await page.evaluate(el => el.innerText, testGroupTitles[i])
+
+            // "Deep link extraction" is not yet supported.
+            if (groupTitle === 'First Party Cloaked AMP links') {
+                continue
+            }
+
+            for (const li of await testGroups[i].$$('li')) {
+                // eslint-disable-next-line no-shadow
+                testCases.push(await page.evaluate((li, groupTitle) => {
+                    const {
+                        innerText: testTitle,
+                        href: initialUrl
+                    } = li.querySelector('a')
+                    const description = groupTitle + ': ' + testTitle
+
+                    let {
+                        innerText: expectedUrl
+                    } = li.querySelector('.expected')
+                    // Strip the 'Expected: ' prefix and normalise the URL.
+                    expectedUrl = expectedUrl.split(' ')[1]
+
+                    return { initialUrl, expectedUrl, description }
+                }, li, groupTitle))
+            }
+        }
+
+        // Perform the tests.
+        for (const { initialUrl, expectedUrl, description } of testCases) {
+            // Test the URL was redirected.
+            // Note: It would be preferable to use pageWait.forGoto() here
+            //       instead, but some of the test cases are very slow to load.
+            //       Since only the redirected main_frame URL is required for
+            //       these tests, just wait for load rather than network idle.
+            try {
+                await await page.goto(
+                    initialUrl, { waitUntil: 'load', timeout: 15000 }
+                )
+            } catch (e) {
+                if (e instanceof puppeteer.errors.TimeoutError) {
+                    pending('Timed out loading URL: ' + initialUrl)
+                } else {
+                    throw e
+                }
+            }
+
+            expect(await page.url()).withContext(description).toEqual(expectedUrl)
+        }
+    })
+})

--- a/integration-test/data/configs/amp-protection.json
+++ b/integration-test/data/configs/amp-protection.json
@@ -1,0 +1,29 @@
+{
+    "globalThis.dbg.tds.config.features.trackingParameters": {
+        "state": "enabled",
+        "exceptions": [ ],
+        "settings": {
+            "deepExtractionEnabled": true,
+            "deepExtractionTimeout": 1500,
+            "linkFormats": [
+                "^https?:\\/\\/(?:w{3}\\.)?google\\.\\S{2,}\\/amp\\/s\\/(\\S+)$",
+                "^https?:\\/\\/\\S+ampproject\\.org\\/\\S\\/s\\/(\\S+)$"
+            ],
+            "keywords": [
+                "=amp",
+                "amp=",
+                "&amp",
+                "amp&",
+                "/amp",
+                "amp/",
+                ".amp",
+                "amp.",
+                "%amp",
+                "amp%",
+                "_amp",
+                "amp_",
+                "?amp"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Add an integration test runner for the AMP link protection test page.

**Reviewer:** @SlayterDev 

_**Note**: Depends on https://github.com/duckduckgo/privacy-test-pages/pull/110_

## Steps to test this PR:
1. Check integration tests still pass.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
