### PR TITLE
Fix encoding of TDS parameter in broken site reports

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -45,7 +45,7 @@ export function fire (querystring) {
     url += `?${randomNum}&`
     // some params should be not urlencoded
     let extraParams = '';
-    ['blockedTrackers', 'surrogates'].forEach((key) => {
+    ['tds', 'blockedTrackers', 'surrogates'].forEach((key) => {
         if (searchParams.has(key)) {
             extraParams += `&${key}=${decodeURIComponent(searchParams.get(key) || '')}`
             searchParams.delete(key)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Escaping the TDS etag value in broken site reports broke the server site parsing of the value. This PR fixes this by not piping this value through `URLSearchParams` - we add the value directly to the URL, `/` and all.

## Steps to test this PR:
1. Submit a broken site report
2. Request from the background page should include `tds=W/%2226f3dfbb234cfd28a47af59b497e301c` in it (with `/` unescaped).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
