### PR TITLE
Avoid throwing exceptions when new tabs are created for MV3

### DIFF
--- a/shared/js/background/before-request.es6.js
+++ b/shared/js/background/before-request.es6.js
@@ -93,6 +93,12 @@ function handleRequest (requestData) {
         }
     }
 
+    // There is a chance this tab was closed before the
+    // webRequest.onBeforeRequest event fired. For new tabs, there is also a
+    // chance that the webRequest.onBeforeRequest event fired before the
+    // tabs.onCreated event.
+    if (!thisTab) return
+
     if (requestData.type === 'main_frame') {
         let mainFrameRequestURL = new URL(requestData.url)
 
@@ -152,7 +158,7 @@ function handleRequest (requestData) {
          * there is a chance this tab was closed before
          * we got the webrequest event
          */
-        if (!(thisTab && thisTab.url && thisTab.id)) return
+        if (!(thisTab.url && thisTab.id)) return
 
         // skip blocking on new tab and extension pages
         if (thisTab.site.specialDomainName) {


### PR DESCRIPTION
We listen for chrome.tabs.onCreated events, to keep track of which tabs are open on which URLs. We also listen for
chrome.webRequest.onBeforeRequest events to enforce tracker blocking and other features on MV2. The onBeforeRequest code-path is also active for Chrome MV3 builds for now (but non-blocking), though the aim is to disable that in the future.

In the mean time, it turns out that while on MV2 the tabs.onCreated event fired reliably before the onBeforeRequest event for a new tab, with Chrome MV3 that is no longer the case. Let's take care to return if the current tab isn't known yet, before trying to access the tab's details.

**Reviewer:** @jdorweiler 
**CC:** @sammacbeth 

## Steps to test this PR:
1. Check tests are still passing.
2. Check that an exception is not logged to the background ServiceWorker when opening new tabs with Chrome MV3 builds.
3. Check that tracker blocking and the ATB parameter still works correctly with MV2 builds.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
