### PR TITLE
Add email param to atb request

### DIFF
--- a/shared/js/background/atb.es6.js
+++ b/shared/js/background/atb.es6.js
@@ -50,9 +50,12 @@ const ATB = (() => {
                 errorParam = '&e=1'
             }
 
+            const user = settings.getSetting('userData')
+            const emailSetting = user && user.userName ? 1 : 0
+
             const randomValue = Math.ceil(Math.random() * 1e7)
             // @ts-ignore
-            const url = `${ddgAtbURL}${randomValue}&browser=${parseUserAgentString().browser}&atb=${atbSetting}&set_atb=${setAtbSetting}${errorParam}`
+            const url = `${ddgAtbURL}${randomValue}&browser=${parseUserAgentString().browser}&atb=${atbSetting}&set_atb=${setAtbSetting}&email=${emailSetting}${errorParam}`
 
             return load.JSONfromExternalFile(url).then((res) => {
                 settings.updateSetting('set_atb', res.data.version)


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

1. Inspect extension's background page
2. Perform a search request
3. In background page, you should see a request to atb.js with `email=0`
4. Go to https://duckduckgo.com/email and signup / login to your existing account
5. Perform search again
6. In background page, you should see a request to atb.js with `email=1`
7. Go extension Settings -> Email Protection -> Disable
8. Perform search again 
9. In background page, you should see a request to atb.js with `email=0`

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
