### PR TITLE
shane/dashboard-localization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.5.0",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
-                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.1.1",
+                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.2.0",
@@ -1861,7 +1861,7 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#432857442b6f2081fc94767af4452f9fb4a329b6",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#37504f1d5294f9921ec2cb2d78f3540fb07e816c",
             "engines": {
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
@@ -15660,8 +15660,8 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#432857442b6f2081fc94767af4452f9fb4a329b6",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#1.1.1"
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#37504f1d5294f9921ec2cb2d78f3540fb07e816c",
+            "from": "@duckduckgo/privacy-dashboard@github:@duckduckgo/privacy-dashboard#1.2.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#0b7ce45599c8529d1d5a8ef2e7ebb90dc3e7a521",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.5.0",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
         "@duckduckgo/jsbloom": "^1.0.2",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.1.1",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.2.0",

--- a/shared/js/background/classes/privacy-dashboard-data.js
+++ b/shared/js/background/classes/privacy-dashboard-data.js
@@ -51,7 +51,12 @@ export function dashboardDataFromTab (tab, userData) {
             protections,
             upgradedHttps: tab.upgradedHttps,
             parentEntity,
-            specialDomainName: tab.site.specialDomainName || undefined
+            specialDomainName: tab.site.specialDomainName || undefined,
+            /**
+             * Explicitly setting this to 'en' for now. When ready we can send 2-character codes such
+             * as 'pl' or 'de' etc. Please see https://duckduckgo.github.io/privacy-dashboard/interfaces/Generated_Schema_Definitions.LocaleSettings.html
+             */
+            localeSettings: { locale: 'en' }
         },
         requestData: {
             requests

--- a/unit-test/background/classes/privacy-dashboard.js
+++ b/unit-test/background/classes/privacy-dashboard.js
@@ -32,7 +32,8 @@ describe('Tab -> Privacy Dashboard conversion', () => {
                     unprotectedTemporary: false,
                     enabledFeatures: ['contentBlocking']
                 },
-                upgradedHttps: false
+                upgradedHttps: false,
+                localeSettings: { locale: 'en' }
             },
             requestData: {
                 requests: []
@@ -57,7 +58,8 @@ describe('Tab -> Privacy Dashboard conversion', () => {
                     unprotectedTemporary: false,
                     enabledFeatures: ['contentBlocking']
                 },
-                upgradedHttps: false
+                upgradedHttps: false,
+                localeSettings: { locale: 'en' }
             },
             requestData: {
                 requests: []
@@ -98,7 +100,8 @@ describe('Tab -> Privacy Dashboard conversion', () => {
                 unprotectedTemporary: false,
                 enabledFeatures: ['contentBlocking']
             },
-            upgradedHttps: false
+            upgradedHttps: false,
+            localeSettings: { locale: 'en' }
         })
         /**
          * Not asserting on everything in the request data for 2 reasons:
@@ -152,7 +155,8 @@ describe('Tab -> Privacy Dashboard conversion', () => {
                 unprotectedTemporary: false,
                 enabledFeatures: ['contentBlocking']
             },
-            upgradedHttps: false
+            upgradedHttps: false,
+            localeSettings: { locale: 'en' }
         })
         /**
          * There should be 2 entries now, even though the domains match, one was "block"


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

https://app.asana.com/0/892838074342800/1203529112592104/f

## Description:

This change bumps the Dashboard to https://github.com/duckduckgo/privacy-dashboard/releases/tag/1.2.0 - the main change is that the Dashboard will NOT attempt to detect the Extension's locale any more.

This puts the extension in full control over opting in to localization, or not.

For now I've hard-coded `{ localSettings: { local: 'en' } }` into the data sent to the Dashboard, this means the extension can simply opt in or out of localization by sending any supported value.

## Steps to test this PR:
1. Change your OS language to something none-english
2. Re-start Chrome (or in FF you need a new download) and ensure the Dashboard remains in English

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
