### PR TITLE
Release CI: create tag on the commit the build is run on.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           prerelease: false
           body: "${{ steps.changelog.outputs.changelog }}\n\n${{ env.BUILT_WITH }}"
           tag_name: ${{ env.VERSION }}
+          target_commitish: ${{ github.ref }}
           files: |
             ./build/firefox/release/web-ext-artifacts/*.zip
             ./build/chrome/release/*.zip


### PR DESCRIPTION
## Description:
Set release tag explicitly, rather than implicitly tagging latest `develop` commit.

