### PR TITLE
Attribute trackers to parents when defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",
-                "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
+                "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.2",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.2.0",
                 "bel": "6.0.0",
@@ -1868,8 +1868,7 @@
         },
         "node_modules/@duckduckgo/privacy-grade": {
             "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#0b7ce45599c8529d1d5a8ef2e7ebb90dc3e7a521",
-            "integrity": "sha512-iU47ASI2T4Nwidv5yuNEYlpZ1vXSQT81+D8ta+Fs3smfDk1kMs9caGIRhKj0XsAmnCWvrcdTXHJIgw8xADIPpg==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#625fec709dfb1512f38e1706c0617f0d169c7601",
             "license": "Apache-2.0",
             "dependencies": {
                 "tldts": "^5.7.84"
@@ -15659,12 +15658,11 @@
         },
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#37504f1d5294f9921ec2cb2d78f3540fb07e816c",
-            "from": "@duckduckgo/privacy-dashboard@github:@duckduckgo/privacy-dashboard#1.2.0"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#1.2.0"
         },
         "@duckduckgo/privacy-grade": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#0b7ce45599c8529d1d5a8ef2e7ebb90dc3e7a521",
-            "integrity": "sha512-iU47ASI2T4Nwidv5yuNEYlpZ1vXSQT81+D8ta+Fs3smfDk1kMs9caGIRhKj0XsAmnCWvrcdTXHJIgw8xADIPpg==",
-            "from": "@duckduckgo/privacy-grade@github:duckduckgo/privacy-grade#2.1.1",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#625fec709dfb1512f38e1706c0617f0d169c7601",
+            "from": "@duckduckgo/privacy-grade@github:duckduckgo/privacy-grade#2.1.2",
             "requires": {
                 "tldts": "^5.7.84"
             }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",
-        "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.1",
+        "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.2.0",
         "bel": "6.0.0",

--- a/shared/js/background/classes/tracker.js
+++ b/shared/js/background/classes/tracker.js
@@ -26,8 +26,8 @@ export class Tracker {
         if (!t.tracker) {
             throw new Error('Tracker object required for Tracker constructor')
         }
-        this.parentCompany = Companies.get(t.tracker.owner.name)
-        this.displayName = t.tracker.owner.displayName
+        this.parentCompany = Companies.get(t.tracker.owner.ownedBy || t.tracker.owner.name)
+        this.displayName = this.parentCompany?.displayName || t.tracker.owner.displayName
         this.prevalence = tdsStorage.tds.entities[t.tracker.owner.name]?.prevalence
     }
 

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -125,7 +125,10 @@ export function findParent (url) {
     while (parts.length > 1) {
         const joinURL = parts.join('.')
 
-        if (tdsStorage.tds.domains[joinURL]) {
+        // check if tracker owner has 'ownedBy' to indicate a parent.
+        if (tdsStorage.tds.trackers[joinURL]?.owner?.ownedBy) {
+            return tdsStorage.tds.trackers[joinURL].owner.ownedBy
+        } else if (tdsStorage.tds.domains[joinURL]) {
             return tdsStorage.tds.domains[joinURL]
         }
         parts.shift()


### PR DESCRIPTION
## Description:
https://app.asana.com/0/0/1203197597853143/f
Attributes sites and trackers to their parents in the dashboard, where applicable.

Before             |  after
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/248111/207540393-fbfc127f-ef94-476b-8d7a-514d0ffccaa4.png)  |  ![](https://user-images.githubusercontent.com/248111/207540462-29db49b5-a7a2-4ad9-a086-a7c5ef6f1207.png)
<img width="360" alt="youtube details before" src="https://user-images.githubusercontent.com/248111/207540814-314e05af-4004-422c-b301-ea126b52aef9.png"> | <img width="361" alt="youtube details after" src="https://user-images.githubusercontent.com/248111/207540843-83511285-2252-4d30-a901-f2a7d32d8d5a.png">