### PR TITLE
Autofill pixels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.0",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1833,13 +1833,9 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
-            "integrity": "sha512-hcrfRC/lyv8IeID0woW+QUSmS+nr8Ev5KiL7/AhJT8JuL0JX5fhKjC6ad7Y8GK/3QF9He/pb8kX+GVxpc9qDzQ==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
             "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
-            }
+            "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
             "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dd3ba277b76d1ad1703671bb4d44d7c842c25979",
@@ -15956,12 +15952,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
-            "integrity": "sha512-hcrfRC/lyv8IeID0woW+QUSmS+nr8Ev5KiL7/AhJT8JuL0JX5fhKjC6ad7Y8GK/3QF9He/pb8kX+GVxpc9qDzQ==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#5.3.1",
-            "requires": {
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
-            }
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dd3ba277b76d1ad1703671bb4d44d7c842c25979",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.0",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
         "@duckduckgo/jsbloom": "^1.0.2",

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -9,6 +9,7 @@ const browserWrapper = require('./wrapper.es6')
 const settings = require('./settings.es6')
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string.es6')
 const { getURLWithoutQueryString } = require('./utils.es6')
+const { getURL } = require('./pixels')
 
 /**
  *
@@ -63,12 +64,6 @@ export function fire (querystring) {
  * @param {string} pixelName
  * @returns {string}
  */
-export function getURL (pixelName) {
-    if (!pixelName) throw new Error('pixelName is required')
-
-    const url = 'https://improving.duckduckgo.com/t/'
-    return url + pixelName
-}
 
 /**
  * Given an optional category and description, create a report for a given Tab instance.

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -59,13 +59,6 @@ export function fire (querystring) {
 }
 
 /**
- *
- * Return URL for the pixel request
- * @param {string} pixelName
- * @returns {string}
- */
-
-/**
  * Given an optional category and description, create a report for a given Tab instance.
  *
  * This code previously lived within the UI section of the dashboard,

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -105,27 +105,31 @@ function currentDate () {
     })
 }
 
-const pixelName = (name) => {
-    const browserInfo = parseUserAgentString()
-    const browserName = browserInfo?.browser ?? 'unknown'
+const pixelName = (name, browserName) => {
 
     return `${name}_${browserName.toLowerCase()}`
 }
 
-export const privateAddressUsed = () => {
+const addressUsed = (pixel) => {
+    const browserInfo = parseUserAgentString()
+    const browserName = browserInfo?.browser?.toLowerCase() ?? 'unknown'
+    if (browserName === 'firefox') return
+
     const userData = getSetting('userData')
-    if (!userData) return
+    if (!userData?.userName) return
+
     const lastAddressUsedAt = getSetting('lastAddressUsedAt') ?? ''
-    firePixel(pixelName('email_filled_random_extension'), { duck_address_last_used: lastAddressUsedAt, cohort: userData.cohort })
+
+    firePixel(pixelName(pixel, browserName), { duck_address_last_used: lastAddressUsedAt, cohort: userData.cohort })
     updateSetting('lastAddressUsedAt', currentDate())
 }
 
+export const privateAddressUsed = () => {
+    addressUsed('email_filled_random_extension')
+}
+
 export const personalAddressUsed = () => {
-    const userData = getSetting('userData')
-    if (!userData) return
-    const lastAddressUsedAt = getSetting('lastAddressUsedAt') ?? ''
-    firePixel(pixelName('email_filled_main_extension'), { duck_address_last_used: lastAddressUsedAt, cohort: userData.cohort })
-    updateSetting('lastAddressUsedAt', currentDate())
+    addressUsed('email_filled_main_extension')
 }
 
 /**

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -92,11 +92,8 @@ export const getAddresses = () => {
 
 function sendPixelRequest (pixelName, params) {
     const randomNum = Math.ceil(Math.random() * 1e7)
-
     const searchParams = new URLSearchParams(Object.entries(params))
-
     const url = getURL(pixelName) + `?${randomNum}&${searchParams.toString()}`
-
     load.url(url)
 }
 

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -1,11 +1,15 @@
 import browser from 'webextension-polyfill'
-import parseUserAgentString from '../shared-utils/parse-user-agent-string.es6'
+
 import { getURL } from './pixels'
 import load from './load.es6'
 const { getSetting, updateSetting } = require('./settings.es6')
 const browserWrapper = require('./wrapper.es6')
+const utils = require('./utils.es6')
+
 export const REFETCH_ALIAS_ALARM = 'refetchAlias'
 const REFETCH_ALIAS_ATTEMPT = 'refetchAliasAttempt'
+
+const pixelsEnabled = utils.getBrowserName() !== 'moz'
 
 export const fetchAlias = () => {
     // if another fetch was previously scheduled, clear that and execute now
@@ -108,9 +112,8 @@ const getFullPixelName = (name, browserName) => {
 }
 
 const fireAddressUsedPixel = (pixel) => {
-    const browserInfo = parseUserAgentString()
-    const browserName = browserInfo?.browser?.toLowerCase() ?? 'unknown'
-    if (browserName === 'firefox') return
+    const browserName = utils.getBrowserName() ?? 'unknown'
+    if (!pixelsEnabled) return
 
     const userData = getSetting('userData')
     if (!userData?.userName) return
@@ -131,7 +134,7 @@ const fireAddressUsedPixel = (pixel) => {
  *
  * @param {FirePixelOptions}  options
  */
-export const firePixel = (options) => {
+export const sendJSPixel = (options) => {
     const { pixelName } = options
     switch (pixelName) {
     case 'autofill_private_address':
@@ -175,5 +178,5 @@ module.exports = {
     formatAddress,
     isValidUsername,
     isValidToken,
-    firePixel
+    sendJSPixel
 }

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -382,8 +382,6 @@ browser.runtime.onMessage.addListener((req, sender) => {
         'removeUserData',
         'getEmailProtectionCapabilities',
         'getAddresses',
-        'privateAddressUsed',
-        'personalAddressUsed',
         'refreshAlias',
         'debuggerMessage'
     ]

--- a/shared/js/background/events.es6.js
+++ b/shared/js/background/events.es6.js
@@ -382,6 +382,8 @@ browser.runtime.onMessage.addListener((req, sender) => {
         'removeUserData',
         'getEmailProtectionCapabilities',
         'getAddresses',
+        'privateAddressUsed',
+        'personalAddressUsed',
         'refreshAlias',
         'debuggerMessage'
     ]

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -292,14 +292,13 @@ const {
     isValidToken,
     isValidUsername,
     getAddresses,
-    personalAddressUsed,
-    privateAddressUsed,
+    firePixel,
     fetchAlias,
     showContextMenuAction,
     hideContextMenuAction
 } = require('./email-utils.es6')
 
-export { getAddresses, privateAddressUsed, personalAddressUsed }
+export { getAddresses, firePixel }
 
 export function getAlias () {
     const userData = settings.getSetting('userData')

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -292,13 +292,13 @@ const {
     isValidToken,
     isValidUsername,
     getAddresses,
-    firePixel,
+    sendJSPixel,
     fetchAlias,
     showContextMenuAction,
     hideContextMenuAction
 } = require('./email-utils.es6')
 
-export { getAddresses, firePixel }
+export { getAddresses, sendJSPixel }
 
 export function getAlias () {
     const userData = settings.getSetting('userData')

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -292,12 +292,14 @@ const {
     isValidToken,
     isValidUsername,
     getAddresses,
+    personalAddressUsed,
+    privateAddressUsed,
     fetchAlias,
     showContextMenuAction,
     hideContextMenuAction
 } = require('./email-utils.es6')
 
-export { getAddresses }
+export { getAddresses, privateAddressUsed, personalAddressUsed }
 
 export function getAlias () {
     const userData = settings.getSetting('userData')
@@ -394,6 +396,7 @@ export async function removeUserData (_, sender) {
 
 export async function logout () {
     settings.updateSetting('userData', {})
+    settings.updateSetting('lastAddressUsedAt', '')
     // Broadcast the logout to all tabs
     const tabs = await browser.tabs.query({})
     tabs.forEach((tab) => {

--- a/shared/js/background/pixels.js
+++ b/shared/js/background/pixels.js
@@ -1,3 +1,9 @@
+/**
+ *
+ * Return URL for the pixel request
+ * @param {string} pixelName
+ * @returns {string}
+ */
 export function getURL (pixelName) {
     if (!pixelName) throw new Error('pixelName is required')
 

--- a/shared/js/background/pixels.js
+++ b/shared/js/background/pixels.js
@@ -1,0 +1,6 @@
+export function getURL (pixelName) {
+    if (!pixelName) throw new Error('pixelName is required')
+
+    const url = 'https://improving.duckduckgo.com/t/'
+    return url + pixelName
+}

--- a/unit-test/background/pixels.js
+++ b/unit-test/background/pixels.js
@@ -1,5 +1,5 @@
 
-const pixel = require('../../shared/js/background/broken-site-report')
+const pixel = require('../../shared/js/background/pixels')
 const url = 'https://improving.duckduckgo.com/t/'
 const getURLTestCases = [
     {


### PR DESCRIPTION
**Reviewer:** @GioSensation 


**CC:** @jonathanKingston @englehardt @sammacbeth 
**Depends on:** https://github.com/duckduckgo/duckduckgo-autofill/pull/242


## Description:
Send pixel events when user selects Personal Duck Address or Private Duck Address in autofill popup.

Pixel names follow existing naming convention (see here: https://app.asana.com/0/0/1203215367236121/f)

```
email_filled_{main,random}_extension_{$browser}
```

Firefox is excluded (see https://app.asana.com/0/0/1203364229726655/f)

## Steps to test this PR:
1. Setup repo together with https://github.com/duckduckgo/duckduckgo-autofill/pull/242
2. Build & load extension in Chrome
3. Go to duckduckgo.com/email and Signup/Login to email protection
4. Inspect extension's background page
5. Goto to any page where Autofill pops up, and select Private Duck Address
6. You should see a request to improving.duckduckgo.com
7. Goto to any page where Autofill pops up, and select Private Duck Address
8. You should see a request to improving.duckduckgo.com
9. Load extension in Firefox
10. Repeat steps 5 and 7. You shouldn't see any requests to improving.duckduckgo.com in Extension's network tab.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications 
