### PR TITLE
Fix user allowlist for after upgrade from MV2 to MV3 extension

### DIFF
--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -471,6 +471,25 @@ export async function toggleUserAllowlistDomain (domain, enable) {
 }
 
 /**
+ * Reset the user allowlisting declarativeNetRequest rule to match the given
+ * array of user allowlisted domains.
+ * @param {string[]} allowlistedDomains
+ * @return {Promise}
+ */
+export async function refreshUserAllowlistRules (allowlistedDomains) {
+    // Normalise and validate the domains. We're passing the user provided
+    // domains through to the declarativeNetRequest API, so it's important to
+    // prevent invalid input sneaking through.
+    const normalizedAllowlistedDomains = /** @type {string[]} */ (
+        allowlistedDomains
+            .map(normalizeUntrustedDomain)
+            .filter(domain => typeof domain === 'string')
+    )
+
+    await updateUserAllowlistRule(normalizedAllowlistedDomains)
+}
+
+/**
  * Update all contentBlocking and unprotectedTemporary allowlisting rules so
  * that user "denylisted" domains are excluded.
  * @return {Promise}

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -13,6 +13,7 @@ import {
     ensureServiceWorkerInitiatedRequestException,
     getMatchDetails,
     onConfigUpdate,
+    refreshUserAllowlistRules,
     toggleUserAllowlistDomain,
     SETTING_PREFIX,
     SERVICE_WORKER_INITIATED_ALLOWING_RULE_ID,
@@ -450,6 +451,15 @@ describe('declarativeNetRequest', () => {
 
         // Domains should be normalized.
         await toggleUserAllowlistDomain('FOO.InVaLiD', true)
+        expectState(['foo.invalid', 'example.invalid'])
+
+        // Allowlisting rule should be restored by refresh.
+        expectState(['foo.invalid', 'example.invalid'])
+        refreshUserAllowlistRules(['foo.invalid', 'ExAmPlE.invalid'])
+        expectState(['foo.invalid', 'example.invalid'])
+        dynamicRulesByRuleId.clear()
+        expectState([])
+        refreshUserAllowlistRules(['foo.invalid', 'example.invalid'])
         expectState(['foo.invalid', 'example.invalid'])
 
         // Try removing domains from the allowlist.


### PR DESCRIPTION
Fix user allowlist for after upgrade from MV2 to MV3 extension

When the user "allowlists" (disables protections for) a domain, we add
the domain to our user allowlisting declarativeNetRequest rule. That
works fine, but unfortunately does not consider domains that the user
allowlisted before migrating from the Chrome MV2 to Chrome MV3
extension.

We previously handled this case, since we wrongly believed dynamic
rules were lost on an extension update. We since removed the code
however[1]. Let's reapply those changes, to handle the MV2 -> MV3
upgrade case.

1 - https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/8b95cd144051da4d41ae4c2fc4ed6c1f94c88915

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Follow instructions (and use test builds) here: https://app.asana.com/0/0/1203569813824180/f

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
