### PR TITLE
Get some of the Click to Load integration tests running again

### DIFF
--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -3,7 +3,11 @@ const { getDomain } = require('tldts')
 
 const harness = require('../helpers/harness')
 const { logPageRequests } = require('../helpers/requests')
-const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
+const {
+    loadTestConfig,
+    unloadTestConfig,
+    loadTestTds
+} = require('../helpers/testConfig')
 const backgroundWait = require('../helpers/backgroundWait')
 const pageWait = require('../helpers/pageWait')
 const { setupAPISchemaTest } = require('../helpers/apiSchema')
@@ -66,6 +70,7 @@ describe('Test Facebook Click To Load', () => {
 
         // Overwrite the parts of the configuration needed for our tests.
         await loadTestConfig(bgPage, 'click-to-load-facebook.json')
+        await loadTestTds(bgPage, 'click-to-load-tds.json')
     })
 
     afterAll(async () => {
@@ -77,7 +82,7 @@ describe('Test Facebook Click To Load', () => {
         } catch (e) {}
     })
 
-    xit('CTL: Facebook request blocking/redirecting', async () => {
+    it('CTL: Facebook request blocking/redirecting', async () => {
         // Open the test page and start logging network requests.
         const page = await browser.newPage()
         const pageRequests = []

--- a/integration-test/background/click-to-load-youtube.js
+++ b/integration-test/background/click-to-load-youtube.js
@@ -1,6 +1,10 @@
 const harness = require('../helpers/harness')
 const { logPageRequests } = require('../helpers/requests')
-const { loadTestConfig, unloadTestConfig } = require('../helpers/testConfig')
+const {
+    loadTestConfig,
+    unloadTestConfig,
+    loadTestTds
+} = require('../helpers/testConfig')
 const backgroundWait = require('../helpers/backgroundWait')
 const pageWait = require('../helpers/pageWait')
 const { setupAPISchemaTest } = require('../helpers/apiSchema')
@@ -74,6 +78,7 @@ describe('Test YouTube Click To Load', () => {
 
         // Overwrite the parts of the configuration needed for our tests.
         await loadTestConfig(bgPage, 'click-to-load-youtube.json')
+        await loadTestTds(bgPage, 'click-to-load-tds.json')
     })
 
     afterAll(async () => {
@@ -85,7 +90,7 @@ describe('Test YouTube Click To Load', () => {
         } catch (e) {}
     })
 
-    xit('CTL: YouTube request blocking/redirecting', async () => {
+    it('CTL: YouTube request blocking/redirecting', async () => {
         // Open the test page and start logging network requests.
         const page = await browser.newPage()
         const pageRequests = []
@@ -183,7 +188,7 @@ describe('Test YouTube Click To Load', () => {
         await page.close()
     })
 
-    xit('CTL: YouTube interacting with iframe API', async () => {
+    it('CTL: YouTube interacting with iframe API', async () => {
         const page = await browser.newPage()
         await pageWait.forGoto(page, testSite)
 
@@ -259,7 +264,7 @@ describe('Test YouTube Click To Load', () => {
         await page.close()
     })
 
-    xit('CTL: YouTube Preview', async () => {
+    it('CTL: YouTube Preview', async () => {
         // Open the test page and start logging network requests.
         const page = await browser.newPage()
         const pageRequests = []

--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -3,6 +3,7 @@
     "spec_files": [
         "background/*.js",
         "content-scripts/gpc.js",
+        "!background/click-to-load-youtube.js",
         "!background/https-loop-protection.js"
     ]
 }

--- a/integration-test/data/click-to-load-tds.json
+++ b/integration-test/data/click-to-load-tds.json
@@ -1,0 +1,378 @@
+{
+    "trackers": {
+        "facebook.com": {
+            "domain": "facebook.com",
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook",
+                "privacyPolicy": "https://www.facebook.com/privacy/explanation",
+                "url": "http://facebook.com"
+            },
+            "prevalence": 0.271,
+            "fingerprinting": 1,
+            "cookies": 0.00303,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Ad Fraud",
+                "Analytics",
+                "Audience Measurement",
+                "Federated Login",
+                "Social - Comment",
+                "Social - Share",
+                "Action Pixels",
+                "Badge",
+                "Embedded Content",
+                "Social Network"
+            ],
+            "default": "ignore",
+            "rules": [
+                {
+                    "rule": "facebook\\.com\\/en_US\\/fbevents\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.0000204
+                },
+                {
+                    "rule": "facebook\\.com\\/[a-z_A-Z]+\\/sdk\\.js",
+                    "surrogate": "fb-sdk.js",
+                    "action": "block-ctl-fb"
+                },
+                {
+                    "rule": "facebook\\.com\\/tr\\/",
+                    "fingerprinting": 0,
+                    "cookies": 0.000543,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.com\\/tr",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.com\\/photo\\.php",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.com\\/ajax\\/bz",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.com\\/method\\/links\\.getStats",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.com\\/",
+                    "action": "block-ctl-fb"
+                }
+            ]
+        },
+        "facebook.net": {
+            "domain": "facebook.net",
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook",
+                "privacyPolicy": "https://www.facebook.com/privacy/explanation",
+                "url": "http://facebook.com"
+            },
+            "prevalence": 0.283,
+            "fingerprinting": 2,
+            "cookies": 0.22,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Advertising",
+                "Ad Fraud",
+                "Analytics",
+                "Audience Measurement",
+                "Federated Login",
+                "Social - Comment",
+                "Social - Share",
+                "Action Pixels",
+                "Badge",
+                "Embedded Content",
+                "Social Network"
+            ],
+            "default": "ignore",
+            "rules": [
+                {
+                    "rule": "facebook\\.net\\/.*\\/all\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.000103
+                },
+                {
+                    "rule": "facebook\\.net\\/.*\\/fbevents\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.329
+                },
+                {
+                    "rule": "facebook\\.net\\/signals\\/config\\/",
+                    "fingerprinting": 1,
+                    "cookies": 0.000202
+                },
+                {
+                    "rule": "facebook\\.net\\/.*\\/sdk\\/.*customerchat\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.000101
+                },
+                {
+                    "rule": "facebook\\.net\\/en_US\\/messenger\\.Extensions\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0
+                },
+                {
+                    "rule": "facebook\\.net\\/en_US\\/sdk\\/debug\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.00000679
+                },
+                {
+                    "rule": "facebook\\.net\\/en_US\\/sdk\\/xfbml\\.save\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0
+                },
+                {
+                    "rule": "facebook\\.net\\/en_US\\/api\\/auth\\/event\\/init\\/ui\\/xfbml\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0.0000136
+                },
+                {
+                    "rule": "facebook\\.net\\/[a-z_A-Z]+\\/sdk\\.js",
+                    "surrogate": "fb-sdk.js",
+                    "action": "block-ctl-fb"
+                },
+                {
+                    "rule": "facebook\\.net\\/\\/log\\/error",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.net\\/en_US\\/fp\\.js",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.net\\/new_domain_gating\\/",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "facebook\\.net\\/",
+                    "action": "block-ctl-fb"
+                }
+            ]
+        },
+        "youtube-nocookie.com": {
+            "domain": "youtube-nocookie.com",
+            "owner": {
+                "name": "Youtube",
+                "displayName": "Youtube (Google)",
+                "localizedName": "Youtube",
+                "ownedBy": "Google LLC"
+            },
+            "prevalence": 0.00233,
+            "fingerprinting": 3,
+            "cookies": 0.00221,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Content Delivery",
+                "Embedded Content"
+            ],
+            "default": "ignore",
+            "rules": [
+                {
+                    "rule": "youtube-nocookie\\.com\\/iframe_api",
+                    "surrogate": "youtube-iframe-api.js",
+                    "action": "block-ctl-yt"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/generate_204",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/api\\/stats\\/qoe",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/api\\/stats\\/atr",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/api\\/stats\\/playback",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/ptracking",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/api\\/stats\\/watchtime",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/api\\/stats\\/delayplay",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube-nocookie\\.com\\/",
+                    "action": "block-ctl-yt"
+                }
+            ]
+        },
+        "youtube.com": {
+            "domain": "youtube.com",
+            "owner": {
+                "name": "Youtube",
+                "displayName": "Youtube (Google)",
+                "localizedName": "Youtube",
+                "ownedBy": "Google LLC"
+            },
+            "prevalence": 0.0703,
+            "fingerprinting": 3,
+            "cookies": 0.064,
+            "categories": [
+                "Ad Motivated Tracking",
+                "Content Delivery",
+                "Embedded Content"
+            ],
+            "default": "ignore",
+            "rules": [
+                {
+                    "rule": "youtube\\.com\\/iframe_api",
+                    "surrogate": "youtube-iframe-api.js",
+                    "action": "block-ctl-yt"
+                },
+                {
+                    "rule": "youtube\\.com\\/generate_204",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/qoe",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/atr",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/playback",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/ptracking",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/watchtime",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/delayplay",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/watch",
+                    "fingerprinting": 0,
+                    "cookies": 0.00036,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/s\\/player\\/4bbf8bdb\\/www-widgetapi\\.vflset\\/www-widgetapi\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/s\\/player\\/24c6f8bd\\/www-widgetapi\\.vflset\\/www-widgetapi\\.js",
+                    "fingerprinting": 1,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/api\\/stats\\/ads",
+                    "fingerprinting": 0,
+                    "cookies": 0,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/embed\\/Yf_AfGGC8C0",
+                    "fingerprinting": 0,
+                    "cookies": 0.0000136,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/embed\\/AcdSBBsKyu4",
+                    "fingerprinting": 0,
+                    "cookies": 0.00000679,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/embed\\/3yl8n7lxkhw",
+                    "fingerprinting": 0,
+                    "cookies": 0.00000679,
+                    "comment": "pixel"
+                },
+                {
+                    "rule": "youtube\\.com\\/",
+                    "action": "block-ctl-yt"
+                }
+            ]
+        }
+    },
+    "cnames": [],
+    "domains": {
+        "facebook.com": "Facebook, Inc.",
+        "facebook.net": "Facebook, Inc.",
+        "youtube.com": "Youtube",
+        "youtube-nocookie.com": "Youtube"
+    },
+    "entities": {
+         "Facebook, Inc.": {
+            "domains": [
+                "facebook.com",
+                "facebook.net"
+            ]
+         },
+        "Youtube": {
+            "domains": [
+                "youtube.com",
+                "youtube-nocookie.com"
+            ]
+        }
+    }
+}

--- a/integration-test/data/configs/click-to-load-youtube.json
+++ b/integration-test/data/configs/click-to-load-youtube.json
@@ -1,22 +1,4 @@
 {
-    "globalThis.dbg.tds.tds.trackers.youtube\\.com": {
-        "owner": {
-            "name": "Google LLC",
-            "displayName": "YouTube",
-            "privacyPolicy": "https://policies.google.com/privacy?hl=en",
-            "url": "http://google.com"
-        },
-        "default": "ignore"
-    },
-    "globalThis.dbg.tds.tds.trackers.youtube-nocookie\\.com": {
-        "owner": {
-            "name": "Google LLC",
-            "displayName": "YouTube",
-            "privacyPolicy": "https://policies.google.com/privacy?hl=en",
-            "url": "http://google.com"
-        },
-        "default": "ignore"
-    },
     "globalThis.dbg.tds.ClickToLoadConfig.Youtube": {
         "domains": [
             "youtube.com",
@@ -27,11 +9,60 @@
             "domain": "duckduckgo.com",
             "reason": "Existing privacy protections for YouTube videos"
         }],
-        "surrogates": [
-            {
-                "rule": "(www.)?youtube(-nocookie)?.com/iframe_api",
-                "surrogate": "youtube-iframe-api.js"
+        "elementData": {
+            "YouTube embedded video": {
+                "selectors": [
+                    "iframe[src*='://youtube.com/embed']",
+                    "iframe[src*='://youtube-nocookie.com/embed']",
+                    "iframe[src*='://www.youtube.com/embed']",
+                    "iframe[src*='://www.youtube-nocookie.com/embed']",
+                    "iframe[data-src*='://youtube.com/embed']",
+                    "iframe[data-src*='://youtube-nocookie.com/embed']",
+                    "iframe[data-src*='://www.youtube.com/embed']",
+                    "iframe[data-src*='://www.youtube-nocookie.com/embed']"
+                ],
+                "replaceSettings": {
+                    "type": "youtube-video",
+                    "buttonText": "Unblock video",
+                    "infoTitle": "DuckDuckGo blocked this YouTube video to prevent Google from tracking you",
+                    "infoText": "We blocked Google (which owns YouTube) from tracking you when the page loaded. If you unblock this video, Google will know your activity.",
+                    "simpleInfoText": "We blocked Google (which owns YouTube) from tracking you when the page loaded. If you unblock this video, Google will know your activity.",
+                    "previewToggleText": "Previews disabled for additional privacy",
+                    "placeholder": {
+                        "previewToggleEnabledText": "Previews enabled",
+                        "previewInfoText": "Turn previews off for additional privacy from DuckDuckGo.",
+                        "videoPlayIcon": {
+                            "lightMode": "#",
+                            "darkMode": "#"
+                        }
+                    }
+                },
+                "clickAction": {
+                    "type": "youtube-video"
+                }
+            },
+            "YouTube embedded subscription button": {
+                "selectors": [
+                    "iframe[src*='://youtube.com/subscribe_embed']",
+                    "iframe[src*='://youtube-nocookie.com/subscribe_embed']",
+                    "iframe[src*='://www.youtube.com/subscribe_embed']",
+                    "iframe[src*='://www.youtube-nocookie.com/subscribe_embed']",
+                    "iframe[data-src*='://youtube.com/subscribe_embed']",
+                    "iframe[data-src*='://youtube-nocookie.com/subscribe_embed']",
+                    "iframe[data-src*='://www.youtube.com/subscribe_embed']",
+                    "iframe[data-src*='://www.youtube-nocookie.com/subscribe_embed']"
+                ],
+                "replaceSettings": {
+                    "type": "blank"
+                }
             }
-        ]
+        },
+        "informationalModal": {
+            "icon": "#",
+            "messageTitle": "Enable YouTube previews and reduce privacy?",
+            "messageBody": "Showing previews will allow Google (which owns YouTube) to see some of your device's information, but is still more private than playing the video.",
+            "confirmButtonText": "Enable Previews",
+            "rejectButtonText": "No Thanks"
+        }
     }
 }

--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -4,6 +4,8 @@ const path = require('path')
 const puppeteer = require('puppeteer')
 const spawnSync = require('child_process').spawnSync
 
+const backgroundWait = require('../helpers/backgroundWait')
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
 if (process.env.KEEP_OPEN) {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000 * 1000
@@ -67,6 +69,15 @@ const setup = async (ops) => {
         if (!bgPage) {
             throw new Error('Couldn\'t find background page.')
         }
+
+        // Set a flag to mark this as an integration test session.
+        await backgroundWait.forFunction(
+            bgPage, async () => globalThis?.dbg?.browserWrapper
+        )
+        await bgPage.evaluate(
+            () => globalThis.dbg.browserWrapper
+                .setToSessionStorage('integrationTest', true)
+        )
 
         bgPage.on('request', (req) => { requests.push(req.url()) })
     }

--- a/integration-test/helpers/testConfig.js
+++ b/integration-test/helpers/testConfig.js
@@ -114,10 +114,18 @@ async function unloadTestConfig (bgPage) {
  * @param {string} tdsFilePath path to TDS file to load (from integration-test/data)
  */
 async function loadTestTds (bgPage, tdsFilePath) {
-    await bgPage.evaluate((tds) => {
-        return globalThis.dbg.setListContents({
-            name: 'tds',
-            value: tds
+    await bgPage.evaluate(async tds => {
+        // Wait until the default list is loaded.
+        await globalThis.dbg.tds.ready('tds')
+
+        // Then load the test list and wait until the update listeners have
+        // been called.
+        return await new Promise(resolve => {
+            globalThis.dbg.tds.onUpdate('tds', resolve)
+            globalThis.dbg.setListContents({
+                name: 'tds',
+                value: tds
+            })
         })
     }, JSON.parse(await fs.promises.readFile(path.join(__dirname, '..', 'data', tdsFilePath), 'utf-8')))
 }


### PR DESCRIPTION
A lot of the Click to Load integration tests were disabled recently,
during the migration to Chrome MV3 and the new Click to Load
configuration system. While Click to Load YouTube is not yet working
correctly for Chrome MV3, let's get the other integration tests
running again.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Check that the integration tests are passing.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
