### PR TITLE
Enable Chrome MV3 URL tracking parameter protection integration tests

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -10,6 +10,7 @@
         "background/request-blocking.js",
         "background/storage.js",
         "background/test-fingerprint.js",
+        "background/url-parameters.js",
         "content-scripts/gpc.js"
     ]
 }

--- a/integration-test/data/configs/url-parameters.json
+++ b/integration-test/data/configs/url-parameters.json
@@ -4,9 +4,31 @@
         "exceptions": [ ],
         "settings": {
             "parameters": [
-                "utm_[a-z]+",
+                "utm_source",
+                "utm_medium",
+                "utm_campaign",
+                "utm_term",
+                "utm_content",
+                "gclid",
                 "fbclid",
-                "fb_source"
+                "fb_action_ids",
+                "fb_action_types",
+                "fb_source",
+                "fb_ref",
+                "ga_source",
+                "ga_medium",
+                "ga_term",
+                "ga_content",
+                "ga_campaign",
+                "ga_place",
+                "action_object_map",
+                "action_type_map",
+                "action_ref_map",
+                "gs_l",
+                "mkt_tok",
+                "hmb_campaign",
+                "hmb_source",
+                "hmb_medium"
             ]
         }
     }


### PR DESCRIPTION
Let's enable the URL tracking parameter protection integration tests
for Chrome MV3. That required a couple of small tweaks:

1. Since the "breakage flag" is not set with Chrome MV3, we needed to
   disable the corresponding test case.
2. We needed to accept the URL ending with a trailing "?", since it
   turns out that declarativeNetRequest query tranform rules do not
   take care to remove that when removing the last parameter.

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
