### PR TITLE
Enable integration tests for Chrome MV3 by default

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -1,16 +1,8 @@
 {
     "spec_dir": "integration-test",
     "spec_files": [
-        "background/ampProtection.js",
-        "background/atb.js",
-        "background/click-attribution.js",
-        "background/click-to-load-facebook.js",
-        "background/click-to-load-youtube.js",
-        "background/onboarding.js",
-        "background/request-blocking.js",
-        "background/storage.js",
-        "background/test-fingerprint.js",
-        "background/url-parameters.js",
-        "content-scripts/gpc.js"
+        "background/*.js",
+        "content-scripts/gpc.js",
+        "!background/https-loop-protection.js"
     ]
 }


### PR DESCRIPTION
Previously, we only enabled certain integration tests for the Chrome
MV3 manually. Since we're nearing feature parity, let's do the
opposite and only disable the failing integration tests manually.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
