### PR TITLE
Fix https/tds storage when indexedDB is disabled

### DIFF
--- a/shared/js/background/startup.js
+++ b/shared/js/background/startup.js
@@ -27,11 +27,14 @@ export async function onStartup () {
     try {
         const httpsLists = await httpsStorage.getLists(/* preferLocal= */true)
         https.setLists(httpsLists)
-
+    } catch (e) {
+        console.warn('Error loading https lists', e)
+    }
+    try {
         const tdsLists = await tdsStorage.getLists(/* preferLocal= */true)
         trackers.setLists(tdsLists)
     } catch (e) {
-        console.log(e)
+        console.warn('Error loading tds lists', e)
     }
 
     Companies.buildFromStorage()


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
In Firefox `indexedDB` can be disabled, for example with the "History -> Always use private browsing mode" setting. In this case, we fail to load our blocklists correctly, as the indexedDB exception is not caught.

This PR fixes this issue by catching the failure case, and resetting our stored etags. This means that the extension will refetch the lists every time (though the browser cache will cache it within the same session).

## Steps to test this PR:
1. In Firefox settings enable: "History -> Always use private browsing mode"
2. Load the extension in `about:debugging`
3. Go to `about:addons` and 'Manage' the settings for this extension. Set 'Run in Private windows' to 'Allow'.
4. Check that the extension is working (popup and tracker blocking works).
5. Reload the extension and check that it continues to work.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
