### PR TITLE
Remove grunt --watch argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ grunt-dev:
 	mkdir -p build/$(browser)/dev/test/html
 	cp -r shared/img build/$(browser)/dev/test/html
 	cp -r shared/data build/$(browser)/dev/test/html
-	grunt dev --browser=$(browser) --type=$(type) --watch=$(watch)
+	grunt dev --browser=$(browser) --type=$(type)
 
 setup-artifacts-dir:
 	rm -rf integration-test/artifacts


### PR DESCRIPTION
Our dev-firefox, dev-chrome and dev-chrome-mv3 Node.js "scripts" pass
the --watch=1 argument to Grunt via the Makefile. It turns out, that
with Node.js 19[1], the --watch argument is now supported by Node.js
as well. Grunt therefore starts passing that argument through to
Node.js instead, which causes the build to fail.

Let's stop passing the --watch argument for now while we figure it
out, at least that way the builds will work again.

1 - https://nodejs.org/en/blog/announcements/v19-release-announce/#node-watch-experimental


<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @GuiltyDolphin 
**CC:** @sammacbeth 