### PR TITLE
Update autofill to 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.5.2",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1832,13 +1832,9 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
-            "integrity": "sha512-hcrfRC/lyv8IeID0woW+QUSmS+nr8Ev5KiL7/AhJT8JuL0JX5fhKjC6ad7Y8GK/3QF9He/pb8kX+GVxpc9qDzQ==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
             "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
-            }
+            "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
             "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#71456ed78716be77076f079c0b73b4b429c177d6",
@@ -15861,17 +15857,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7ddea0cc34cc4d2695c1d490fcbb1cb2fde641d6",
-            "integrity": "sha512-hcrfRC/lyv8IeID0woW+QUSmS+nr8Ev5KiL7/AhJT8JuL0JX5fhKjC6ad7Y8GK/3QF9He/pb8kX+GVxpc9qDzQ==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#5.3.1",
-            "requires": {
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
-            }
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#71456ed78716be77076f079c0b73b4b429c177d6",
             "integrity": "sha512-L2MTDPsErEszMU5c4nTrBwDj2AaENi8dicOHSiC0NbSuQW35nXLmuQP6qTGSbkk4otIyzqkmtD/F3lLwaKsG1w==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#71456ed78716be77076f079c0b73b4b429c177d6",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#3.5.2",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -15900,7 +15892,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#88d351f68863fbf3683bb5b2c96e3385ec06b2d5",
             "integrity": "sha512-B5+e/7bpkHpJTaQBIZyPQgG+yHl/FYxHCy/G6zW9qEIRyFIRXHdjgyfuucu5LVY9adPGHaLcmMfKSWIqUxvCcQ==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#88d351f68863fbf3683bb5b2c96e3385ec06b2d5"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#cb5245ddc7af80b0c893f843f5862583faad923d",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.3.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.5.2",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.0",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203674907697565/1203674907697565
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.1


## Description
Updates Autofill to version [6.1.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.1).

### Autofill 6.1.1 release notes
## What's Changed
* Fix types for ID by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/239
* Email Protection sign-up tooltip by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/240
* Autofill pixels by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/242
* More minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/244
* Fix schema issue in extension repo by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/245
* Remove form frontend validation by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/246


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.0.0...6.1.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).