### PR TITLE
Fix building with local content-scope-scripts/tracker-surrogates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "install-ci": "npm ci --ignore-scripts && npm rebuild puppeteer && npm run postinstall",
         "postinstall": "npm run copy-modules && export PATH=\"$PATH:$PWD/node_modules/chromedriver/bin\" && npm run setup-test-int",
-        "copy-modules": "rsync -av --exclude='.git/' node_modules/@duckduckgo/privacy-reference-tests/ unit-test/data/reference-tests/ && cp -r node_modules/@duckduckgo/content-scope-scripts shared/ && cp -r node_modules/@duckduckgo/tracker-surrogates shared/",
+        "copy-modules": "rsync -av --exclude='.git/' node_modules/@duckduckgo/privacy-reference-tests/ unit-test/data/reference-tests/ && cp -r node_modules/@duckduckgo/content-scope-scripts/ shared/ && cp -r node_modules/@duckduckgo/tracker-surrogates/ shared/",
         "bundle-config": "node scripts/bundleConfig.mjs && node scripts/bundleTrackers.mjs",
         "build": "echo 'Try npm run release-firefox or npm run release-chrome instead' && exit 0",
         "dev": "echo 'Try npm run dev-firefox or npm run dev-chrome instead' && exit 0",


### PR DESCRIPTION
Our build scripts include the dubious step of copying the
content-scope-scripts and tracker-surrogates node modules into another
location before use. It turns out that the source paths need a
trailing "/" for that to work correctly when testing with local
versions of those modules.

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Ensure builds still work generally.
2. Try changing `content-scope-scripts` or `tracker-surrogate dependencies` in packages.json to a local copy, then try the build again (after clearing `shared/content-scope-scripts` and `shared/tracker-surrogates`.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
