### PR TITLE
Add a note about using a rule ID filter for getDynamicRules

### DIFF
--- a/shared/js/background/declarative-net-request.js
+++ b/shared/js/background/declarative-net-request.js
@@ -69,6 +69,10 @@ function generateEtagRule (id, etag) {
  * @returns {Promise<import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule|null>}
  */
 async function findExistingDynamicRule (desiredRuleId) {
+    // TODO: Pass a rule ID filter[1] (to avoid querying all rules) once
+    //       Chrome >= 111 is the minimum supported version.
+    //       See https://crbug.com/1379699
+    // 1 - https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-GetRulesFilter
     const existingRules = await chrome.declarativeNetRequest.getDynamicRules()
 
     for (const rule of existingRules) {


### PR DESCRIPTION
With Chrome 111 there will be a way to filter fetched dynamic/session rules by rule ID. We should make use of that for
`findExistingDynamicRule()`, since we can query for the desired rule directly and avoid fetching all the other rules.

Since we currently support back to Chrome 102 for the MV3 extension we can't use it yet, but let's add a note so we can do that later.

**Reviewer:** @jdorweiler 

## Steps to test this PR:
N/A

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
