### PR TITLE
Simplify Click to Load message handling

### DIFF
--- a/integration-test/data/configs/click-to-load-youtube.json
+++ b/integration-test/data/configs/click-to-load-youtube.json
@@ -1,4 +1,11 @@
 {
+    "globalThis.dbg.tds.config.features.clickToPlay": {
+        "state": "enabled",
+        "exceptions": [ ],
+        "settings": {
+            "Youtube": { }
+        }
+    },
     "globalThis.dbg.tds.ClickToLoadConfig.Youtube": {
         "domains": [
             "youtube.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.1",
+                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.3",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",
@@ -1838,7 +1838,7 @@
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#be63500b90412daa46aca30f172398a1b0397b53",
+            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#fb1eda3772743f755a0e22c954f77470c1c0619a",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -16033,8 +16033,8 @@
             "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.2"
         },
         "@duckduckgo/content-scope-scripts": {
-            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#be63500b90412daa46aca30f172398a1b0397b53",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.0.1",
+            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#fb1eda3772743f755a0e22c954f77470c1c0619a",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.0.3",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     },
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.3",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.2.0",

--- a/shared/js/content-scripts/content-scope-messaging.js
+++ b/shared/js/content-scripts/content-scope-messaging.js
@@ -1,12 +1,10 @@
 const allowedMessages = [
-    'getDevMode',
-    'initClickToLoad',
-    'enableSocialTracker',
-    'openShareFeedbackPage',
+    'getClickToLoadState',
     'getYouTubeVideoDetails',
-    'updateYouTubeCTLAddedFlag',
-    'getYoutubePreviewsEnabled',
-    'setYoutubePreviewsEnabled'
+    'openShareFeedbackPage',
+    'setYoutubePreviewsEnabled',
+    'unblockClickToLoadContent',
+    'updateYouTubeCTLAddedFlag'
 ]
 
 function getSecret () {


### PR DESCRIPTION
Let's simplify the Click to Load message handlers now that the
content-scope-script migration is complete:

  - Instead of passing the whole content-scope-script configuration
    for Click to Load to the background and back to the content script
    again, let's only pass what's required.
  - Instead of handling the simple messaging and enabled/disabled
    logic in the background, let's let the content script take care of
    it. That should make porting the feature to other platforms
    simpler.
  - Combine the messages needed for to start Click to Load into one,
    to reduce the back-and-forth + fix a race condition.
  - Remove some now unused message handlers and rename the
    "enableSocialTracker" message to "unblockClickToLoadContent".
  - Remove the workaround for being passed the incorrect action to
    unblock.
  - Update the test configuration for YouTube Click to Load to get the
    tests passing again with the above changes.

**Reviewer:** @ladamski 
**CC:** @jonathanKingston

## Steps to test this PR:
1. Test Facebook Click to Load logins work correctly (e.g. with https://yelp.com/login ).
2. Test Facebook Click to Load blocking and placeholders work correctly [on our Facebook test page](https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/).
3. Test that the videos on [our YouTube test page](https://privacy-test-pages.glitch.me/privacy-protections/youtube-click-to-load/) aren't blocked or replaced with placeholders.
4. Check the integration tests pass.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
