### PR TITLE
Update autofill to 6.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.1",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1833,7 +1833,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3a329ee47224295fd4e8e85d8674daa126145134",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -16029,8 +16029,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b35f79da552b3b0e772c0f7582a8ff79f0e9cd29",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3a329ee47224295fd4e8e85d8674daa126145134",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.2"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#be63500b90412daa46aca30f172398a1b0397b53",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.1",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203789390844840/1203789390844840
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.2


## Description
Updates Autofill to version [6.1.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.1.2).

### Autofill 6.1.2 release notes
## What's Changed
* Type consistency internally + when consumed by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/247
* Improve hybrid form UX by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/248


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.1...6.1.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).