### PR TITLE
Update autofill to 6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.3",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1833,7 +1833,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3a329ee47224295fd4e8e85d8674daa126145134",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#49c5e80e44306937cb3eaa7afb690b7889de3895",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -16029,8 +16029,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3a329ee47224295fd4e8e85d8674daa126145134",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.1.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#49c5e80e44306937cb3eaa7afb690b7889de3895",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#fb1eda3772743f755a0e22c954f77470c1c0619a",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.3",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.3.1",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203845335740051/1203845335740051
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0


## Description
Updates Autofill to version [6.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0).

### Autofill 6.2.0 release notes
## What's Changed
* Send autofill pixels on macOS by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/249


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.2...6.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).