### PR TITLE
Fix the Facebook Click to Load request integration tests

### DIFF
--- a/integration-test/background/click-to-load-facebook.js
+++ b/integration-test/background/click-to-load-facebook.js
@@ -111,7 +111,7 @@ describe('Test Facebook Click To Load', () => {
             globalThis.buttons =
                 Array.from(document.querySelectorAll('body > div'))
                     .map(div => div.shadowRoot && div.shadowRoot.querySelector('button'))
-                    .filter(button => button)
+                    .filter(button => button && button.innerText.startsWith('Unblock'))
             return globalThis.buttons.length
         })
         for (let i = 0; i < buttonCount; i++) {


### PR DESCRIPTION
Since we started also protecting Facebook login buttons with a
shadowRoot, the integration tests started clicking the login buttons
as well as the "Unblock ..." buttons. That caused the login overlay to
display which stopped the unblock buttons from working. In turn, that
caused the requests not to be unblocked.

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Check the Facebook Click to Load integration tests pass, and not marked with pending "Timed out waiting for Facebook requests!".

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
