### PR TITLE
Add Email Protection in-context signup support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.5",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.0",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1839,7 +1839,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#49c5e80e44306937cb3eaa7afb690b7889de3895",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#9f0c2eab4223f1f28cced4eac73e4381a8daa35e",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15932,8 +15932,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#49c5e80e44306937cb3eaa7afb690b7889de3895",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.2.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#9f0c2eab4223f1f28cced4eac73e4381a8daa35e",
+            "from": "@duckduckgo/autofill@git+ssh://git@github.com:duckduckgo/duckduckgo-autofill.git#6.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#12d75c8c9fc01cfcdd26448747d7f5493016dad2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "yargs": "^17.6.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.0.5",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.0",
         "@duckduckgo/jsbloom": "^1.0.2",

--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -122,6 +122,13 @@ const fireAddressUsedPixel = (pixel) => {
     updateSetting('lastAddressUsedAt', currentDate())
 }
 
+const fireIncontextSignupPixel = (pixel) => {
+    const browserName = utils.getBrowserName() ?? 'unknown'
+    if (!pixelsEnabled) return
+
+    sendPixelRequest(getFullPixelName(pixel, browserName))
+}
+
 /**
  * Config type definition
  * @typedef {Object} FirePixelOptions
@@ -140,6 +147,18 @@ export const sendJSPixel = (options) => {
         break
     case 'autofill_personal_address':
         fireAddressUsedPixel('email_filled_main_extension')
+        break
+    case 'incontext_show':
+        fireIncontextSignupPixel('incontext_show_extension')
+        break
+    case 'incontext_get_email_protection':
+        fireIncontextSignupPixel('incontext_get_email_protection_extension')
+        break
+    case 'incontext_dismiss_persisted':
+        fireIncontextSignupPixel('incontext_dismiss_persisted_extension')
+        break
+    case 'incontext_dismiss_initial':
+        fireIncontextSignupPixel('incontext_dismiss_initial_extension')
         break
     default:
         console.error('Unknown pixel name', pixelName)

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -301,6 +301,20 @@ export function getEmailProtectionCapabilities (_, sender) {
     }
 }
 
+export function getIncontextSignupDismissedAt () {
+    const initiallyDismissedAt = settings.getSetting('incontextSignupInitiallyDismissedAt')
+    const permanentlyDismissedAt = settings.getSetting('incontextSignupPermanentlyDismissedAt')
+    return { success: { initiallyDismissedAt, permanentlyDismissedAt } }
+}
+
+export function setIncontextSignupInitiallyDismissedAt ({ value }) {
+    settings.updateSetting('incontextSignupInitiallyDismissedAt', value)
+}
+
+export function setIncontextSignupPermanentlyDismissedAt ({ value }) {
+    settings.updateSetting('incontextSignupPermanentlyDismissedAt', value)
+}
+
 // Get user data to be used by the email web app settings page. This includes
 // username, last alias, and a token for generating additional aliases.
 export async function getUserData (_, sender) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

**Depends on:**  https://github.com/duckduckgo/duckduckgo-autofill/pull/243

## Description:
<!-- Explain what is being changed, why, etc -->

- Run `npm install` to updates autofill
- Adds support for in-context signup saving dismissal state information
- Adds support for in-context signup firing pixel data
- In-context signup depends on `incontextSignup` being in the enabled features
  - https://github.com/duckduckgo/privacy-configuration/pull/674


## Steps to test this PR:
1. Build extension (~make sure to enable `incontextSignup` as a feature~ -- already added to features)
2. Go to web page with email field, e.g. https://duckduckgo.com/newsletter
3. Confirm in-context signup tooltip shows
    - This can be used to sign up or log in to an Email Protection account
    - This can be dismissed, and disappears completely on the second dismissal

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203937331479733