### PR TITLE
Hide Email Protection context menu in http://

### DIFF
--- a/shared/js/background/email-utils.es6.js
+++ b/shared/js/background/email-utils.es6.js
@@ -57,6 +57,7 @@ browser.contextMenus.create({
     id: MENU_ITEM_ID,
     title: 'Generate Private Duck Address',
     contexts: ['editable'],
+    documentUrlPatterns: ['https://*/*'],
     visible: false
 }, () => {
     // It's fine if this context menu already exists, suppress that error.


### PR DESCRIPTION
**Reviewer:** @kzar 

## Description:
Hides the Email Protection context menu item in insecure contexts, because autofill is disabled there so the button doesn't work.


## Steps to test this PR:
1. Visit http://privacy-test-pages.glitch.me/autofill/frame-parent.html (note the `http://`)
2. Open the context menu and verify that the Email Protection autofill item is not there
3. Use the `https://` protocol
4. Verify that the context menu item is present and working