### PR TITLE
Reinstate watch command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,8 @@ Run the dev build task for your browser from the 'Build' section above. The gene
 
 After running the build task it will continue watching for changes to any of the source files. After saving any changes to these files it will automatically rebuild the `dev` directory for you.
 
+Note: If you wish to *not* monitor for changes please add watch=0 to your command such as `npm run dev-chrome -- watch=0`. This will require you to build other module changes yourself listed below.
+
 ### Locally testing changes to modules
 
 The extension imports several DDG-owned modules (see [package.json](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/7a5616b5c54155a99f79c672e007785f76a8d3ee/package.json#L75-L78)). If you need to locally test changes to these modules follow these steps.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,7 @@ module.exports = function (grunt) {
     let contentScopeInstall = 'echo "Skipping content-scope-scripts install";'
     let contentScopeBuild = 'echo "Skipping content-scope-scripts build";'
     // If we're watching the content scope files, regenerate them
-    if (grunt.option('watch')) {
+    if (Number(grunt.option('monitor'))) {
         contentScopeInstall = `cd ${ddgContentScope} && npm install --legacy-peer-deps`
         contentScopeBuild = `cd ${ddgContentScope} && npm run build && cd -`
     }
@@ -288,7 +288,7 @@ module.exports = function (grunt) {
     ])
 
     const devTasks = ['build']
-    if (grunt.option('watch')) {
+    if (Number(grunt.option('monitor'))) {
         devTasks.push('watch')
     }
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ grunt-dev:
 	mkdir -p build/$(browser)/dev/test/html
 	cp -r shared/img build/$(browser)/dev/test/html
 	cp -r shared/data build/$(browser)/dev/test/html
-	grunt dev --browser=$(browser) --type=$(type)
+	grunt dev --browser=$(browser) --type=$(type) --monitor=$(watch)
 
 setup-artifacts-dir:
 	rm -rf integration-test/artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -15914,7 +15914,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#04f7d05a6eee06ff03c2f466e80109806c81f68e",
             "integrity": "sha512-Y6DU83fWba/9HWtEvtw2dVP1diGu+L3PuIRg6ZKqGyXDfD5P1oFTe0069f+e5t2fo8Zc0l0XsCOxA/1oyOmO1A==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#04f7d05a6eee06ff03c2f466e80109806c81f68e"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#1.4.1"
         },
         "@duckduckgo/privacy-grade": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-grade.git#241537876de9852006e82a88d8354da20609d92b",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:

- Reinstates the watch command as 'monitor' internally. No other changes needed to dev flows.
- Externally presenting it as watch=1 and 0 still.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
