### PR TITLE
Do not create release as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          draft: true
+          draft: false
           prerelease: false
           body: "${{ steps.changelog.outputs.changelog }}\n\n${{ env.BUILT_WITH }}"
           tag_name: ${{ env.VERSION }}


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Make a full release when running the release pipeline.

This change is because, when we create a draft release, the tag is only created when someone publishes that draft. This means that, unless the draft is published immediately, the tag will be incorrect. This is especially problematic when we use the Github release to download source for extension release, as if the tag commit is wrong, it will not reproduce the same build.