### PR TITLE
Remove some more old Click to Load code

### DIFF
--- a/shared/js/background/dnr-click-to-load.js
+++ b/shared/js/background/dnr-click-to-load.js
@@ -1,7 +1,6 @@
 import { getNextSessionRuleId } from './dnr-session-rule-id'
 import settings from './settings.es6'
 import tdsStorage from './storage/tds.es6'
-import * as utils from './utils.es6'
 
 /**
  * Generates the declarativeNetRequest allowing rules required to disable the
@@ -78,7 +77,7 @@ async function generateDnrAllowingRules (tab, ruleAction) {
  */
 export function getDefaultEnabledClickToLoadRuleActionsForTab (tab) {
     // Click to Load feature isn't supported or is disabled for the tab.
-    if (!utils.getClickToLoadSupport(tab)) {
+    if (!tab?.site?.isFeatureEnabled('clickToPlay')) {
         return []
     }
 

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -143,8 +143,6 @@ export function getTopBlockedByPages (options) {
 
 /**
  * @typedef getClickToLoadStateResponse
- * @property {Object} clickToLoadClicks
- *   [DEPRECATED] Empty Object.
  * @property {boolean} devMode
  *   True if developer mode is enabled (e.g. this is a development build or a
  *   test run), false if this is a release build.
@@ -157,10 +155,6 @@ export function getTopBlockedByPages (options) {
  * @returns {Promise<getClickToLoadStateResponse>}
  */
 export async function getClickToLoadState () {
-    // TODO: Remove clickToLoadClicks once corresponding content-scope-scripts
-    //       changes are made.
-    const clickToLoadClicks = {}
-
     const devMode =
         (await browserWrapper.getFromSessionStorage('dev')) || false
 
@@ -168,7 +162,7 @@ export async function getClickToLoadState () {
     const youtubePreviewsEnabled =
         (await settings.getSetting('youtubePreviewsEnabled')) || false
 
-    return { clickToLoadClicks, devMode, youtubePreviewsEnabled }
+    return { devMode, youtubePreviewsEnabled }
 }
 
 export async function getYouTubeVideoDetails (videoURL) {

--- a/shared/js/background/utils.es6.js
+++ b/shared/js/background/utils.es6.js
@@ -194,13 +194,6 @@ export function getUpgradeToSecureSupport () {
     return canUpgrade
 }
 
-export function getClickToLoadSupport (tab) {
-    if (getBrowserName() === 'moz' && browserInfo && browserInfo.version <= 88) {
-        return false
-    }
-    return (tab && tab.site.isFeatureEnabled('clickToPlay'))
-}
-
 // return true if browser allows to handle request async
 export function getAsyncBlockingSupport () {
     const browserName = getBrowserName()


### PR DESCRIPTION
Remove some more old Click to Load code

In the past, we needed to disable the Click to Load feature for
Firefox versions <= 88. Since our minimum supported version is now
91[1], this check can be removed.

Also, the deprecated clickToLoadClicks field has been removed[2] from
the "getClickToLoadState" response handler in content-scope-scripts,
so that can be removed too.

1 - https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/3a23810d164e9bd17823d0cecc79f7731a8290ce/browsers/firefox/manifest.json#L6
2 - https://github.com/duckduckgo/content-scope-scripts/commit/cec60d47bd0c6881ddb9b0643d40f9a5efef1e29#diff-658f5706013e4033baa9dd3e8885fcbd34cf73ea331a3bfd34764a39b0d0186aR1317-R1318

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Check Click to Load still works (e.g. on [the Facebook test page](https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/).)

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
