### PR TITLE
Trigger refresh of Click to Load placeholders on request block

### DIFF
--- a/integration-test/config.json
+++ b/integration-test/config.json
@@ -2,6 +2,7 @@
     "spec_dir": "integration-test",
     "spec_files": [
         "legacy/*.js",
-        "content-scripts/gpc.js"
+        "content-scripts/gpc.js",
+        "!legacy/click-to-load-youtube.js"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
+                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",
@@ -1861,8 +1861,7 @@
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60b9a4c2bbafe45f5d6fd1a5fa5389e5c133730a",
-            "integrity": "sha512-CCtHb/Wlxv8KyQG2RlL90+kws+zNqvYuLKuiwaSXHA1gYdfCi89R6qwslGWpILoggStK0UWspHUNiXcIEDmwcA==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5434ffe98a21256187700d7c142a00b12336a952",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -16352,9 +16351,8 @@
             "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
-            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60b9a4c2bbafe45f5d6fd1a5fa5389e5c133730a",
-            "integrity": "sha512-CCtHb/Wlxv8KyQG2RlL90+kws+zNqvYuLKuiwaSXHA1gYdfCi89R6qwslGWpILoggStK0UWspHUNiXcIEDmwcA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#60b9a4c2bbafe45f5d6fd1a5fa5389e5c133730a",
+            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5434ffe98a21256187700d7c142a00b12336a952",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.3.3",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     },
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",

--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -18,8 +18,9 @@ const {
 } = require('./url-parameters')
 const ampProtection = require('./amp-protection')
 const {
+    displayClickToLoadPlaceholders,
     getDefaultEnabledClickToLoadRuleActionsForTab
-} = require('./dnr-click-to-load')
+} = require('./click-to-load')
 
 function buildResponse (url, requestData, tab, isMainFrame) {
     if (url.toLowerCase() !== requestData.url.toLowerCase()) {
@@ -255,6 +256,10 @@ function blockHandleResponse (thisTab, requestData) {
     const serviceWorkerInitiated = requestData.tabId === -1
 
     if (tracker) {
+        if (tracker?.matchedRule?.action?.startsWith('block-ctl-')) {
+            displayClickToLoadPlaceholders(thisTab, tracker.matchedRule.action)
+        }
+
         // temp allowlisted trackers to fix site breakage
         if (thisTab.site.isFeatureEnabled('trackerAllowlist')) {
             const allowListed = trackerAllowlist(thisTab.site.url, requestData.url)

--- a/shared/js/background/click-to-load.js
+++ b/shared/js/background/click-to-load.js
@@ -1,0 +1,69 @@
+import tdsStorage from './storage/tds'
+import { sendTabMessage } from './utils'
+
+/**
+ * Find the enabled Click to Load rule actions for the given tab.
+ * Note: Take care to ensure wait for the extension configuration to be ready
+ *       first.
+ * @param {import('./classes/tab')} tab
+ * @return {string[]}
+ */
+export function getDefaultEnabledClickToLoadRuleActionsForTab (tab) {
+    // Click to Load feature isn't supported or is disabled for the tab.
+    if (!tab?.site?.isFeatureEnabled('clickToPlay')) {
+        return []
+    }
+
+    const clickToLoadSettings =
+        tdsStorage?.config?.features?.clickToPlay?.settings
+
+    // Click to Load configuration isn't ready yet.
+    if (!clickToLoadSettings) {
+        console.warn('Click to Load configuration not ready yet, skipped.')
+        return []
+    }
+
+    const enabledRuleActions = []
+    const { parentEntity } = tab.site
+
+    for (let [entity, { ruleActions, state }] of Object.entries(clickToLoadSettings)) {
+        // No rule actions, or entity is disabled.
+        if (!ruleActions || ruleActions.length === 0 || state !== 'enabled') {
+            continue
+        }
+
+        // TODO: Remove this workaround once the content-scope-scripts and
+        //       privacy-configuration repositories have been updated.
+        if (entity === 'Facebook') entity = 'Facebook, Inc.'
+
+        // Enabled Click to Load entity is third-party for this tab, note its
+        // rule actions.
+        if (parentEntity !== entity) {
+            enabledRuleActions.push(...ruleActions)
+        }
+    }
+
+    return enabledRuleActions
+}
+
+/**
+ * Triggers a refresh of the Click to Load placeholders for the given tab.
+ * @param {import('./classes/tab')} tab
+ * @param {string} [ruleAction]
+ *   If provided, only placeholders associated with the entity containing that
+ *   rule action will be refreshed. By default, all placeholders will be
+ *   refreshed.
+ */
+export async function displayClickToLoadPlaceholders (tab, ruleAction) {
+    const message = {
+        type: 'update',
+        feature: 'clickToLoad',
+        messageType: 'displayClickToLoadPlaceholders',
+        options: { }
+    }
+    if (typeof ruleAction === 'string') {
+        message.options.ruleAction = ruleAction
+    }
+
+    await sendTabMessage(tab.id, message)
+}

--- a/shared/js/background/dnr-click-to-load.js
+++ b/shared/js/background/dnr-click-to-load.js
@@ -1,3 +1,4 @@
+import { getDefaultEnabledClickToLoadRuleActionsForTab } from './click-to-load'
 import { getNextSessionRuleId } from './dnr-session-rule-id'
 import settings from './settings'
 import tdsStorage from './storage/tds'
@@ -66,51 +67,6 @@ async function generateDnrAllowingRules (tab, ruleAction) {
     }
 
     return allowingRules
-}
-
-/**
- * Find the enabled Click to Load rule actions for the given tab.
- * Note: Take care to ensure wait for the extension configuration to be ready
- *       first.
- * @param {import('./classes/tab')} tab
- * @return {string[]}
- */
-export function getDefaultEnabledClickToLoadRuleActionsForTab (tab) {
-    // Click to Load feature isn't supported or is disabled for the tab.
-    if (!tab?.site?.isFeatureEnabled('clickToPlay')) {
-        return []
-    }
-
-    const clickToLoadSettings =
-        tdsStorage?.config?.features?.clickToPlay?.settings
-
-    // Click to Load configuration isn't ready yet.
-    if (!clickToLoadSettings) {
-        console.warn('Click to Load configuration not ready yet, skipped.')
-        return []
-    }
-
-    const enabledRuleActions = []
-    const { parentEntity } = tab.site
-
-    for (let [entity, { ruleActions, state }] of Object.entries(clickToLoadSettings)) {
-        // No rule actions, or entity is disabled.
-        if (!ruleActions || ruleActions.length === 0 || state !== 'enabled') {
-            continue
-        }
-
-        // TODO: Remove this workaround once the content-scope-scripts and
-        //       privacy-configuration repositories have been updated.
-        if (entity === 'Facebook') entity = 'Facebook, Inc.'
-
-        // Enabled Click to Load entity is third-party for this tab, note its
-        // rule actions.
-        if (parentEntity !== entity) {
-            enabledRuleActions.push(...ruleActions)
-        }
-    }
-
-    return enabledRuleActions
 }
 
 /**


### PR DESCRIPTION
Historically, the Click to Load placeholders were only drawn once at
the point page load completed. That had two problems:
1. Sometimes placeholders would take too long to display, if the page
   took a long time to load fully.
2. Sometimes placeholders would not be displayed at all, if the
   blocked content was only created after page load had finished.

To fix that, let's send a message to the content-scope-script to
ensure that placeholders are refreshed each time a Click to Load
request is blocked.

Also tweak the response messages to be inline with the recent
content-scope-script changes to make response messages easier to
identify.

Unfortunately the YouTube Click to Load integration tests need to be
disabled for now, since we had to disable the "hideTrackingElement"
option for now which breaks some of the YouTube SDK integration.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @ladamski 
**CC:** @franfaccin 

## Steps to test this PR:
0. [These changes depends on these content-scope-scripts changes.](https://github.com/duckduckgo/content-scope-scripts/pull/287)

1. Open the options page, change "options.html" in the URL to "devtools-panel.html", click the tiny config icon in the top-right, select "config" in the drop-down, search for "clickToPlay" and add update the config to enable YouTube Click to Load:

```json
    "clickToPlay": {
      "exceptions": [],
      "settings": {
        "Facebook": {
          "ruleActions": [
            "block-ctl-fb"
          ],
          "state": "enabled"
        },
        "Youtube": {
          "ruleActions": [
            "block-ctl-yt"
          ],
          "state": "enabled"
        }
      }
    }
```
2. [Navigate to this post](https://merveilles.town/@tendigits/109320044343105659) and click to play the video. Ensure the Click to Load placeholder is displayed. (Ignore styling issues, that's unrelated.)
3. [Navigate to the YouTube test page](https://privacy-test-pages.glitch.me/privacy-protections/youtube-click-to-load/). Ensure the placeholders are displayed immediately, not after a long pause. (Ignore placeholders being displayed twice, or load button not working. Those are unrelated issues.)
4. [Navigate to the Facebook test page](https://privacy-test-pages.glitch.me/privacy-protections/click-to-load/) and ensure Facebook Click to Load works correctly still.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
