### PR TITLE
Ensure only enabled+supported feature configs are passed to ddg2dnr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.1.1",
-                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.0",
+                "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",
                 "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.3",
@@ -1855,7 +1855,7 @@
             }
         },
         "node_modules/@duckduckgo/ddg2dnr": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#71126cb74ef53f0ff1a0b7f5cb7c7df3f4a2fd6d",
+            "resolved": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#8060ca97c25d75cdc0ef71e128cefef0cd0a8a21",
             "license": "Apache-2.0",
             "bin": {
                 "ddg2dnr": "cli.js"
@@ -15917,8 +15917,8 @@
             }
         },
         "@duckduckgo/ddg2dnr": {
-            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#71126cb74ef53f0ff1a0b7f5cb7c7df3f4a2fd6d",
-            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.4.0"
+            "version": "git+ssh://git@github.com/duckduckgo/ddg2dnr.git#8060ca97c25d75cdc0ef71e128cefef0cd0a8a21",
+            "from": "@duckduckgo/ddg2dnr@github:duckduckgo/ddg2dnr#0.4.1"
         },
         "@duckduckgo/jsbloom": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.1.1",
-        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.0",
+        "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",
         "@duckduckgo/privacy-grade": "github:duckduckgo/privacy-grade#2.1.3",

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -31,7 +31,7 @@ import {
 } from '@duckduckgo/ddg2dnr/lib/rulePriorities'
 
 const TEST_ETAGS = ['flib', 'flob', 'cabbage']
-const TEST_EXTENION_VERSIONS = ['0.1', '0.2', '0.3']
+const TEST_EXTENION_VERSIONS = ['2023.1.1', '2023.2.1', '2023.3.1']
 
 let onUpdateListeners
 


### PR DESCRIPTION
Since the ddg2dnr library does not enforce "minSupportedVersion"
option for features in the extension-config.json configuration, let's
take care to remove disabled and unsupported features from the
configuration before passing it to ddg2dnr.

**Reviewer:** @sammacbeth 
**Cc:** @jdorweiler 

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
