### PR TITLE
Fix typo in integration test configuration

### DIFF
--- a/integration-test/config-mv3.json
+++ b/integration-test/config-mv3.json
@@ -3,6 +3,6 @@
     "spec_files": [
         "legacy/*.js",
         "content-scripts/gpc.js",
-        "!background/click-to-load-youtube.js"
+        "!legacy/click-to-load-youtube.js"
     ]
 }


### PR DESCRIPTION
The Click to Load YouTube integration tests do not yet work for Chrome
MV3 builds of the extension. Unfortunately, while migrating our
integration tests to Playwright, we introduced a typo that started
the tests running anyway. Let's fix that typo, so the tests don't keep
running and failing.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
