### PR TITLE
Improve logPageRequests integration test helper

### DIFF
--- a/integration-test/helpers/requests.js
+++ b/integration-test/helpers/requests.js
@@ -87,8 +87,9 @@ async function logPageRequests (page, requests, filter) {
         requestId, blockedReason, errorText
     }) => {
         saveRequestOutcome(requestId, details => {
-            if (blockedReason === 'other' &&
-                errorText === 'net::ERR_BLOCKED_BY_CLIENT') {
+            if ((blockedReason === 'other' &&
+                 errorText === 'net::ERR_BLOCKED_BY_CLIENT') ||
+                (!blockedReason && errorText === 'net::ERR_ABORTED')) {
                 details.status = 'blocked'
             } else {
                 details.status = 'failed'


### PR DESCRIPTION
It turns out that if the extension blocks a request, but then replaces
the corresponding element very quickly afterwards, Puppeteer will
report the request as 'net::ERR_ABORTED' instead of
'net::ERR_BLOCKED_BY_CLIENT'. Let's consider both as blocked, for the
purposes of the integration tests.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 
**CC:** @ladamski 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. just check that the Click to Load integration tests still work.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
