### PR TITLE
Switch Click to Load to the "clickToLoad" feature name

### DIFF
--- a/integration-test/data/configs/click-to-load-facebook.json
+++ b/integration-test/data/configs/click-to-load-facebook.json
@@ -1,14 +1,19 @@
 {
-    "globalThis.dbg.tds.config.features.clickToPlay": {
+    "globalThis.dbg.tds.config.features.clickToLoad": {
         "state": "enabled",
         "exceptions": [],
         "settings": {
-            "Facebook": {
+            "Facebook, Inc.": {
                 "ruleActions": [
                     "block-ctl-fb"
                 ],
                 "state": "enabled"
             }
         }
+    },
+    "globalThis.dbg.tds.config.features.clickToPlay": {
+        "state": "disabled",
+        "exceptions": [],
+        "settings": { }
     }
 }

--- a/integration-test/data/configs/click-to-load-youtube.json
+++ b/integration-test/data/configs/click-to-load-youtube.json
@@ -1,5 +1,5 @@
 {
-    "globalThis.dbg.tds.config.features.clickToPlay": {
+    "globalThis.dbg.tds.config.features.clickToLoad": {
         "state": "enabled",
         "exceptions": [ ],
         "settings": {
@@ -10,5 +10,10 @@
                 ]
             }
         }
+    },
+    "globalThis.dbg.tds.config.features.clickToPlay": {
+        "state": "disabled",
+        "exceptions": [],
+        "settings": { }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
+                "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.4",
                 "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
                 "@duckduckgo/jsbloom": "^1.0.2",
                 "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",
@@ -1853,7 +1853,7 @@
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5434ffe98a21256187700d7c142a00b12336a952",
+            "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c186382e9a3658f02bdbd4ac5919d95f7d0dc99d",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1890,8 +1890,7 @@
             }
         },
         "node_modules/@duckduckgo/privacy-reference-tests": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#5a7ea321332f60aec9fa6395ad85098edc87e93e",
-            "integrity": "sha512-9VGO9aBUdBBchrin9Zb2UkQFYwoWzNgE0F7d0NLeDHs0/UHgjazIQYqh1p/gRwmtr/RbN2/I45MnXSeeXyYJfQ==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7b4ad91de2d67123d4b5d10ccb3ac0565abfd355",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/tracker-surrogates": {
@@ -15827,8 +15826,8 @@
             "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
-            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5434ffe98a21256187700d7c142a00b12336a952",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.3.3",
+            "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c186382e9a3658f02bdbd4ac5919d95f7d0dc99d",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.3.4",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -15856,8 +15855,7 @@
             }
         },
         "@duckduckgo/privacy-reference-tests": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#5a7ea321332f60aec9fa6395ad85098edc87e93e",
-            "integrity": "sha512-9VGO9aBUdBBchrin9Zb2UkQFYwoWzNgE0F7d0NLeDHs0/UHgjazIQYqh1p/gRwmtr/RbN2/I45MnXSeeXyYJfQ==",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7b4ad91de2d67123d4b5d10ccb3ac0565abfd355",
             "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     },
     "dependencies": {
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.4",
         "@duckduckgo/ddg2dnr": "github:duckduckgo/ddg2dnr#0.4.1",
         "@duckduckgo/jsbloom": "^1.0.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.1",

--- a/shared/js/background/click-to-load.js
+++ b/shared/js/background/click-to-load.js
@@ -10,12 +10,12 @@ import { sendTabMessage } from './utils'
  */
 export function getDefaultEnabledClickToLoadRuleActionsForTab (tab) {
     // Click to Load feature isn't supported or is disabled for the tab.
-    if (!tab?.site?.isFeatureEnabled('clickToPlay')) {
+    if (!tab?.site?.isFeatureEnabled('clickToLoad')) {
         return []
     }
 
     const clickToLoadSettings =
-        tdsStorage?.config?.features?.clickToPlay?.settings
+        tdsStorage?.config?.features?.clickToLoad?.settings
 
     // Click to Load configuration isn't ready yet.
     if (!clickToLoadSettings) {
@@ -26,15 +26,11 @@ export function getDefaultEnabledClickToLoadRuleActionsForTab (tab) {
     const enabledRuleActions = []
     const { parentEntity } = tab.site
 
-    for (let [entity, { ruleActions, state }] of Object.entries(clickToLoadSettings)) {
+    for (const [entity, { ruleActions, state }] of Object.entries(clickToLoadSettings)) {
         // No rule actions, or entity is disabled.
         if (!ruleActions || ruleActions.length === 0 || state !== 'enabled') {
             continue
         }
-
-        // TODO: Remove this workaround once the content-scope-scripts and
-        //       privacy-configuration repositories have been updated.
-        if (entity === 'Facebook') entity = 'Facebook, Inc.'
 
         // Enabled Click to Load entity is third-party for this tab, note its
         // rule actions.

--- a/unit-test/data/extension-config.json
+++ b/unit-test/data/extension-config.json
@@ -107,11 +107,11 @@
             },
             "exceptions": []
         },
-        "clickToPlay": {
+        "clickToLoad": {
             "state": "enabled",
             "exceptions": [],
             "settings": {
-                "Facebook": {
+                "Facebook, Inc.": {
                     "state": "enabled",
                     "ruleActions": ["block-ctl-fb"]
                 }


### PR DESCRIPTION
Initially the Click to Load feature was misnamed "clickToPlay". Also
the Facebook entity name was inconsistently called either "Facebook"
or "Facebook, Inc.". We have corrected those the extension
configuration, content-scope-scripts and the reference tests. Let's
update those dependencies and make the necessary extension changes
here.

**Reviewer:** @ladamski 
**CC:** @kdzwinel 

## Testing
1. Ensure the unit tests still pass.
2. Ignore if Facebook integration tests are marked pending, Sam has a follow-up to switch to Playwright for those.
3. Edit the configuration and check the "clickToLoad" feature controls Facebook/YouTube Click to Load, instead of the "clickToPlay" feature.
4. Smoke test Click to Load still works.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
