### PR TITLE
Fix C-S-S copy step to avoid copying unnecessary files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ watch:
 unit-test: build/test/background.js build/test/ui.js build/test/shared-utils.js
 	$(KARMA) start karma.conf.js
 
-shared/content-scope-scripts: node_modules/@duckduckgo/content-scope-scripts
-	cp -r node_modules/@duckduckgo/content-scope-scripts shared/
+shared/content-scope-scripts: node_modules/@duckduckgo/content-scope-scripts $(shell find node_modules/@duckduckgo/content-scope-scripts/src -type f)
+	rsync -av node_modules/@duckduckgo/content-scope-scripts/ shared/content-scope-scripts --include="lib/***" --include="src/***" --exclude="*"
 
 .PHONY: unit-test
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ unit-test: build/test/background.js build/test/ui.js build/test/shared-utils.js
 	$(KARMA) start karma.conf.js
 
 shared/content-scope-scripts: node_modules/@duckduckgo/content-scope-scripts $(shell find node_modules/@duckduckgo/content-scope-scripts/src -type f)
-	rsync -av node_modules/@duckduckgo/content-scope-scripts/ shared/content-scope-scripts --include="lib/***" --include="src/***" --exclude="*"
+	rsync -a node_modules/@duckduckgo/content-scope-scripts/ shared/content-scope-scripts --include="lib/***" --include="src/***" --exclude="*"
+
+shared/content-scope-scripts/lib/%: shared/content-scope-scripts
+shared/content-scope-scripts/src/%: shared/content-scope-scripts
 
 .PHONY: unit-test
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fixes an issue since #1735 when developing with content-scope-scripts. This change limits what gets copied to `shared/content-scope/scripts` so this doesn't pollute the workspace and break other build targets.

Note, you may need to run `make clean` to remove your existing `shared/content-scope-scripts` folder for this change to fix your local copy.

## Steps to test this PR:
1. `npm ci`
2. `cd /path/to/content-scope-scripts && npm ci && npm link`
3. `cd /path/to/extension`
4. `npm link @duckduckgo/content-scope-scripts`
5. `npm test`
6. `npm run dev-chrome`

These steps should complete as expected with no errors.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
