### PR TITLE
Display Click to Load YouTube settings if feature is enabled

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -3,7 +3,7 @@ import { dashboardDataFromTab } from './classes/privacy-dashboard-data'
 import { breakageReportForTab } from './broken-site-report'
 import parseUserAgentString from '../shared-utils/parse-user-agent-string'
 import { getExtensionURL, notifyPopup } from './wrapper'
-import { reloadCurrentTab } from './utils'
+import { isFeatureEnabled, reloadCurrentTab } from './utils'
 import { ensureClickToLoadRuleActionDisabled } from './dnr-click-to-load'
 const { getDomain } = require('tldts')
 const utils = require('./utils')
@@ -412,4 +412,13 @@ export function search ({ term }) {
 
 export function openShareFeedbackPage () {
     return browserWrapper.openExtensionPage('/html/feedback.html')
+}
+
+export async function isClickToLoadYoutubeEnabled () {
+    await tdsStorage.ready('config')
+
+    return (
+        isFeatureEnabled('clickToLoad') &&
+        tdsStorage?.config?.features?.clickToLoad?.settings?.Youtube?.state === 'enabled'
+    )
 }

--- a/shared/js/ui/models/privacy-options.js
+++ b/shared/js/ui/models/privacy-options.js
@@ -5,6 +5,7 @@ function PrivacyOptions (attrs) {
     attrs.httpsEverywhereEnabled = true
     attrs.embeddedTweetsEnabled = false
     attrs.GPC = false
+    attrs.youtubeClickToLoadEnabled = false
     attrs.youtubePreviewsEnabled = false
 
     Parent.call(this, attrs)
@@ -24,18 +25,17 @@ PrivacyOptions.prototype = window.$.extend({},
             }
         },
 
-        getSettings: function () {
-            const self = this
-            return new Promise((resolve, reject) => {
-                self.sendMessage('getSetting', 'all').then((settings) => {
-                    self.httpsEverywhereEnabled = settings.httpsEverywhereEnabled
-                    self.embeddedTweetsEnabled = settings.embeddedTweetsEnabled
-                    self.GPC = settings.GPC
-                    self.youtubePreviewsEnabled = settings.youtubePreviewsEnabled
+        async getState () {
+            const [settings, youtubeClickToLoadEnabled] = await Promise.all([
+                this.sendMessage('getSetting', 'all'),
+                this.sendMessage('isClickToLoadYoutubeEnabled')
+            ])
 
-                    resolve()
-                })
-            })
+            this.httpsEverywhereEnabled = settings.httpsEverywhereEnabled
+            this.embeddedTweetsEnabled = settings.embeddedTweetsEnabled
+            this.GPC = settings.GPC
+            this.youtubeClickToLoadEnabled = youtubeClickToLoadEnabled
+            this.youtubePreviewsEnabled = settings.youtubePreviewsEnabled
         }
     }
 )

--- a/shared/js/ui/templates/privacy-options.js
+++ b/shared/js/ui/templates/privacy-options.js
@@ -36,8 +36,7 @@ module.exports = function () {
             </p>
         </li>
     </ul>
-    <!-- TODO: Remove content when YouTube CTL is live
-    <ul class="default-list">
+    <ul class="default-list${this.model.youtubeClickToLoadEnabled ? '' : ' is-hidden'}">
         <li>
             <h2 class="menu-title">
                 ${t('options:enableYoutubePreviews.title')}
@@ -49,6 +48,5 @@ module.exports = function () {
             </p>
         </li>
     </ul>
-    -->
 </section>`
 }

--- a/shared/js/ui/views/privacy-options.js
+++ b/shared/js/ui/views/privacy-options.js
@@ -7,7 +7,7 @@ function PrivacyOptions (ops) {
 
     Parent.call(this, ops)
 
-    this.model.getSettings().then(() => {
+    this.model.getState().then(() => {
         this.rerender()
     })
 }


### PR DESCRIPTION
The Click to Load YouTube feature has a settings in the options page,
so that the user can configure video previews. Let's start displaying
that, but only if the feature is enabled.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @franfaccin 

## Steps to test this PR:
1. Open the options page and check the YouTube preview setting _isn't_ visible.
2. Enable YouTube Click to Load (change "options.html" in options page URL to "devtools-panel.html", select the tiny config icon at top left, select "config" in drop down, search for "clickToLoad" and set "Youtube" state to "enabled".
3. Open options page again, and check the setting is visible.
4. Test toggling the setting to ensure previews are disabled/enabled (you can use [the test page](https://privacy-test-pages.glitch.me/privacy-protections/youtube-click-to-load/) here).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
