### PR TITLE
Fix source maps for development builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ ITEMS   := shared/html shared/data shared/img
 SASS = node_modules/.bin/sass
 BROWSERIFY_BIN = node_modules/.bin/browserify
 BROWSERIFY = $(BROWSERIFY_BIN) -t babelify
+ifeq ($(type),dev)
+	BROWSERIFY += -d
+endif
 KARMA = node_modules/.bin/karma
 
 ###--- Variables ---###


### PR DESCRIPTION
Let's have Browserify generate source maps again for development
builds, they make debugging the code a lot easier. But let's keep them
off for production builds, since the background.js bundle grows from
~2 MB to ~5 MB when we add them.

**Reviewer:** @sammacbeth 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
