### PR TITLE
Ensure Makefile notices changes to our other repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_DIR = build/$(browser)/$(type)
 ifeq ($(browser),test)
 	BUILD_DIR := build/test
 endif
-SOURCE_FILES = $(shell find shared/ -type f)
+SOURCE_FILES = $(shell find shared/ packages/ node_modules/@duckduckgo/ -type f)
 TEST_FILES = $(shell find unit-test/ -type f)
 
 ###--- Top level targets ---###


### PR DESCRIPTION
The Makefile is set up to notice changes to the code, rebuilding as
necessary. Let's also have it watch for changes to our other
repositories (under node_modules/@duckduckgo/) and repositories that
have been combined with this one (under packages/).

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Run `make dev browser=chrome type=dev` twice.
2. It should say "make: Nothing to be done for 'dev'."
3. Edit a file under `packages/privacy-grade` or `node_modules/@duckduckgo/*`
4. Run `make dev browser=chrome type=dev` and ensure the bundles are rebuilt.
 
## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
