### PR TITLE
Improve output when watching for changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ dev: $(BUILD_DIR)/public/js copy sass js
 ## watch: rebuild when changes are made
 MAKE = make -j4 $(type) browser=$(browser) type=$(type)
 watch:
-	while true; do $(MAKE) -q || $(MAKE); sleep 1; done
+	$(MAKE)
+	@echo "\n** Build ready -  Watching for changes **\n"
+	while true; do $(MAKE) -q --silent || $(MAKE); sleep 1; done
 
 .PHONY: release dev
 


### PR DESCRIPTION
Commands such as `npm run dev-chrome` call something like `make watch
browser=chrome type=dev` under the hood. The CLI output was a little
confusing, since it wasn't clear when the initial build had
finished. Let's improve that by keeping make silent until there are
changes, and displaying a clear "Build ready -  Watching for changes"
message.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Run `npm run dev-chrome` and check the output makes sense.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
