### PR TITLE
Revert "Ensure Makefile notices changes to our other repositories"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_DIR = build/$(browser)/$(type)
 ifeq ($(browser),test)
 	BUILD_DIR := build/test
 endif
-SOURCE_FILES = $(shell find shared/ packages/ node_modules/@duckduckgo/ -type f)
+SOURCE_FILES = $(shell find shared/ -type f)
 TEST_FILES = $(shell find unit-test/ -type f)
 
 ###--- Top level targets ---###


### PR DESCRIPTION
Reverts duckduckgo/duckduckgo-privacy-extension#1774

This has broken the build on mac.