### PR TITLE
Avoid Make watching for changes to packages/*/node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_DIR = build/$(browser)/$(type)
 ifeq ($(browser),test)
 	BUILD_DIR := build/test
 endif
-SOURCE_FILES = $(shell find shared/ packages/ node_modules/@duckduckgo/ -type f)
+SOURCE_FILES = $(shell find shared/ packages/ node_modules/@duckduckgo/ -type f -not -path "packages/*/node_modules/*")
 TEST_FILES = $(shell find unit-test/ -type f)
 
 ###--- Top level targets ---###


### PR DESCRIPTION
It turns out that including packages/privacy-grade/node_modules caused
builds to break on macOS when some temporary Puppeteer files were
included by mistake. Let's exclude node_modules for packages/.

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
