### PR TITLE
Fix Chrome build targets after make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,16 +156,20 @@ ifeq ($(browser),chrome-mv3)
 endif
 
 ## Copy tasks: Copying resources that don't need and compiling
-$(BUILD_DIR)/manifest.json: browsers/$(browser)/*
-	cp -r browsers/$(browser)/* $(BUILD_DIR)
+$(BUILD_DIR)/manifest.json: browsers/$(browser)/*.json
+	mkdir -p `dirname $@`
+	cp browsers/$(browser)/*.json $(BUILD_DIR)
 
 build/chrome-mv3/$(type)/managed-schema.json: browsers/chrome/managed-schema.json
+	mkdir -p `dirname $@`
 	cp $< $@
 
 $(BUILD_DIR)/_locales: browsers/chrome/_locales
+	mkdir -p `dirname $@`
 	cp -r $< $@
 
 $(BUILD_DIR)/data: $(ITEMS)
+	mkdir -p `dirname $@`
 	cp -r $(ITEMS) $(BUILD_DIR)
 
 $(BUILD_DIR)/dashboard: $(DASHBOARD_DIR)/
@@ -178,13 +182,16 @@ $(BUILD_DIR)/data/surrogates.txt: $(BUILD_DIR)/web_accessible_resources
 	node scripts/generateListOfSurrogates.js -i $</ > $@
 
 $(BUILD_DIR)/public/font: shared/font
+	mkdir -p `dirname $@`
 	cp -r $< $@
 
 # Copy autofill scripts and assets
 $(BUILD_DIR)/public/js/content-scripts/autofill.js: $(AUTOFILL_DIR)/autofill.js
+	mkdir -p `dirname $@`
 	cp $(AUTOFILL_DIR)/*.js `dirname $@`
 
 $(BUILD_DIR)/public/css/autofill.css: $(AUTOFILL_DIR)/autofill.css
+	mkdir -p `dirname $@`
 	cp $< $@
 
 $(BUILD_DIR)/public/css/autofill-host-styles.css: $(AUTOFILL_DIR)/autofill-host-styles_$(BROWSER_TYPE).css


### PR DESCRIPTION
The manifest.json target in the Makefile copied the locales/ directory
for the chrome target. That clashed with the $(BUILD_DIR)/_locales
target, causing the first chrome build to fail after a `make clean`.

Another issue, was that for chrome-mv3 target some of the required
directories weren't ready in time for the first build after a `make
clean`.

These targets probably need to be tidied up, but as a workaround let's
ensure that only the browsers/BROWSER/*.json files are copied for the
manifest.json target, and that the prerequisite directories are
created for the other problematic targets.

**Reviewer:** @sammacbeth 
**CC:** @jdorweiler 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. `make clean && make dev browser=chrome type=dev`
3. `make clean && make dev browser=chrome-mv3 type=dev`
5.  Ensure builds are created first time, without errors.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
