### PR TITLE
Fix importing ES Module imports when our other repositories are symlinked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 ITEMS   := shared/html shared/data shared/img
 
+# Workaround Browserify not following symlinks in --only.
+# TODO: Remove this once Browserify has been replaced with a different bundler.
+BROWSERIFY_GLOBAL_TARGETS = ./node_modules/@duckduckgo
+BROWSERIFY_GLOBAL_TARGETS += $(shell find node_modules/@duckduckgo/ -maxdepth 1 -type l | xargs -n1 readlink -f)
+
 ###--- Binaries ---###
 SASS = node_modules/.bin/sass
 BROWSERIFY_BIN = node_modules/.bin/browserify
-BROWSERIFY = $(BROWSERIFY_BIN) -t babelify -t [ babelify --global  --only [ ./node_modules/@duckduckgo ] --presets [ @babel/preset-env ] ]
+BROWSERIFY = $(BROWSERIFY_BIN) -t babelify -t [ babelify --global  --only [ $(BROWSERIFY_GLOBAL_TARGETS) ] --presets [ @babel/preset-env ] ]
 ifeq ($(type),dev)
 	BROWSERIFY += -d
 endif


### PR DESCRIPTION
It turns out that Browserify does not follow symlinks for `--global
--only ...`. Let's fix that by passing it a list of the symlinked
targets.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 
**CC:** @sammacbeth 

## Steps to test this PR:
1. Point the content-scope-scripts directory to a local path in package.json, e.g. `"@duckduckgo/content-scope-scripts": "../content-scope-scripts",`
2. `make clean`
3. `npm run test`
4. Ensure tests build and run OK. (Without this change, bundling should fail.)

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
