### PR TITLE
Tidy up the Makefile and ensure updated files are copied again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,7 @@ public/js/*.*
 public/css/*.*
 *.swp
 *.swo
-build/firefox
-build/chrome
-build/chrome-mv3
-build/test
+build/
 test/background.js
 integration-test/artifacts/
 shared/tracker-surrogates/

--- a/browsers/chrome-mv3/managed-schema.json
+++ b/browsers/chrome-mv3/managed-schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "hasSeenPostInstall": {
+            "title": "Has the post install screen been shown to the user",
+            "description": "If set to true then no postinstall tab will be opened on start.",
+            "type": "boolean"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "scripts": {
         "install-ci": "make npm",
         "bundle-config": "node scripts/bundleConfig.mjs && node scripts/bundleTrackers.mjs",
-        "bundle-se": "ddg2dnr smarter-encryption shared/data/smarter_encryption.txt shared/data/bundled/smarter-encryption-rules.json",
         "build": "echo 'Try npm run release-firefox or npm run release-chrome instead' && exit 0",
         "dev": "echo 'Try npm run dev-firefox or npm run dev-chrome instead' && exit 0",
         "eslint": "eslint '*.js' shared/js shared/data unit-test integration-test scripts",


### PR DESCRIPTION
The Makefile had an issue whereby copied files were not re-copied when
they were updated. This could cause builds to contain out of date
files.

While I was fixing that, I decided to refactor/tidy the Makefile:
- Grouped all top-level targets together at the start of the Makefile.
- Added some missing comments.
- Used whitespace more consistently.
- Moved some out of place targets into the correct section.
- Added missing .PHONY target dependencies.

There is more work to do, in particular it would be nice to use
automatic dependency generation (e.g. `browserify --list`) in order to
reduce regeneration of the bundles.

**Reviewer:** @jdorweiler 
**CC:** @sammacbeth 

## Steps to test this PR:
1. Check build outputs are identical.
2. Check when files are changed (e.g. shared/data/constants.json) they are copied again with new builds.
3. Check that bundles are updated when files are changed too.
4. Check that files are not recopied/bundled when files _haven't_ changed.
5. Check unit and integration tests still pass.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
