### PR TITLE
Use parent puppeteer version in privacy-grade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,6 @@
                 "grunt-exec": "3.0.0",
                 "grunt-karma": "4.0.2",
                 "load-grunt-tasks": "3.5.2",
-                "puppeteer": "12.0.0",
                 "request": "2.88.2",
                 "url-parse-lax": "^3.0.0"
             }
@@ -14894,29 +14893,6 @@
                 "node": ">=14"
             }
         },
-        "packages/privacy-grade/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/privacy-grade/node_modules/devtools-protocol": {
-            "version": "0.0.937139",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
-            "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
-            "dev": true
-        },
         "packages/privacy-grade/node_modules/find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -14928,19 +14904,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "packages/privacy-grade/node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "packages/privacy-grade/node_modules/load-grunt-tasks": {
@@ -14961,18 +14924,6 @@
                 "grunt": ">=0.4.0"
             }
         },
-        "packages/privacy-grade/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "packages/privacy-grade/node_modules/multimatch": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
@@ -14988,45 +14939,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "packages/privacy-grade/node_modules/node-fetch": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-            "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            }
-        },
-        "packages/privacy-grade/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/privacy-grade/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "packages/privacy-grade/node_modules/path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -15039,40 +14951,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "packages/privacy-grade/node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/privacy-grade/node_modules/pkg-dir/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/privacy-grade/node_modules/pkg-dir/node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "packages/privacy-grade/node_modules/pkg-up": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
@@ -15083,31 +14961,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "packages/privacy-grade/node_modules/puppeteer": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.0.tgz",
-            "integrity": "sha512-a+vLxtwuDLUIq8Vz8X5bX+YMhcQrgyfq0Jo5Wcm49EfUawgCxeCN9/rUAS3VdAAiQZ1PKiv9pGyQN8jj1ypecQ==",
-            "deprecated": "< 19.2.0 is no longer supported",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "debug": "4.3.2",
-                "devtools-protocol": "0.0.937139",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.0",
-                "node-fetch": "2.6.5",
-                "pkg-dir": "4.2.0",
-                "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "rimraf": "3.0.2",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.2.3"
-            },
-            "engines": {
-                "node": ">=10.18.1"
             }
         },
         "packages/privacy-grade/node_modules/resolve-from": {
@@ -15129,49 +14982,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "packages/privacy-grade/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
-        },
-        "packages/privacy-grade/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "packages/privacy-grade/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "packages/privacy-grade/node_modules/ws": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         }
     },
@@ -16420,7 +16230,7 @@
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#801b7f23476f797c6eaa72b070e6c80abb82801a",
             "integrity": "sha512-kOW2Cl+AeJkhPdj0zJEhcq+OPiWEZkUcNv6vI41YrRz4EIXqVrOI2f3fRNe6ngYlE3RCZfVFtZfM2vAO28uA5w==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#801b7f23476f797c6eaa72b070e6c80abb82801a",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.4.4",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -16451,7 +16261,6 @@
                 "grunt-exec": "3.0.0",
                 "grunt-karma": "4.0.2",
                 "load-grunt-tasks": "3.5.2",
-                "puppeteer": "12.0.0",
                 "request": "2.88.2",
                 "tldts": "^5.7.84",
                 "url-parse-lax": "^3.0.0"
@@ -16495,21 +16304,6 @@
                     "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
                     "dev": true
                 },
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "devtools-protocol": {
-                    "version": "0.0.937139",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
-                    "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
-                    "dev": true
-                },
                 "find-up": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -16518,16 +16312,6 @@
                     "requires": {
                         "path-exists": "^2.0.0",
                         "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-                    "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "6",
-                        "debug": "4"
                     }
                 },
                 "load-grunt-tasks": {
@@ -16542,15 +16326,6 @@
                         "resolve-pkg": "^0.1.0"
                     }
                 },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^4.1.0"
-                    }
-                },
                 "multimatch": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
@@ -16563,33 +16338,6 @@
                         "minimatch": "^3.0.0"
                     }
                 },
-                "node-fetch": {
-                    "version": "2.6.5",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-                    "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
                 "path-exists": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -16599,33 +16347,6 @@
                         "pinkie-promise": "^2.0.0"
                     }
                 },
-                "pkg-dir": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-                    "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                            "dev": true,
-                            "requires": {
-                                "locate-path": "^5.0.0",
-                                "path-exists": "^4.0.0"
-                            }
-                        },
-                        "path-exists": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                            "dev": true
-                        }
-                    }
-                },
                 "pkg-up": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
@@ -16633,26 +16354,6 @@
                     "dev": true,
                     "requires": {
                         "find-up": "^1.0.0"
-                    }
-                },
-                "puppeteer": {
-                    "version": "12.0.0",
-                    "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.0.tgz",
-                    "integrity": "sha512-a+vLxtwuDLUIq8Vz8X5bX+YMhcQrgyfq0Jo5Wcm49EfUawgCxeCN9/rUAS3VdAAiQZ1PKiv9pGyQN8jj1ypecQ==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "4.3.2",
-                        "devtools-protocol": "0.0.937139",
-                        "extract-zip": "2.0.1",
-                        "https-proxy-agent": "5.0.0",
-                        "node-fetch": "2.6.5",
-                        "pkg-dir": "4.2.0",
-                        "progress": "2.0.3",
-                        "proxy-from-env": "1.1.0",
-                        "rimraf": "3.0.2",
-                        "tar-fs": "2.1.1",
-                        "unbzip2-stream": "1.4.3",
-                        "ws": "8.2.3"
                     }
                 },
                 "resolve-from": {
@@ -16669,35 +16370,6 @@
                     "requires": {
                         "resolve-from": "^2.0.0"
                     }
-                },
-                "tr46": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-                    "dev": true
-                },
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-                    "dev": true
-                },
-                "whatwg-url": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "dev": true,
-                    "requires": {
-                        "tr46": "~0.0.3",
-                        "webidl-conversions": "^3.0.0"
-                    }
-                },
-                "ws": {
-                    "version": "8.2.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-                    "dev": true,
-                    "requires": {}
                 }
             }
         },

--- a/packages/privacy-grade/package.json
+++ b/packages/privacy-grade/package.json
@@ -25,7 +25,6 @@
     "grunt-exec": "3.0.0",
     "grunt-karma": "4.0.2",
     "load-grunt-tasks": "3.5.2",
-    "puppeteer": "12.0.0",
     "request": "2.88.2",
     "url-parse-lax": "^3.0.0"
   }


### PR DESCRIPTION
The privacy-grade tests were using an ancient puppeteer version, but we can't upgrade to the latest without breaking our extension integration tests. We can just remove puppeteer from the privacy-grade `package.json` so it will inherit the version that the extension uses.