### PR TITLE
Squash three more bugs in the Makefile

### DIFF
--- a/shared/js/background/devbuild-reloader.js
+++ b/shared/js/background/devbuild-reloader.js
@@ -15,8 +15,12 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
         return
     }
 
-    const response = await fetch('/buildtime.txt', { cache: 'no-store' })
-    const buildTime = await response.text()
+    let buildTime = null
+
+    try {
+        const response = await fetch('/buildtime.txt', { cache: 'no-store' })
+        buildTime = await response.text()
+    } catch (e) { }
 
     if (buildTime) {
         const previousBuildTime = await browserWrapper.getFromSessionStorage('buildTime')


### PR DESCRIPTION
1. Fix the build/ path in `make clean`, since the browser + type
   variables shouldn't be used there.
2. Ensure build-locales is run before build-$(browser) when rebuilding
   the content-scope-scripts repository.
3. Ensure the reloader keeps checking when unpacked extension
   directory is cleared. That way, it will reload on next build.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 
**CC:** @sammacbeth 

## Steps to test this PR:
1. Run `make clean browser=foo type=bar` and check that the build directory is still removed correctly.
2. Point package.json at a freshly cloned local copy of content-scope-scripts, run `npm install` for the extension and `npm run dev-chrome` and ensure the build succeeds.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
