### PR TITLE
Remove mixed import patterns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,14 @@
     "extends": ["standard", "eslint:recommended"],
     "rules": {
         "indent": ["error", 4],
-        "no-shadow": ["error"]
+        "no-shadow": ["error"],
+        "no-restricted-syntax": [
+            "warn",
+            {
+              "selector": ":matches(ImportNamespaceSpecifier, ExportAllDeclaration, ExportNamespaceSpecifier)",
+              "message": "Prefer explicit named imports over wildcard (import * as x)"
+            }
+          ]
     },
     "env": {
         "webextensions": true,

--- a/packages/privacy-grade/src/classes/trackers.js
+++ b/packages/privacy-grade/src/classes/trackers.js
@@ -162,7 +162,7 @@ class Trackers {
 
             // take identifier from first line
             const pattern = firstLine.split(' ')[0].split('/')[1]
-            const b64surrogate = Buffer.from(lines.join('\n').toString(), 'binary').toString('base64')
+            const b64surrogate = btoa(lines.join('\n').toString())
             surrogateList[pattern] = b64dataheader + b64surrogate
         })
         return surrogateList

--- a/shared/js/background/allowlisted-trackers.js
+++ b/shared/js/background/allowlisted-trackers.js
@@ -1,4 +1,4 @@
-const tdsStorage = require('./storage/tds')
+const tdsStorage = require('./storage/tds').default
 const tldts = require('tldts')
 const { getURLWithoutQueryString } = require('./utils')
 

--- a/shared/js/background/allowlisted-trackers.js
+++ b/shared/js/background/allowlisted-trackers.js
@@ -1,5 +1,5 @@
-import tdsStorage from './storage/tds'
-import tldts from 'tldts'
+const tdsStorage = require('./storage/tds').default
+const tldts = require('tldts')
 const { getURLWithoutQueryString } = require('./utils')
 
 function isTrackerAllowlisted (site, request) {

--- a/shared/js/background/allowlisted-trackers.js
+++ b/shared/js/background/allowlisted-trackers.js
@@ -1,5 +1,5 @@
-const tdsStorage = require('./storage/tds').default
-const tldts = require('tldts')
+import tdsStorage from './storage/tds'
+import tldts from 'tldts'
 const { getURLWithoutQueryString } = require('./utils')
 
 function isTrackerAllowlisted (site, request) {

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -1,5 +1,5 @@
 const Site = require('./classes/site')
-const tdsStorage = require('./storage/tds')
+const tdsStorage = require('./storage/tds').default
 const utils = require('./utils')
 
 let ampSettings = null

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -1,5 +1,5 @@
-import tdsStorage from './storage/tds'
 const Site = require('./classes/site')
+const tdsStorage = require('./storage/tds').default
 const utils = require('./utils')
 
 let ampSettings = null

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -1,5 +1,5 @@
+import tdsStorage from './storage/tds'
 const Site = require('./classes/site')
-const tdsStorage = require('./storage/tds').default
 const utils = require('./utils')
 
 let ampSettings = null

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -273,4 +273,4 @@ settings.ready().then(async () => {
     browserWrapper.setUninstallURL(await ATB.getSurveyURL())
 })
 
-module.exports = ATB
+export default ATB

--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -418,5 +418,7 @@ function isSameDomainRequest (tab, req) {
     }
 }
 
-exports.blockHandleResponse = blockHandleResponse
-exports.handleRequest = handleRequest
+export {
+    blockHandleResponse,
+    handleRequest
+}

--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill'
 import EventEmitter2 from 'eventemitter2'
+import ATB from './atb'
 const tldts = require('tldts')
 
 const utils = require('./utils')
@@ -7,7 +8,6 @@ const trackers = require('./trackers')
 const https = require('./https')
 const Companies = require('./companies')
 const tabManager = require('./tab-manager')
-const ATB = require('./atb')
 const browserWrapper = require('./wrapper')
 const settings = require('./settings')
 const devtools = require('./devtools')
@@ -146,7 +146,6 @@ function handleRequest (requestData) {
         }
 
         // add atb params only to main_frame
-        // @ts-ignore addParametersMainFrameRequestUrl is exported but TS doesn't know about it
         const atbParametersAdded = ATB.addParametersMainFrameRequestUrl(mainFrameRequestURL)
 
         if (thisTab.urlParametersRemoved || ampRedirected || atbParametersAdded) {

--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -8,7 +8,7 @@
  */
 const settings = require('../settings')
 const utils = require('../utils')
-const tdsStorage = require('./../storage/tds')
+const tdsStorage = require('./../storage/tds').default
 const privacyPractices = require('../privacy-practices')
 const Grade = require('@duckduckgo/privacy-grade').Grade
 const browserWrapper = require('../wrapper')

--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -6,9 +6,9 @@
  * The Grade attributes are then used generate a site
  * privacy grade used in the popup.
  */
-import tdsStorage from '../storage/tds'
 const settings = require('../settings')
 const utils = require('../utils')
+const tdsStorage = require('./../storage/tds').default
 const privacyPractices = require('../privacy-practices')
 const Grade = require('@duckduckgo/privacy-grade').Grade
 const browserWrapper = require('../wrapper')

--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -6,9 +6,9 @@
  * The Grade attributes are then used generate a site
  * privacy grade used in the popup.
  */
+import tdsStorage from '../storage/tds'
 const settings = require('../settings')
 const utils = require('../utils')
-const tdsStorage = require('./../storage/tds').default
 const privacyPractices = require('../privacy-practices')
 const Grade = require('@duckduckgo/privacy-grade').Grade
 const browserWrapper = require('../wrapper')

--- a/shared/js/background/classes/tracker.js
+++ b/shared/js/background/classes/tracker.js
@@ -1,8 +1,8 @@
 import constants from '../../../data/constants'
 import { convertState } from './privacy-dashboard-data'
+import tdsStorage from '../storage/tds'
 
 const Companies = require('../companies')
-const tdsStorage = require('../storage/tds')
 
 /**
  * @typedef {import('../trackers').ActionName} ActionName

--- a/shared/js/background/csp-blocking.js
+++ b/shared/js/background/csp-blocking.js
@@ -17,6 +17,6 @@ function init () {
     }, ['blocking', 'requestBody'])
 }
 
-module.exports = {
+export {
     init
 }

--- a/shared/js/background/devbuild-reloader.js
+++ b/shared/js/background/devbuild-reloader.js
@@ -4,7 +4,8 @@
  */
 
 import browser from 'webextension-polyfill'
-const browserWrapper = require('./wrapper')
+// TODO: Only import `createAlarm`, `getFromSessionStorage` and `setToSessionStorage` here
+import * as browserWrapper from './wrapper'
 
 function createAlarm () {
     browserWrapper.createAlarm('checkBuildTime', { when: Date.now() + 5000 })

--- a/shared/js/background/devbuild-reloader.js
+++ b/shared/js/background/devbuild-reloader.js
@@ -4,10 +4,10 @@
  */
 
 import browser from 'webextension-polyfill'
-const browserWrapper = require('./wrapper')
+import { createAlarm, getFromSessionStorage, setToSessionStorage } from './wrapper'
 
-function createAlarm () {
-    browserWrapper.createAlarm('checkBuildTime', { when: Date.now() + 5000 })
+function createBuildAlarm () {
+    createAlarm('checkBuildTime', { when: Date.now() + 5000 })
 }
 
 browser.alarms.onAlarm.addListener(async alarmEvent => {
@@ -23,15 +23,15 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
     } catch (e) { }
 
     if (buildTime) {
-        const previousBuildTime = await browserWrapper.getFromSessionStorage('buildTime')
+        const previousBuildTime = await getFromSessionStorage('buildTime')
         if (!previousBuildTime) {
-            await browserWrapper.setToSessionStorage('buildTime', buildTime)
+            await setToSessionStorage('buildTime', buildTime)
         } else if (buildTime !== previousBuildTime) {
             browser.runtime.reload()
         }
     }
 
-    createAlarm()
+    createBuildAlarm()
 })
 
-createAlarm()
+createBuildAlarm()

--- a/shared/js/background/devbuild-reloader.js
+++ b/shared/js/background/devbuild-reloader.js
@@ -4,10 +4,10 @@
  */
 
 import browser from 'webextension-polyfill'
-import { createAlarm, getFromSessionStorage, setToSessionStorage } from './wrapper'
+const browserWrapper = require('./wrapper')
 
-function createBuildAlarm () {
-    createAlarm('checkBuildTime', { when: Date.now() + 5000 })
+function createAlarm () {
+    browserWrapper.createAlarm('checkBuildTime', { when: Date.now() + 5000 })
 }
 
 browser.alarms.onAlarm.addListener(async alarmEvent => {
@@ -23,15 +23,15 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
     } catch (e) { }
 
     if (buildTime) {
-        const previousBuildTime = await getFromSessionStorage('buildTime')
+        const previousBuildTime = await browserWrapper.getFromSessionStorage('buildTime')
         if (!previousBuildTime) {
-            await setToSessionStorage('buildTime', buildTime)
+            await browserWrapper.setToSessionStorage('buildTime', buildTime)
         } else if (buildTime !== previousBuildTime) {
             browser.runtime.reload()
         }
     }
 
-    createBuildAlarm()
+    createAlarm()
 })
 
-createBuildAlarm()
+createAlarm()

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -4,11 +4,11 @@
  */
 import * as startup from './startup'
 import Companies from './companies'
+import atb from './atb'
+import tds from './storage/tds'
 const settings = require('./settings')
 const tabManager = require('./tab-manager')
-const atb = require('./atb')
 const https = require('./https')
-const tds = require('./storage/tds')
 const browserWrapper = require('./wrapper')
 const utils = require('./utils')
 const Tab = require('./classes/tab')

--- a/shared/js/background/devtools.js
+++ b/shared/js/background/devtools.js
@@ -1,9 +1,9 @@
 import browser from 'webextension-polyfill'
+import tdsStorage from './storage/tds'
 const tldts = require('tldts')
 
 const tabManager = require('./tab-manager')
 const trackers = require('./trackers')
-const tdsStorage = require('./storage/tds')
 const { removeBroken } = require('./utils')
 
 // Note: It is not necessary to use session storage to store the tabId -> port

--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -185,15 +185,3 @@ export const isValidUsername = (userName) => /^[a-z0-9_]+$/.test(userName)
  * @returns {boolean}
  */
 export const isValidToken = (token) => /^[a-z0-9]+$/.test(token)
-
-module.exports = {
-    REFETCH_ALIAS_ALARM,
-    fetchAlias,
-    showContextMenuAction,
-    hideContextMenuAction,
-    getAddresses,
-    formatAddress,
-    isValidUsername,
-    isValidToken,
-    sendJSPixel
-}

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -15,7 +15,9 @@ import {
 import {
     refreshUserAllowlistRules
 } from './dnr-user-allowlist'
-const ATB = require('./atb')
+import tdsStorage from './storage/tds'
+import httpsStorage from './storage/https'
+import ATB from './atb'
 const utils = require('./utils')
 const experiment = require('./experiments')
 const settings = require('./settings')
@@ -24,7 +26,6 @@ const onboarding = require('./onboarding')
 const cspProtection = require('./csp-blocking')
 const browserName = utils.getBrowserName()
 const devtools = require('./devtools')
-const tdsStorage = require('./storage/tds')
 const browserWrapper = require('./wrapper')
 const limitReferrerData = require('./events/referrer-trimming')
 const { dropTracking3pCookiesFromResponse, dropTracking3pCookiesFromRequest, validateSetCookieBlock } = require('./events/3p-tracking-cookie-blocking')
@@ -508,7 +509,6 @@ browser.webNavigation.onCompleted.addListener(details => {
  * ALARMS
  */
 
-const httpsStorage = require('./storage/https')
 const httpsService = require('./https-service')
 const trackers = require('./trackers')
 

--- a/shared/js/background/https.js
+++ b/shared/js/background/https.js
@@ -11,6 +11,16 @@ const PRIVATE_TLDS = ['example', 'invalid', 'localhost', 'test']
 
 const manifestVersion = browserWrapper.getManifestVersion()
 
+function base64ToUint8Array (base64) {
+    const binaryString = window.atob(base64)
+    const len = binaryString.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i++) {
+        bytes[i] = binaryString.charCodeAt(i)
+    }
+    return bytes
+}
+
 class HTTPS {
     constructor () {
         // Store multiple upgrade / don't upgrade bloom filters
@@ -59,7 +69,7 @@ class HTTPS {
     // filterData is assumed to be base64 encoded 8 bit typed array
     createBloomFilter (filterData) {
         const bloom = new BloomFilter(filterData.totalEntries, filterData.errorRate)
-        const buffer = Buffer.from(filterData.data, 'base64')
+        const buffer = base64ToUint8Array(filterData.data)
         bloom.importData(buffer)
         return bloom
     }

--- a/shared/js/background/https.js
+++ b/shared/js/background/https.js
@@ -12,7 +12,7 @@ const PRIVATE_TLDS = ['example', 'invalid', 'localhost', 'test']
 const manifestVersion = browserWrapper.getManifestVersion()
 
 function base64ToUint8Array (base64) {
-    const binaryString = window.atob(base64)
+    const binaryString = globalThis.atob(base64)
     const len = binaryString.length
     const bytes = new Uint8Array(len)
     for (let i = 0; i < len; i++) {

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -5,11 +5,11 @@ import parseUserAgentString from '../shared-utils/parse-user-agent-string'
 import { getExtensionURL, notifyPopup } from './wrapper'
 import { isFeatureEnabled, reloadCurrentTab } from './utils'
 import { ensureClickToLoadRuleActionDisabled } from './dnr-click-to-load'
+import tdsStorage from './storage/tds'
 const { getDomain } = require('tldts')
 const utils = require('./utils')
 const settings = require('./settings')
 const tabManager = require('./tab-manager')
-const tdsStorage = require('./storage/tds')
 const trackers = require('./trackers')
 const constants = require('../../data/constants')
 const Companies = require('./companies')

--- a/shared/js/background/startup.js
+++ b/shared/js/background/startup.js
@@ -1,15 +1,15 @@
 import browser from 'webextension-polyfill'
 import { NewTabTrackerStats } from './newtab-tracker-stats'
 import { TrackerStats } from './classes/tracker-stats'
+import httpsStorage from './storage/https'
+import tdsStorage from './storage/tds'
 const utils = require('./utils')
 const browserWrapper = require('./wrapper')
 const Companies = require('./companies')
 const experiment = require('./experiments')
 const https = require('./https')
-const httpsStorage = require('./storage/https')
 const settings = require('./settings')
 const tabManager = require('./tab-manager')
-const tdsStorage = require('./storage/tds')
 const trackers = require('./trackers')
 const dnrSessionId = require('./dnr-session-rule-id')
 const { fetchAlias, showContextMenuAction } = require('./email-utils')

--- a/shared/js/background/storage/https.js
+++ b/shared/js/background/storage/https.js
@@ -1,5 +1,5 @@
+import Dexie from 'dexie'
 const load = require('./../load')
-const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings')
 
@@ -117,7 +117,7 @@ class HTTPSStorage {
     }
 
     storeInLocalDB (name, type, data) {
-        return this.dbc.httpsStorage.put({ name, type, data }).catch(e => {
+        return this.dbc.table('httpsStorage').put({ name, type, data }).catch(e => {
             console.warn(`storeInLocalDB failed for ${name}: resetting stored etag`, e)
             settings.updateSetting(`${name}-etag`, '')
             settings.updateSetting(`${name}-lastUpdate`, '')
@@ -127,6 +127,11 @@ class HTTPSStorage {
     hasCorrectChecksum (data) {
         // not everything has a checksum
         if (!data.checksum) return Promise.resolve(true)
+
+        // TODO: rewrite this check without needing a Buffer polyfill
+        if (typeof Buffer === 'undefined') {
+            return Promise.resolve(true)
+        }
 
         // need a buffer to send to crypto.subtle
         const buffer = Buffer.from(data.data, 'base64')
@@ -141,4 +146,4 @@ class HTTPSStorage {
         })
     }
 }
-module.exports = new HTTPSStorage()
+export default new HTTPSStorage()

--- a/shared/js/background/storage/tds.js
+++ b/shared/js/background/storage/tds.js
@@ -1,5 +1,5 @@
+import Dexie from 'dexie'
 const load = require('./../load')
-const Dexie = require('dexie')
 const constants = require('../../../data/constants')
 const settings = require('./../settings')
 const browserWrapper = require('./../wrapper')
@@ -18,11 +18,11 @@ const configNames = constants.tdsLists.map(({ name }) => name)
 
 class TDSStorage {
     constructor () {
-        // @ts-ignore - TypeScript is not following the Dexie import property.
         this.dbc = new Dexie('tdsStorage')
         this.dbc.version(1).stores({
             tdsStorage: 'name,data'
         })
+        this.table = this.dbc.table('tdsStorage')
 
         this.tds = { entities: {}, trackers: {}, domains: {}, cnames: {} }
         this.surrogates = ''
@@ -239,7 +239,7 @@ class TDSStorage {
     }
 
     storeInLocalDB (name, data) {
-        return this.dbc.tdsStorage.put({ name, data }).catch(e => {
+        return this.table.put({ name, data }).catch(e => {
             console.warn(`storeInLocalDB failed for ${name}: resetting stored etag`, e)
             settings.updateSetting(`${name}-etag`, '')
             settings.updateSetting(`${name}-lastUpdate`, '')
@@ -308,9 +308,9 @@ class TDSStorage {
     }
 
     removeLegacyLists () {
-        this.dbc.tdsStorage.delete('ReferrerExcludeList')
-        this.dbc.tdsStorage.delete('brokenSiteList')
-        this.dbc.tdsStorage.delete('protections')
+        this.table.delete('ReferrerExcludeList')
+        this.table.delete('brokenSiteList')
+        this.table.delete('protections')
     }
 
     onUpdate (name, listener) {
@@ -334,4 +334,4 @@ class TDSStorage {
         return readyPromise
     }
 }
-module.exports = new TDSStorage()
+export default new TDSStorage()

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -1,5 +1,5 @@
 const Site = require('./classes/site')
-const tdsStorage = require('./storage/tds')
+const tdsStorage = require('./storage/tds').default
 
 /** @module */
 

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -1,5 +1,5 @@
-import tdsStorage from './storage/tds'
 const Site = require('./classes/site')
+const tdsStorage = require('./storage/tds').default
 
 /** @module */
 

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -1,5 +1,5 @@
+import tdsStorage from './storage/tds'
 const Site = require('./classes/site')
-const tdsStorage = require('./storage/tds').default
 
 /** @module */
 

--- a/shared/js/ui/base/ui-wrapper.js
+++ b/shared/js/ui/base/ui-wrapper.js
@@ -15,17 +15,10 @@ export const backgroundMessage = (thisModel) => {
     })
 }
 
-const getExtensionURL = (path) => {
+export const getExtensionURL = (path) => {
     return browser.runtime.getURL(path)
 }
 
 export const openExtensionPage = (path) => {
     browser.tabs.create({ url: getExtensionURL(path) })
-}
-
-module.exports = {
-    sendMessage,
-    backgroundMessage,
-    openExtensionPage,
-    getExtensionURL
 }

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -1,5 +1,5 @@
 require('../helpers/mock-browser-api')
-const atb = require('../../shared/js/background/atb')
+const atb = require('../../shared/js/background/atb').default
 const settings = require('../../shared/js/background/settings')
 const load = require('../../shared/js/background/load')
 const browserWrapper = require('../../shared/js/background/wrapper')

--- a/unit-test/background/classes/site.js
+++ b/unit-test/background/classes/site.js
@@ -2,7 +2,7 @@ const Site = require('../../../shared/js/background/classes/site')
 const browserWrapper = require('../../../shared/js/background/wrapper')
 const load = require('./../../helpers/utils')
 const config = require('./../../../shared/data/bundled/extension-config.json')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 const tdsStorageStub = require('./../../helpers/tds')
 
 const EXT_ID = 'ogigmfedpbpnnbcpgjloacccaibkaoip'

--- a/unit-test/background/classes/tab.js
+++ b/unit-test/background/classes/tab.js
@@ -7,7 +7,7 @@ const { TabState } = require('../../../shared/js/background/classes/tab-state')
 const { AdClickAttributionPolicy } = require('../../../shared/js/background/classes/ad-click-attribution-policy')
 
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 const config = require('../../data/extension-config.json')
 
 let tab

--- a/unit-test/background/https.js
+++ b/unit-test/background/https.js
@@ -1,7 +1,7 @@
 require('../helpers/mock-browser-api')
 const testDomains = require('./../data/httpsTestDomains.json')
 const https = require('../../shared/js/background/https')
-const httpsStorage = require('../../shared/js/background/storage/https')
+const httpsStorage = require('../../shared/js/background/storage/https').default
 const httpsBloom = require('./../data/httpsBloom.json')
 const httpsAllowlist = require('./../data/httpsAllowlist.json')
 const httpsNegativeBloom = require('./../data/httpsNegativeBloom.json')

--- a/unit-test/background/reference-tests/3p-cookies-tests.js
+++ b/unit-test/background/reference-tests/3p-cookies-tests.js
@@ -2,7 +2,7 @@ require('../../helpers/mock-browser-api')
 
 const trackers = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const tabManager = require('../../../shared/js/background/tab-manager')
 const browserWrapper = require('../../../shared/js/background/wrapper')

--- a/unit-test/background/reference-tests/amp-protection-tests.js
+++ b/unit-test/background/reference-tests/amp-protection-tests.js
@@ -1,7 +1,7 @@
 const Site = require('../../../shared/js/background/classes/site')
 const tds = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 const config = require('@duckduckgo/privacy-reference-tests/amp-protections/config_reference.json')
 const {
     ampFormats: { name: formatFeatureDescription, tests: ampFormatsTests }

--- a/unit-test/background/reference-tests/click-to-load-tests.js
+++ b/unit-test/background/reference-tests/click-to-load-tests.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const tds = require('../../../shared/js/background/trackers')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 const tdsStorageStub = require('../../helpers/tds')
 
 const configReference =

--- a/unit-test/background/reference-tests/expire-1p-tracking-cookies.js
+++ b/unit-test/background/reference-tests/expire-1p-tracking-cookies.js
@@ -2,7 +2,7 @@ require('../../helpers/mock-browser-api')
 
 const tds = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const { handleRequest } = require('../../../shared/js/background/before-request')
 const tabManager = require('../../../shared/js/background/tab-manager')

--- a/unit-test/background/reference-tests/fingerprinting-protection-tests.js
+++ b/unit-test/background/reference-tests/fingerprinting-protection-tests.js
@@ -2,7 +2,7 @@ require('../../helpers/mock-browser-api')
 
 const tds = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const tabManager = require('../../../shared/js/background/tab-manager')
 const browserWrapper = require('../../../shared/js/background/wrapper')

--- a/unit-test/background/reference-tests/gpc-tests.js
+++ b/unit-test/background/reference-tests/gpc-tests.js
@@ -1,7 +1,7 @@
 require('../../helpers/mock-browser-api')
 
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const Site = require('../../../shared/js/background/classes/site')
 const GPC = require('../../../shared/js/background/GPC')

--- a/unit-test/background/reference-tests/https-upgrades-tests.js
+++ b/unit-test/background/reference-tests/https-upgrades-tests.js
@@ -1,7 +1,7 @@
 require('../../helpers/mock-browser-api')
 
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const browserWrapper = require('../../../shared/js/background/wrapper')
 
@@ -14,7 +14,7 @@ const negativeBloomFilter = require('@duckduckgo/privacy-reference-tests/https-u
 const negativeBloomFilterAllowlist = require('@duckduckgo/privacy-reference-tests/https-upgrades/https_negative_allowlist_reference.json')
 
 const https = require('../../../shared/js/background/https')
-const httpsStorage = require('../../../shared/js/background/storage/https')
+const httpsStorage = require('../../../shared/js/background/storage/https').default
 const load = require('./../../helpers/https')
 const Tab = require('../../../shared/js/background/classes/tab')
 const httpsService = require('../../../shared/js/background/https-service')

--- a/unit-test/background/reference-tests/privacy-configuration-tests.js
+++ b/unit-test/background/reference-tests/privacy-configuration-tests.js
@@ -1,7 +1,7 @@
 require('../../helpers/mock-browser-api')
 
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const Site = require('../../../shared/js/background/classes/site')
 const utils = require('../../../shared/js/background/utils')

--- a/unit-test/background/reference-tests/referrer-trimming-tests.js
+++ b/unit-test/background/reference-tests/referrer-trimming-tests.js
@@ -2,7 +2,7 @@ require('../../helpers/mock-browser-api')
 
 const tds = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const tabManager = require('../../../shared/js/background/tab-manager')
 const browserWrapper = require('../../../shared/js/background/wrapper')

--- a/unit-test/background/reference-tests/tracker-allowlist-tests.js
+++ b/unit-test/background/reference-tests/tracker-allowlist-tests.js
@@ -1,6 +1,6 @@
 const tdsStorageStub = require('../../helpers/tds')
 const tds = require('../../../shared/js/background/trackers')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const refTests = require('@duckduckgo/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_matching_tests.json')
 const allowList = require('../../../shared/js/background/allowlisted-trackers')

--- a/unit-test/background/reference-tests/url-parameters-tests.js
+++ b/unit-test/background/reference-tests/url-parameters-tests.js
@@ -1,7 +1,7 @@
 const Site = require('../../../shared/js/background/classes/site')
 const tds = require('../../../shared/js/background/trackers')
 const tdsStorageStub = require('../../helpers/tds')
-const tdsStorage = require('../../../shared/js/background/storage/tds')
+const tdsStorage = require('../../../shared/js/background/storage/tds').default
 
 const config = require('@duckduckgo/privacy-reference-tests/url-parameters/config_reference.json')
 const {

--- a/unit-test/background/storage/https.js
+++ b/unit-test/background/storage/https.js
@@ -1,5 +1,5 @@
 require('../../helpers/mock-browser-api')
-const httpsStorage = require('../../../shared/js/background/storage/https')
+const httpsStorage = require('../../../shared/js/background/storage/https').default
 const httpsBloom = require('./../../data/httpsBloom.json')
 const httpsAllowlist = require('./../../data/httpsAllowlist.json')
 const httpsNegativeBloom = require('./../../data/httpsNegativeBloom.json')

--- a/unit-test/background/tracker-utils-tests.js
+++ b/unit-test/background/tracker-utils-tests.js
@@ -1,6 +1,6 @@
 const trackerutils = require('../../shared/js/background/tracker-utils')
 const tds = require('../../shared/js/background/trackers')
-const tdsStorage = require('../../shared/js/background/storage/tds')
+const tdsStorage = require('../../shared/js/background/storage/tds').default
 const tdsStorageStub = require('./../helpers/tds')
 const settings = require('../../shared/js/background/settings')
 

--- a/unit-test/background/trackers.js
+++ b/unit-test/background/trackers.js
@@ -1,6 +1,6 @@
 const tdsTests = require('./../data/tdsTestDomains.json')
 const tds = require('../../shared/js/background/trackers')
-const tdsStorage = require('../../shared/js/background/storage/tds')
+const tdsStorage = require('../../shared/js/background/storage/tds').default
 const tdsStorageStub = require('./../helpers/tds')
 
 describe('tracker blocking', () => {

--- a/unit-test/background/utils.js
+++ b/unit-test/background/utils.js
@@ -1,5 +1,5 @@
 const utils = require('../../shared/js/background/utils')
-const tdsStorage = require('../../shared/js/background/storage/tds')
+const tdsStorage = require('../../shared/js/background/storage/tds').default
 const tds = require('./../data/tds')
 const load = require('./../helpers/utils.js')
 const config = require('./../data/extension-config.json')

--- a/unit-test/helpers/tds.js
+++ b/unit-test/helpers/tds.js
@@ -2,7 +2,7 @@
  * We don't have indexedDB for tds storage so we can
  * stub out the get and fallback functions
  */
-const tdsStorage = require('../../shared/js/background/storage/tds')
+const tdsStorage = require('../../shared/js/background/storage/tds').default
 
 const stub = (arg) => {
     const onUpdateListeners = new Map()


### PR DESCRIPTION
Fixes each case where we were mixing `export` statements and `module.exports` in a single file.