### PR TITLE
Set release version in Asana when preparing release task

### DIFF
--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -28,7 +28,7 @@ let asana
 function setupAsana () {
     asana = Asana.Client.create({
         defaultHeaders: {
-            'Asana-Enable': 'new_user_task_lists,new_project_templates'
+            'Asana-Enable': 'new_user_task_lists,new_project_templates,new_goal_memberships'
         }
     }).useAccessToken(ASANA_ACCESS_TOKEN)
 }

--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -22,6 +22,7 @@ const extensionTemplateTaskGid = '1201192367380462'
 const extensionProjectGid = '312629933896096'
 const releaseSectionGid = '1138897367672278'
 const extensionReleaseSectionGid = '1201759129227683'
+const extensionVersionCustomFieldGid = '1204270899747122'
 
 let asana
 
@@ -147,6 +148,15 @@ const run = async () => {
             duplicateTestingTask.gid,
             { assignee: taskAssignee }
         )
+    }
+
+    console.info('Setting release version field for PR tasks...')
+    for (const task of releaseTasks) {
+        await asana.tasks.updateTask(task.gid, {
+            custom_fields: {
+                [extensionVersionCustomFieldGid]: version
+            }
+        })
     }
 
     console.info('All done. Enjoy! 🎉')

--- a/scripts/asana-release.js
+++ b/scripts/asana-release.js
@@ -21,6 +21,7 @@ const artifacts = platforms.map((platform) => {
 const extensionTemplateTaskGid = '1201192367380462'
 const extensionProjectGid = '312629933896096'
 const releaseSectionGid = '1138897367672278'
+const extensionReleaseSectionGid = '1201759129227683'
 
 let asana
 
@@ -96,7 +97,7 @@ const run = async () => {
 
     await asana.tasks.addProjectForTask(new_task.gid, {
         project: extensionProjectGid,
-        insert_before: releaseTasks[0].gid
+        section: extensionReleaseSectionGid
     })
 
     console.info('Uploading files...')


### PR DESCRIPTION
**Reviewer:** @GioSensation 

## Description:

Updates the release asana script to:
 - Put the release task in the "Extension Releases" section of the project.
 - Add the version number to the 'Release version' field of PR tasks. This indicates which extension version this PR change will land in.
 - Adds another `Asana-Enable` header to disable `new_goal_memberships` warnings.