### PR TITLE
Update autofill to 6.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.7.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1852,7 +1852,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#26283ffcc7ed69a6853dfeca4514a2e552da2c96",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15227,7 +15227,7 @@
             },
             "devDependencies": {
                 "mocha": "10.0.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16487,13 +16487,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#26283ffcc7ed69a6853dfeca4514a2e552da2c96",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.4.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.4.3"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d2b87dcdae086676c9d28544b8b454d2b3f0e17f",
             "integrity": "sha512-WTILwWJTmj0R/5ZEua+EHcQIlz2YnuGLjawphk56/vsJZY3e8iFZ2Wx4YHakMqo2mgTY3FM6QY5iOG1o2rywPw==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#d2b87dcdae086676c9d28544b8b454d2b3f0e17f",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.7.0",
             "requires": {
                 "seedrandom": "^3.0.5",
                 "sjcl": "^1.0.8"
@@ -16503,7 +16503,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.0.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -23953,7 +23953,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#465ebbe3c42371051f8bb463d1b893f7cf93a957",
             "integrity": "sha512-6B/Zv/Rn/l96puZ7ib8mgf0PS1UWS7TuEo77GAnEqQmVxp8dAQ8MgenMlC2hv1/veDnU/5lk4Bw6X79cJEoi7Q==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#465ebbe3c42371051f8bb463d1b893f7cf93a957",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.1.0",
             "requires": {
                 "body-parser": "^1.19.0",
                 "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "yargs": "^17.7.1"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.7.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3


## Description
Updates Autofill to version [6.4.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.4.3).

## What's Changed

### Tests and Tooling

- Remove manual server setup in tests by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/289
- Add windows release automation by @szanto90balazs in https://github.com/duckduckgo/duckduckgo-autofill/pull/272
- Fix extension release flow by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/294
* Update Asana integration to include expected header by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/295

### Bugfixes

- Set tooltip initial offscreen position by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/291
- Only center tooltip on small screensizes by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/290


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.1...6.4.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).