### PR TITLE
Revert recent change to clean target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ npm:
 ## clean: Clear the builds and temporary files.
 clean:
 	rm -f shared/data/smarter_encryption.txt shared/data/bundled/smarter-encryption-rules.json integration-test/artifacts/attribution.json:
-	rm -rf build
+	rm -rf $(BUILD_DIR)
 
 .PHONY: clean
 


### PR DESCRIPTION
There was a bug in the Makefile, whereby `make clean` would run
`rm -rf $(BUILD_DIR)` which usually resulted in `rm -rf build//` being
run. By happenstance this worked, clearing the build directory. I
fixed that, by changing the script to run `rm -rf build` directly.

However, it turns out that the release target also runs `make clean`,
but with the BUILD_DIR variable set correctly. It expected only the
targetted build to be cleared, so when the whole build directory was
cleared instead the release process failed.

For now, let's revert that change, to unblock today's release. In the
future, we should handle this properly.

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
