### PR TITLE
Fix disabling of ServiceWorker initiated request blocking for MV3

### DIFF
--- a/shared/js/background/dnr-service-worker-initiated.js
+++ b/shared/js/background/dnr-service-worker-initiated.js
@@ -20,7 +20,17 @@ import {
 export async function ensureServiceWorkerInitiatedRequestExceptions (config) {
     const removeRuleIds = [SERVICE_WORKER_INITIATED_ALLOWING_RULE_ID]
     const addRules = []
-    if (config.features.serviceworkerInitiatedRequests?.exceptions?.length) {
+
+    if (config.features.serviceworkerInitiatedRequests?.state !== 'enabled') {
+        // All ServiceWorker initiated request blocking is disabled.
+        addRules.push(generateDNRRule({
+            id: SERVICE_WORKER_INITIATED_ALLOWING_RULE_ID,
+            priority: SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY,
+            actionType: 'allow',
+            tabIds: [-1]
+        }))
+    } else if (config.features.serviceworkerInitiatedRequests?.exceptions?.length) {
+        // ServiceWorker initiated request blocking is disabled for some domains.
         const exceptionDomains = config.features.serviceworkerInitiatedRequests.exceptions.map(entry => entry.domain)
         addRules.push(generateDNRRule({
             id: SERVICE_WORKER_INITIATED_ALLOWING_RULE_ID,


### PR DESCRIPTION
ServiceWorker initiated request blocking can often cause problems, so
we gate that behind the "serviceworkerInitiatedRequests"
feature. Unfortunately however, we did not disable the blocking for
MV3 builds properly. Let's fix that here.

See https://crbug.com/1421697

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
