### PR TITLE
Avoid triggering Chrome MV3 builds twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ npm:
 
 ## clean: Clear the builds and temporary files.
 clean:
-	rm -f shared/data/smarter_encryption.txt shared/data/bundled/smarter-encryption-rules.json integration-test/artifacts/attribution.json:
+	rm -f build/.smarter_encryption.txt integration-test/artifacts/attribution.json:
 	rm -rf $(BUILD_DIR)
 
 .PHONY: clean
@@ -170,7 +170,7 @@ LAST_COPY = build/.last-copy-$(browser)-$(type)
 RSYNC = rsync -ra --exclude="*~"
 
 $(LAST_COPY): $(WATCHED_FILES) | $(MKDIR_TARGETS)
-	$(RSYNC) --exclude="smarter_encryption.txt" browsers/$(browser)/* browsers/chrome/_locales shared/data shared/html shared/img $(BUILD_DIR)
+	$(RSYNC) browsers/$(browser)/* browsers/chrome/_locales shared/data shared/html shared/img $(BUILD_DIR)
 	$(RSYNC) node_modules/@duckduckgo/privacy-dashboard/build/app/* $(BUILD_DIR)/dashboard
 	$(RSYNC) node_modules/@duckduckgo/autofill/dist/autofill.css $(BUILD_DIR)/public/css/autofill.css
 	$(RSYNC) node_modules/@duckduckgo/autofill/dist/autofill-host-styles_$(BROWSER_TYPE).css $(BUILD_DIR)/public/css/autofill-host-styles.css
@@ -301,11 +301,11 @@ BUILD_TARGETS += $(BUILD_DIR)/public/css/base.css $(OUTPUT_CSS_FILES)
 
 # Fetch Smarter Encryption data for bundled Smarter Encryption
 # declarativeNetRequest rules.
-shared/data/smarter_encryption.txt:
-	curl https://staticcdn.duckduckgo.com/https/smarter_encryption.txt.gz | gunzip -c > shared/data/smarter_encryption.txt
+build/.smarter_encryption.txt:
+	curl https://staticcdn.duckduckgo.com/https/smarter_encryption.txt.gz | gunzip -c > $@
 
 # Generate Smarter Encryption declarativeNetRequest rules for MV3 builds.
-$(BUILD_DIR)/data/bundled/smarter-encryption-rules.json: shared/data/smarter_encryption.txt
+$(BUILD_DIR)/data/bundled/smarter-encryption-rules.json: build/.smarter_encryption.txt
 	npx ddg2dnr smarter-encryption $< $@
 
 ifeq ('$(browser)','chrome-mv3')


### PR DESCRIPTION
For Chrome MV3 builds, we need to fetch a list of domains that are
then used to generate a "Smarter Encryption" (HTTP -> HTTPS upgrade)
declarativeNetRequest ruleset. We were writing that list of domains as
a text file in the source tree, but that was confusing and could cause
a second incremental build to be triggered during development.

Let's save that text file in the build directory instead, that way
it's clearer, we avoid triggering builds twice and we can remove
the rsync exception.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Run `make clean`
2. Run `make dev browser=chrome-mv3 type=dev` and ensure `build/chrome-mv3/dev/data/bundled/smarter-encryption-rules.json` was created OK.
3. Run `make dev browser=chrome-mv3 type=dev` and ensure it reports "make: Nothing to be done for 'dev'."

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
