### PR TITLE
Ensure surrogates.txt target is triggered each time files are copied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ ifeq ('$(browser)','chrome-mv3')
   BUILD_TARGETS += $(BUILD_DIR)/data/bundled/smarter-encryption-rules.json
 endif
 
-$(BUILD_DIR)/data/surrogates.txt: $(BUILD_DIR)/web_accessible_resources $(wildcard node_modules/@duckduckgo/tracker-surrogates/surrogates/*.js)
+$(BUILD_DIR)/data/surrogates.txt: $(BUILD_DIR)/web_accessible_resources $(LAST_COPY)
 	node scripts/generateListOfSurrogates.js -i $</ > $@
 
 BUILD_TARGETS += $(BUILD_DIR)/data/surrogates.txt


### PR DESCRIPTION
We have a problem that sometimes surrogates.txt will be generated
early, before the surrogate scripts are copied into the build
directory. That causes surrogates.txt to be empty/invalid, and
also causes a second incremental build to run during
development. Let's just have the surrogates.txt target depend on
LAST_COPY instead. The cost of regenerating the file unnecessarily for
incremental builds seems worth generating it reliably.

Ideally, we would have targets for all copied files in the
Makefile, and then we could set proper dependencies for the
surrogates.txt target to ensure it's only regenerated when the
surrogate scripts have changed. In practice though, we have a
LAST_COPY target that represents all the file copying.

## Steps to test this PR:
1. Run `make clean`
2. Run `make dev browser=chrome-mv3 type=dev` and check that build/chrome-mv3/dev/data/surrogates.txt is created and lists the surrogate scripts correctly.
3. Run `make dev browser=chrome-mv3 type=dev` and check that "make: Nothing to be done for 'dev'." is reported.
4. Repeat a few times.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
