### PR TITLE
Fix request blocking integration tests for Chrome MV3

### DIFF
--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from './helpers/playwrightHarness'
 import { forAllConfiguration, forExtensionLoaded } from './helpers/backgroundWait'
+import { loadTestConfig } from './helpers/testConfig'
 
 const testHost = 'privacy-test-pages.glitch.me'
 const testSite = `https://${testHost}/privacy-protections/request-blocking/`
@@ -44,6 +45,7 @@ test.describe('Test request blocking', () => {
     test('Should block all the test tracking requests', async ({ page, backgroundPage, context }) => {
         await forExtensionLoaded(context)
         await forAllConfiguration(backgroundPage)
+        await loadTestConfig(backgroundPage, 'serviceworker-blocking.json')
         const [testCount, pageRequests] = await runRequestBlockingTest(page)
 
         // Verify that no logged requests were allowed.
@@ -97,6 +99,7 @@ test.describe('Test request blocking', () => {
     test('serviceworkerInitiatedRequests exceptions should disable service worker blocking', async ({ page, backgroundPage, context }) => {
         await forExtensionLoaded(context)
         await forAllConfiguration(backgroundPage)
+        await loadTestConfig(backgroundPage, 'serviceworker-blocking.json')
         await backgroundPage.evaluate(async (domain) => {
             /* global dbg */
             const { data: config } = dbg.getListContents('config')


### PR DESCRIPTION
Ensure ServiceWorker initiated request blocking is enabled before
running the request blocking integration tests. Otherwise, the tests
start failing if we disable it in the extension configuration.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
