### PR TITLE
Bump privacy-grade version

### DIFF
--- a/packages/privacy-grade/package.json
+++ b/packages/privacy-grade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/privacy-grade",
-  "version": "1.1.0",
+  "version": "2.1.3",
   "description": "DuckDuckGo's privacy grade algorithm",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the version to match the last tag on the original privacy-grade repo.