### PR TITLE
Update reference test integration to support new breakage reference tests

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -62,7 +62,7 @@ function constructUrl (querystring, truncate) {
     url += `?${randomNum}&`
     // some params should be not urlencoded
     let extraParams = '';
-    ['tds', ...Object.values(requestCategoryMapping)].forEach((key) => {
+    [...Object.values(requestCategoryMapping)].forEach((key) => {
         // if we're truncating, don't include the truncatable fields
         if (truncate && truncatableFields.includes(key)) return
         if (searchParams.has(key)) {

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -102,7 +102,10 @@ const requestCategoryMapping = {
  * @param {string | undefined} category - optional category
  * @param {string | undefined} description - optional description
  */
-export function breakageReportForTab (tab, tds, remoteConfigEtag, remoteConfigVersion, category, description) {
+export function breakageReportForTab ({
+    tab, tds, remoteConfigEtag, remoteConfigVersion,
+    category, description
+}) {
     if (!tab.url) {
         return
     }

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -95,12 +95,13 @@ const requestCategoryMapping = {
  * but has been moved here since there's no longer a relationship to 'where' this request
  * came from.
  *
- * @param {import("./classes/tab")} tab
- * @param {string} tds - tds-etag from settings
- * @param {string} remoteConfigEtag - config-etag from settings
- * @param {string} remoteConfigVersion - config version
- * @param {string | undefined} category - optional category
- * @param {string | undefined} description - optional description
+ * @param {Object} arg
+ * @prop {import("./classes/tab")} arg.tab
+ * @prop {string} arg.tds - tds-etag from settings
+ * @prop {string} arg.remoteConfigEtag - config-etag from settings
+ * @prop {string} arg.remoteConfigVersion - config version
+ * @prop {string | undefined} arg.category - optional category
+ * @prop {string | undefined} arg.description - optional description
  */
 export function breakageReportForTab ({
     tab, tds, remoteConfigEtag, remoteConfigVersion,

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -100,10 +100,10 @@ export async function submitBrokenSiteReport (breakageReport) {
         console.error('cannot access current tab with ID ' + currentTab.id)
         return
     }
-    const tsd = settings.getSetting('tds-etag')
-    const configEtag = settings.getSetting('config-etag')
-    const configVersion = tdsStorage.config.version
-    return breakageReportForTab(tab, tsd, configEtag, configVersion, category, description)
+    const tds = settings.getSetting('tds-etag')
+    const remoteConfigEtag = settings.getSetting('config-etag')
+    const remoteConfigVersion = tdsStorage.config.version
+    return breakageReportForTab({ tab, tds, remoteConfigEtag, remoteConfigVersion, category, description })
 }
 
 /**

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -57,7 +57,7 @@ for (const setName of Object.keys(testSets)) {
                         fullTrackerDomain: domain
                     })
                 })
-                breakageReportForTab(tab, test.blocklistVersion, test.configEtag, test.configVersion, test.category, 'foo bar')
+                breakageReportForTab(tab, test.blocklistVersion, test.configEtag, test.configVersion, test.category, test.providedDescription)
 
                 expect(loadPixelSpy.calls.count()).toEqual(1)
 

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -57,7 +57,14 @@ for (const setName of Object.keys(testSets)) {
                         fullTrackerDomain: domain
                     })
                 })
-                breakageReportForTab(tab, test.blocklistVersion, test.configEtag, test.configVersion, test.category, test.providedDescription)
+                breakageReportForTab({
+                    tab,
+                    tds: test.blocklistVersion,
+                    remoteConfigEtag: test.remoteConfigEtag,
+                    remoteConfigVersion: test.remoteConfigVersion,
+                    category: test.category,
+                    description: test.providedDescription
+                })
 
                 expect(loadPixelSpy.calls.count()).toEqual(1)
 

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -30,33 +30,40 @@ for (const setName of Object.keys(testSets)) {
                 })
                 tab.upgradedHttps = test.wasUpgraded
 
-                test.blockedTrackers.forEach(domain => {
+                const addRequest = (hostname, action, opts = {}) => {
                     tab.addToTrackers({
-                        action: 'block',
-                        reason: 'matched rule - block',
+                        action,
+                        reason: 'reference tests',
                         sameEntity: false,
                         sameBaseDomain: false,
                         redirectUrl: false,
-                        matchedRule: 'block',
+                        matchedRule: 'reference tests',
                         matchedRuleException: false,
                         tracker: trackerObj,
-                        fullTrackerDomain: domain
+                        fullTrackerDomain: hostname,
+                        ...opts
                     })
-                })
+                }
 
-                test.surrogates.forEach(domain => {
-                    tab.addToTrackers({
-                        action: 'redirect',
-                        reason: 'matched rule - surrogate',
-                        sameEntity: false,
-                        sameBaseDomain: false,
-                        redirectUrl: 'something.org/track.js',
-                        matchedRule: 'block',
-                        matchedRuleException: false,
-                        tracker: trackerObj,
-                        fullTrackerDomain: domain
+                const addRequests = (trackers, f) => {
+                    (trackers || []).forEach(hostname => {
+                        const opts = f(hostname)
+                        const { action } = opts
+                        addRequest(hostname, action, opts)
                     })
-                })
+                }
+
+                const addActionRequests = (trackers, action) => {
+                    addRequests(trackers, _ => ({ action }))
+                }
+
+                addActionRequests(test.blockedTrackers, 'block')
+                addActionRequests(test.surrogates, 'redirect')
+                addActionRequests(test.ignoreRequests, 'ignore')
+                addActionRequests(test.ignoredByUserRequests, 'ignore-user')
+                addActionRequests(test.adAttributionRequests, 'ad-attribution')
+                addActionRequests(test.noActionRequests, 'none')
+
                 breakageReportForTab({
                     tab,
                     tds: test.blocklistVersion,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

Updates the reference test plumbing to support the new breakage reference tests. See https://github.com/duckduckgo/privacy-reference-tests/pull/83.

Asana: https://app.asana.com/0/0/1204319236595708/f

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

Broken site reporting reference tests against https://github.com/duckduckgo/privacy-reference-tests/pull/83 should pass.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
