### PR TITLE
Ensure contentBlocking "feature" is properly disabled for MV3 builds

### DIFF
--- a/packages/ddg2dnr/lib/temporaryAllowlist.js
+++ b/packages/ddg2dnr/lib/temporaryAllowlist.js
@@ -34,11 +34,23 @@ function* generateTemporaryAllowlistRules (
         entries: unprotectedTemporary || []
     }]
 
-    if (contentBlocking && contentBlocking.state === 'enabled') {
+    if (contentBlocking?.state !== 'enabled') {
+        yield {
+            rule: generateDNRRule({
+                priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+                actionType: 'allowAllRequests',
+                resourceTypes: ['main_frame']
+            }),
+            matchDetails: {
+                type: 'contentBlocking',
+                reason: 'contentBlocking disabled for all domains.'
+            }
+        }
+    } else {
         configs.push({
             type: 'contentBlocking',
             priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
-            entries: contentBlocking.exceptions || []
+            entries: contentBlocking?.exceptions || []
         })
     }
 

--- a/packages/ddg2dnr/test/ampProtection.js
+++ b/packages/ddg2dnr/test/ampProtection.js
@@ -46,7 +46,8 @@ const baseExtensionConfigStringified = JSON.stringify({
                     '?amp'
                 ]
             }
-        }
+        },
+        contentBlocking: { state: 'enabled' }
     }
 })
 

--- a/packages/ddg2dnr/test/temporaryAllowlist.js
+++ b/packages/ddg2dnr/test/temporaryAllowlist.js
@@ -148,12 +148,35 @@ describe('Temporary Allowlist', () => {
         )
     })
 
-    it('shouldn\'t generate contentBlocking rules if disabled', async () => {
+    it('should allowlist all domains if contentBlocking is disabled', async () => {
         const extensionConfig = JSON.parse(baseExtensionConfigStringifed)
         extensionConfig.features.contentBlocking.state = 'disabled'
         delete extensionConfig.unprotectedTemporary
 
-        await rulesetEqual(extensionConfig, [], [], {})
+        await rulesetEqual(
+            extensionConfig,
+            [],
+            [
+                {
+                    id: 1,
+                    priority: CONTENT_BLOCKING_ALLOWLIST_PRIORITY,
+                    condition: {
+                        resourceTypes: [
+                            'main_frame'
+                        ]
+                    },
+                    action: {
+                        type: 'allowAllRequests'
+                    }
+                }
+            ],
+            {
+                1: {
+                    type: 'contentBlocking',
+                    reason: 'contentBlocking disabled for all domains.'
+                }
+            }
+        )
     })
 
     it('shouldn\'t generate rules for denylisted domains', async () => {

--- a/packages/ddg2dnr/test/trackerAllowlist.js
+++ b/packages/ddg2dnr/test/trackerAllowlist.js
@@ -59,7 +59,8 @@ describe('Tracker Allowlist', () => {
         assert.deepEqual(
             await generateExtensionConfigurationRuleset({
                 features: {
-                    trackerAllowlist: {}
+                    trackerAllowlist: {},
+                    contentBlocking: { state: 'enabled' }
                 }
             }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
@@ -81,7 +82,8 @@ describe('Tracker Allowlist', () => {
                                 }
                             }
                         }
-                    }
+                    },
+                    contentBlocking: { state: 'enabled' }
                 }
             }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
@@ -95,7 +97,8 @@ describe('Tracker Allowlist', () => {
                         settings: {
                             allowlistedTrackers: { }
                         }
-                    }
+                    },
+                    contentBlocking: { state: 'enabled' }
                 }
             }, [], isRegexSupportedTrue),
             { ruleset: [], matchDetailsByRuleId: {} }
@@ -151,7 +154,8 @@ describe('Tracker Allowlist', () => {
                             }
                         }
                     }
-                }
+                },
+                contentBlocking: { state: 'enabled' }
             }
         }
 


### PR DESCRIPTION
The contentBlocking "feature" in the configuration is primarily used
to disable tracker blocking (and a few related features) for domains
where users report breakage. During debugging/development however,
sometimes the feature is disabled entirely to disable those features
for all websites. Let's take care to generate the correct allowing
rule for when the contentBlocking feature is disabled entirely.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler

## Steps to test this PR:
1. Ensure requests are blocking for Chrome MV3 builds on the test page: http://privacy-test-pages.glitch.me/privacy-protections/request-blocking/
2. Disable the contentBlocking feature entirely in the extension config.
3. Refresh the test page, and ensure requests are no longer blocked.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
