### PR TITLE
Autofill shown should not update lastUsed

### DIFF
--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -109,7 +109,7 @@ const getFullPixelName = (name, browserName) => {
     return `${name}_${browserName.toLowerCase()}`
 }
 
-const fireAddressUsedPixel = (pixel) => {
+const fireAutofillPixel = (pixel, shouldUpdateLastUsed = true) => {
     const browserName = utils.getBrowserName() ?? 'unknown'
     if (!pixelsEnabled) return
 
@@ -119,7 +119,9 @@ const fireAddressUsedPixel = (pixel) => {
     const lastAddressUsedAt = getSetting('lastAddressUsedAt') ?? ''
 
     sendPixelRequest(getFullPixelName(pixel, browserName), { duck_address_last_used: lastAddressUsedAt, cohort: userData.cohort })
-    updateSetting('lastAddressUsedAt', currentDate())
+    if (shouldUpdateLastUsed) {
+        updateSetting('lastAddressUsedAt', currentDate())
+    }
 }
 
 const fireIncontextSignupPixel = (pixel) => {
@@ -143,13 +145,13 @@ export const sendJSPixel = (options) => {
     const { pixelName } = options
     switch (pixelName) {
     case 'autofill_show':
-        fireAddressUsedPixel('email_tooltip_show_extension')
+        fireAutofillPixel('email_tooltip_show_extension', false)
         break
     case 'autofill_private_address':
-        fireAddressUsedPixel('email_filled_random_extension')
+        fireAutofillPixel('email_filled_random_extension')
         break
     case 'autofill_personal_address':
-        fireAddressUsedPixel('email_filled_main_extension')
+        fireAutofillPixel('email_filled_main_extension')
         break
     case 'incontext_show':
         fireIncontextSignupPixel('incontext_show_extension')

--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -109,7 +109,7 @@ const getFullPixelName = (name, browserName) => {
     return `${name}_${browserName.toLowerCase()}`
 }
 
-const fireAutofillPixel = (pixel, shouldUpdateLastUsed = true) => {
+const fireAutofillPixel = (pixel, shouldUpdateLastUsed = false) => {
     const browserName = utils.getBrowserName() ?? 'unknown'
     if (!pixelsEnabled) return
 
@@ -145,13 +145,13 @@ export const sendJSPixel = (options) => {
     const { pixelName } = options
     switch (pixelName) {
     case 'autofill_show':
-        fireAutofillPixel('email_tooltip_show_extension', false)
+        fireAutofillPixel('email_tooltip_show_extension')
         break
     case 'autofill_private_address':
-        fireAutofillPixel('email_filled_random_extension')
+        fireAutofillPixel('email_filled_random_extension', true)
         break
     case 'autofill_personal_address':
-        fireAutofillPixel('email_filled_main_extension')
+        fireAutofillPixel('email_filled_main_extension', true)
         break
     case 'incontext_show':
         fireIncontextSignupPixel('incontext_show_extension')


### PR DESCRIPTION
**Reviewer:** @sixers 

## Description:
No longer update `lastUsed` when firing the autofill shown pixel.

## Steps to test this PR:
1. Open the background script devtools on the Network tab
2. With autofill enabled, open the tooltip on a page, for example https://privacy-test-pages.glitch.me/autofill/modal.html
3. Note the `duck_address_last_used` parameter (it should not be today)
4. Open the tooltip again. The parameter should stay the same
5. Now select an address
6. Open the tooltip again. The parameter should now be set to today

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
