### PR TITLE
Re-add fonts for autofill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ $(BUILD_DIR)/public/css/%.css: shared/scss/%.scss $(SCSS_SOURCE)
 BUILD_TARGETS += $(BUILD_DIR)/public/css/base.css $(OUTPUT_CSS_FILES)
 
 ## Fonts
-FONT_FILES = ProximaNova-Reg-webfont.woff ProximaNova-Sbold-webfont.woff ProximaNova-Bold-webfont.woff
+FONT_FILES = ProximaNova-Reg-webfont.woff ProximaNova-Sbold-webfont.woff ProximaNova-Bold-webfont.woff ProximaNova-Reg-webfont.woff2 ProximaNova-Bold-webfont.woff2
 BUILD_TARGETS += $(addprefix $(BUILD_DIR)/public/font/, $(FONT_FILES))
 
 $(BUILD_DIR)/public/font/%: $(INTERMEDIATES_DIR)/%


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
In #1903 I missed that we need `woff2` fonts for autofill. This PR re-adds those fonts.

## Steps to test this PR:
1. Load a page where autofill is triggered.
2. Check that the ProximaNova font is loaded correctly in the popup.
