### PR TITLE
Migrate click attribution tests to Playwright

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,36 +44,6 @@ jobs:
       - run: npm run install-ci
       - run: npm test
 
-  integration-tests:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - run: npm run install-ci
-      - run: npm run test-int
-      - name: Store test artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: integration-test-artifacts
-          path: integration-test/artifacts
-
-  integration-mv3-tests:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - run: npm run install-ci
-      - run: npm run test-int-mv3
-
   playwright-tests:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
       - run: npm test
 
   playwright-tests:
-    timeout-minutes: 10
+    timeout-minutes: 14
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
           retention-days: 30
 
   playwright-tests-mv3:
-    timeout-minutes: 10
+    timeout-minutes: 14
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ unit-test: build/test/background.js build/test/ui.js build/test/shared-utils.js
 .PHONY: unit-test
 
 ## test-int: Run legacy integration tests against the Chrome MV2 extension.
-test-int: integration-test/artifacts/attribution.json
+test-int:
 	make dev browser=chrome type=dev
 	jasmine --config=integration-test/config.json
 
 .PHONY: test-int
 
 ## test-int-mv3: Run legacy integration tests against the Chrome MV3 extension.
-test-int-mv3: integration-test/artifacts/attribution.json
+test-int-mv3:
 	make dev browser=chrome-mv3 type=dev
 	jasmine --config=integration-test/config-mv3.json
 
@@ -143,12 +143,6 @@ setup-artifacts-dir:
 	mkdir -p integration-test/artifacts/api_schemas
 
 .PHONY: setup-artifacts-dir
-
-# Fetch integration test data.
-integration-test/artifacts/attribution.json: node_modules/privacy-test-pages/adClickFlow/shared/testCases.json setup-artifacts-dir
-	mkdir -p integration-test/artifacts
-	cp $< $@
-
 
 ###--- Mkdir targets ---#
 # Note: Intermediate directories can be omitted.

--- a/integration-test/click-attribution.spec.js
+++ b/integration-test/click-attribution.spec.js
@@ -26,19 +26,7 @@ test.describe('Ad click blocking', () => {
     }
 
     /**
-     * @param {Puppeteer.page} page
-     * @param {string} variableName
-     * @returns {Promise<*>}
-     */
-    async function waitForVariable (page, variableName) {
-        const callback = (variableNameInstance) => globalThis[variableNameInstance]
-        await page.waitForFunction(callback, variableName, { timeout: 2000 })
-        return page.evaluate(callback, variableName)
-    }
-
-    /**
      * Clicks on an item and awaits a new tab to load.
-     * https://github.com/puppeteer/puppeteer/issues/3667 without this intercepting new tab requests is too late
      * @param {import('@playwright/test').Page}} existingPage
      * @param {string} selector
      * @returns {Promise<*>}
@@ -88,7 +76,7 @@ test.describe('Ad click blocking', () => {
                     .toBe(step.expected.url)
 
                 if (step.expected.requests) {
-                    const resources = await waitForVariable(page, 'resources')
+                    const resources = await page.evaluate(() => globalThis.resources)
                     expect(resources.length).toBe(step.expected.requests.length)
                     for (const request of step.expected.requests) {
                         const expectedResource = resources.find(resource => resource.url === request.url)

--- a/integration-test/click-attribution.spec.js
+++ b/integration-test/click-attribution.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from './helpers/playwrightHarness'
 import backgroundWait from './helpers/backgroundWait'
 import testCases from 'privacy-test-pages/adClickFlow/shared/testCases.json'
+import { routeFromLocalhost } from './helpers/testPages'
 
 if (testCases.length === 0) {
     throw new Error('No test cases found')
@@ -62,6 +63,8 @@ test.describe('Ad click blocking', () => {
         // Allow to filter to one test case
         const itMethod = testCase.only ? test.only : test
         itMethod(testCase.name, async ({ context }) => {
+            // route requests from all pages in this test to our local test server
+            await routeFromLocalhost(context)
             let page = await context.newPage()
             for (const step of testCase.steps) {
                 if (step.action.type === 'navigate') {

--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -56,7 +56,7 @@ export const test = base.extend({
         })
         // intercept extension install page and use HAR
         context.on('page', (page) => {
-            console.log('page', page.url())
+            // console.log('page', page.url())
             if (page.url().includes('duckduckgo.com/extension-success')) {
                 // HAR file generated with the following command:
                 // npx playwright open --save-har=data/har/duckduckgo.com/extension-success.har https://duckduckgo.com/extension-success

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -6,7 +6,7 @@ const testPageHosts = new Set([
     'bad.third-party.site',
     'www.search-company.site',
     'convert.ad-company.site',
-    'www.ad-company.site',
+    // 'www.ad-company.site', - redirects to this domain via route overriding seem to hang, so this one has to hit the real server
     'www.publisher-company.site',
     'www.payment-company.site'
 ])

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -6,6 +6,7 @@ const testPageHosts = new Set([
     'bad.third-party.site',
     'www.search-company.site',
     'convert.ad-company.site',
+    'www.ad-company.site',
     'www.publisher-company.site',
     'www.payment-company.site'
 ])
@@ -32,12 +33,10 @@ export function routeFromLocalhost (page, overrideHandler) {
         const requestData = new Request(`http://localhost:3000${url.pathname}${url.search}${url.hash}`, {
             method: route.request().method(),
             body: route.request().postDataBuffer(),
-            headers
+            headers,
+            redirect: 'manual'
         })
         const response = await fetch(requestData)
-        if (!response.ok) {
-            console.log(url.href, requestData.url, response.ok)
-        }
         const responseHeaders = {}
         for (const [key, value] of response.headers.entries()) {
             responseHeaders[key] = value
@@ -47,7 +46,6 @@ export function routeFromLocalhost (page, overrideHandler) {
             // so we have to route this request to the real server.
             return route.continue()
         }
-        await new Promise(resolve => setTimeout(resolve, 500))
         return route.fulfill({
             status: response.status,
             body: await response.text(),

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -24,7 +24,7 @@ export function routeFromLocalhost (page, overrideHandler) {
         const url = new URL(route.request().url())
         if (!testPageHosts.has(url.hostname)) {
             // skip requests for other hosts
-            console.log('skipped localhost routing for', url.href)
+            // console.log('skipped localhost routing for', url.href)
             return route.continue()
         }
         const headers = await route.request().allHeaders()

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -3,7 +3,11 @@ const testPageHosts = new Set([
     'privacy-test-pages.glitch.me',
     'broken.third-party.site',
     'good.third-party.site',
-    'bad.third-party.site'
+    'bad.third-party.site',
+    'www.search-company.site',
+    'convert.ad-company.site',
+    'www.publisher-company.site',
+    'www.payment-company.site'
 ])
 /**
  * Route requests to the local test service (privacy-test-pages)

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -4,9 +4,9 @@ const testPageHosts = new Set([
     'broken.third-party.site',
     'good.third-party.site',
     'bad.third-party.site',
-    'www.search-company.site',
     'convert.ad-company.site',
-    // 'www.ad-company.site', - redirects to this domain via route overriding seem to hang, so this one has to hit the real server
+    // 'www.search-company.site',
+    // 'www.ad-company.site', - redirects to these domains via route overriding seem to hang, so this one has to hit the real server
     'www.publisher-company.site',
     'www.payment-company.site'
 ])

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -26,10 +26,13 @@ export function routeFromLocalhost (page, overrideHandler) {
             console.log('skipped localhost routing for', url.href)
             return route.continue()
         }
+        const headers = await route.request().allHeaders()
+        // set host header so that the test server knows which content to serve
+        headers.host = url.host
         const requestData = new Request(`http://localhost:3000${url.pathname}${url.search}${url.hash}`, {
             method: route.request().method(),
             body: route.request().postDataBuffer(),
-            headers: await route.request().allHeaders()
+            headers
         })
         const response = await fetch(requestData)
         if (!response.ok) {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,9 +27,9 @@ export default defineConfig({
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
+    workers: undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: 'html',
+    reporter: process.env.CI ? 'dot' : 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -29,7 +29,7 @@ export default defineConfig({
     /* Opt out of parallel tests on CI. */
     workers: undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: process.env.CI ? 'dot' : 'html',
+    reporter: process.env.CI ? 'line' : 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
Seperated from #1939 because this migration was a bit more complex.