### PR TITLE
[WIP] Send incontext_eligible pixel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7125b0e5207e3a59288fe376057568d5a25dfa35",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1861,7 +1861,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7125b0e5207e3a59288fe376057568d5a25dfa35",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -16637,8 +16637,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.4.3"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7125b0e5207e3a59288fe376057568d5a25dfa35",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#7125b0e5207e3a59288fe376057568d5a25dfa35"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9a07d092c4d8dcad08d61aecb66607a0abc83654",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "yargs": "^17.7.1"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7125b0e5207e3a59288fe376057568d5a25dfa35",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",

--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -2,6 +2,7 @@ import browser from 'webextension-polyfill'
 
 import { getURL } from './pixels'
 import load from './load'
+import { daysInstalled } from './utils'
 const { getSetting, updateSetting } = require('./settings')
 const browserWrapper = require('./wrapper')
 const utils = require('./utils')
@@ -124,11 +125,11 @@ const fireAutofillPixel = (pixel, shouldUpdateLastUsed = false) => {
     }
 }
 
-const fireIncontextSignupPixel = (pixel) => {
+const fireIncontextSignupPixel = (pixel, params) => {
     const browserName = utils.getBrowserName() ?? 'unknown'
     if (!pixelsEnabled) return
 
-    sendPixelRequest(getFullPixelName(pixel, browserName))
+    sendPixelRequest(getFullPixelName(pixel, browserName), params)
 }
 
 /**
@@ -165,6 +166,15 @@ export const sendJSPixel = (options) => {
     case 'incontext_close_x':
         fireIncontextSignupPixel('incontext_close_x_extension')
         break
+    case 'incontext_eligible': {
+        const shouldFireIncontextEligibilityPixel = getSetting('shouldFireIncontextEligibilityPixel')
+        if (!shouldFireIncontextEligibilityPixel) return
+
+        const daysSinceInstallation = Math.ceil(daysInstalled())
+        fireIncontextSignupPixel('incontext_eligible_extension', { days_since_installation: daysSinceInstallation })
+        updateSetting('shouldFireIncontextEligibilityPixel', false)
+        break
+    }
     default:
         console.error('Unknown pixel name', pixelName)
     }

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -40,6 +40,7 @@ async function onInstalled (details) {
         settings.updateSetting('showWelcomeBanner', true)
         if (browserName === 'chrome') {
             settings.updateSetting('showCounterMessaging', true)
+            settings.updateSetting('shouldFireIncontextEligibilityPixel', true)
         }
         await ATB.updateATBValues()
         await ATB.openPostInstallPage()

--- a/shared/js/background/utils.js
+++ b/shared/js/background/utils.js
@@ -440,12 +440,21 @@ export function getInstallTimestamp (atb) {
  * @returns {boolean}
  */
 export function isInstalledWithinDays (numberOfDays, fromDate = Date.now(), atb = settings.getSetting('atb')) {
-    if (!atb) return false
+    return daysInstalled(fromDate, atb) <= numberOfDays
+}
+
+/**
+ * Returns the days since installed using atb
+ * @param {number} [fromDate]
+ * @param {string} [atb]
+ * @returns {number}
+ */
+export function daysInstalled (fromDate = Date.now(), atb = settings.getSetting('atb')) {
+    if (!atb) return NaN
 
     const installTimestamp = getInstallTimestamp(atb)
     // If we can't get the install date, assume it wasn't installed in time period
-    if (!installTimestamp) return false
+    if (!installTimestamp) return NaN
 
-    const daysInstalled = (fromDate - installTimestamp) / dayMultiplier
-    return daysInstalled <= numberOfDays
+    return (fromDate - installTimestamp) / dayMultiplier
 }


### PR DESCRIPTION
*Reviewer:**
**Asana:** https://app.asana.com/0/0/1204486716187197/f

## Description:
Accepts the `incontext_eligible` **temporary** pixel and sends it when needed.

- Only send for new installations
- Only send once per installation
- Add days since installation as a parameter


## Steps to test this PR:
If your dev extension was already installed no pixel should fire when focusing on a field.

After that, try removing and installing again. Now visit an Email Protection-eligible field and click on it. You should see a pixel being fired from the background page devtools. The pixel should include the `days_since_installation` parameter.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
