### PR TITLE
Control how long in-context signup is visible through remote config

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -283,7 +283,8 @@ export function getEmailProtectionCapabilities (_, sender) {
 
 export function getIncontextSignupDismissedAt () {
     const permanentlyDismissedAt = settings.getSetting('incontextSignupPermanentlyDismissedAt')
-    const isInstalledRecently = utils.isInstalledWithinDays(3)
+    const installedDays = tdsStorage.config.features.incontextSignup?.settings?.installedDays ?? 3
+    const isInstalledRecently = utils.isInstalledWithinDays(installedDays)
     return { success: { permanentlyDismissedAt, isInstalledRecently } }
 }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Task: https://app.asana.com/0/0/1204498944638779/f
Make the period of time in which in-context signup is visible configurable through the remote config. This value is currently not in place and so the value will default back to the current value of 3.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
