### PR TITLE
Fix allowlisting does not disable serviceworker request blocking in the same session

### DIFF
--- a/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
+++ b/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
@@ -1176,7 +1176,7 @@
         },
         "serviceworkerInitiatedRequests": {
             "exceptions": [],
-            "state": "disabled",
+            "state": "enabled",
             "hash": "e25bc15aae118274e8d4481baf2033dd"
         },
         "trackerAllowlist": {

--- a/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
+++ b/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
@@ -1176,7 +1176,7 @@
         },
         "serviceworkerInitiatedRequests": {
             "exceptions": [],
-            "state": "enabled",
+            "state": "disabled",
             "hash": "e25bc15aae118274e8d4481baf2033dd"
         },
         "trackerAllowlist": {

--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -167,4 +167,38 @@ test.describe('Test request blocking', () => {
             expect(status, description).toEqual('loaded')
         }
     })
+
+    test('protection toggle disables blocking', async ({ page, backgroundPage, context}) => {
+        await forExtensionLoaded(context)
+        await forAllConfiguration(backgroundPage)
+        await loadTestConfig(backgroundPage, 'serviceworker-blocking.json')
+
+        // load with protection enabled
+        await runRequestBlockingTest(page)
+        // Verify that no logged requests were allowed.
+        let pageResults = await page.evaluate(
+            () => results.results // eslint-disable-line no-undef
+        )
+        for (const { id, category, status } of pageResults) {
+            const description = `ID: ${id}, Category: ${category}`
+            expect(status, description).not.toEqual('loaded')
+        }
+
+        // disable protection on the page and rerun the test
+        await backgroundPage.evaluate(async (domain) => {
+            dbg.tabManager.setList({ list: 'allowlisted', domain, value: true})
+        }, testHost)
+        await runRequestBlockingTest(page)
+        pageResults = await page.evaluate(
+            () => results.results // eslint-disable-line no-undef
+        )
+        for (const { id, category, status } of pageResults) {
+            // skip some flakey request types
+            if (['video', 'websocket'].includes(id)) {
+                continue
+            }
+            const description = `ID: ${id}, Category: ${category}`
+            expect(status, description).toEqual('loaded')
+        }
+    })
 })

--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -168,7 +168,7 @@ test.describe('Test request blocking', () => {
         }
     })
 
-    test('protection toggle disables blocking', async ({ page, backgroundPage, context }) => {
+    test('protection toggle disables blocking', async ({ page, backgroundPage, context, manifestVersion }) => {
         await forExtensionLoaded(context)
         await forAllConfiguration(backgroundPage)
         await loadTestConfig(backgroundPage, 'serviceworker-blocking.json')
@@ -195,6 +195,11 @@ test.describe('Test request blocking', () => {
         for (const { id, category, status } of pageResults) {
             // skip some flakey request types
             if (['video', 'websocket'].includes(id)) {
+                continue
+            }
+            // serviceworker-fetch: allowlist does not work in MV3
+            // https://app.asana.com/0/892838074342800/1204515863331825/f
+            if (manifestVersion === 3 && id === 'serviceworker-fetch') {
                 continue
             }
             const description = `ID: ${id}, Category: ${category}`

--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -168,7 +168,7 @@ test.describe('Test request blocking', () => {
         }
     })
 
-    test('protection toggle disables blocking', async ({ page, backgroundPage, context}) => {
+    test('protection toggle disables blocking', async ({ page, backgroundPage, context }) => {
         await forExtensionLoaded(context)
         await forAllConfiguration(backgroundPage)
         await loadTestConfig(backgroundPage, 'serviceworker-blocking.json')
@@ -186,7 +186,7 @@ test.describe('Test request blocking', () => {
 
         // disable protection on the page and rerun the test
         await backgroundPage.evaluate(async (domain) => {
-            dbg.tabManager.setList({ list: 'allowlisted', domain, value: true})
+            dbg.tabManager.setList({ list: 'allowlisted', domain, value: true })
         }, testHost)
         await runRequestBlockingTest(page)
         pageResults = await page.evaluate(

--- a/shared/js/background/dnr-service-worker-initiated.js
+++ b/shared/js/background/dnr-service-worker-initiated.js
@@ -29,9 +29,10 @@ export async function ensureServiceWorkerInitiatedRequestExceptions (config) {
             actionType: 'allow',
             tabIds: [-1]
         }))
-    } else if (config.features.serviceworkerInitiatedRequests?.exceptions?.length) {
+    } else if (config.features.serviceworkerInitiatedRequests?.exceptions?.length > 0 || config.unprotectedTemporary?.length > 0) {
         // ServiceWorker initiated request blocking is disabled for some domains.
-        const exceptionDomains = config.features.serviceworkerInitiatedRequests.exceptions.map(entry => entry.domain)
+        const exceptionDomains = (config.features.serviceworkerInitiatedRequests?.exceptions || []).concat(config.unprotectedTemporary || [])
+            .map(entry => entry.domain)
         addRules.push(generateDNRRule({
             id: SERVICE_WORKER_INITIATED_ALLOWING_RULE_ID,
             priority: SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY,

--- a/shared/js/background/tab-manager.js
+++ b/shared/js/background/tab-manager.js
@@ -122,12 +122,15 @@ class TabManager {
     async setList (data) {
         this.setGlobalAllowlist(data.list, data.domain, data.value)
 
-        for (const tabId in this.tabContainer) {
-            const tab = this.tabContainer[tabId]
-            if (tab.site && tab.site.domain === data.domain) {
+        // collect all tabs (both normal and SW) tracked by this object
+        const allTabs = [...Object.keys(this.tabContainer).map(tabId => this.tabContainer[tabId]),
+            ...Object.keys(this.swContainer).map(origin => this.swContainer[origin])]
+        // propegate the list change to all tabs with the same site
+        allTabs
+            .filter(tab => tab.site && tab.site.domain === data.domain)
+            .forEach((tab) => {
                 tab.site.setListValue(data.list, data.value)
-            }
-        }
+            })
 
         // Ensure that user allowlisting/denylisting is honoured for manifest v3
         // builds of the extension, by adding/removing the necessary

--- a/unit-test/background/declarative-net-request.js
+++ b/unit-test/background/declarative-net-request.js
@@ -696,18 +696,20 @@ describe('declarativeNetRequest', () => {
             id: ruleId,
             priority: rulePriority,
             action: { type: 'allow' },
-            condition: { tabIds: [-1], initiatorDomains: ['example.com'] }
+            condition: { tabIds: [-1], initiatorDomains: ['example.com', 'google.com', 'suntrust.com'] }
         }
+        const tempUnprotected = config.unprotectedTemporary
 
         // The rule won't exist initially.
         expect(updateSessionRulesObserver.calls.count()).toEqual(0)
         expect(sessionRulesByRuleId.has(ruleId)).toBeFalse()
 
-        // if there are no serviceworker exceptions, no rule should be created
+        // if there are no serviceworker exceptions, or unprotected sites, no rule should be created
         config.features.serviceworkerInitiatedRequests = {
             state: 'enabled',
             exceptions: []
         }
+        config.unprotectedTemporary = []
         await ensureServiceWorkerInitiatedRequestExceptions(config)
         expect(updateSessionRulesObserver.calls.count()).toEqual(1)
         expect(sessionRulesByRuleId.has(ruleId)).toBeFalse()
@@ -718,6 +720,7 @@ describe('declarativeNetRequest', () => {
             state: 'disabled',
             exceptions: [{ domain: 'example.com', reason: '' }]
         }
+        config.unprotectedTemporary = tempUnprotected
         await ensureServiceWorkerInitiatedRequestExceptions(config)
         expect(updateSessionRulesObserver.calls.count()).toEqual(2)
         expect(sessionRulesByRuleId.has(ruleId)).toBeTrue()
@@ -741,9 +744,12 @@ describe('declarativeNetRequest', () => {
         // If enabled and there are no domain exceptions, the rule should be
         // removed.
         config.features.serviceworkerInitiatedRequests.exceptions = []
+        config.unprotectedTemporary = []
         await ensureServiceWorkerInitiatedRequestExceptions(config)
         expect(updateSessionRulesObserver.calls.count()).toEqual(5)
         expect(sessionRulesByRuleId.has(ruleId)).toBeFalse()
+
+        config.unprotectedTemporary = tempUnprotected
     })
 
     it('getMatchDetails', async () => {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Fixes syncing allowlist changes to serviceworker tabs.

## Steps to test this PR:
 1. go to https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/
 2. disable protections
 3. run test
 4. 'serviceworker-fetch' should be allowed.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
