### PR TITLE
Speed up AMP protection tests

### DIFF
--- a/integration-test/amp-protection.spec.js
+++ b/integration-test/amp-protection.spec.js
@@ -57,7 +57,7 @@ test.describe('Test AMP link protection', () => {
             //       Since only the redirected main_frame URL is required for
             //       these tests, just wait for load rather than network idle.
             await page.goto(
-                initialUrl, { waitUntil: 'networkidle' }
+                initialUrl, { waitUntil: 'commit' }
             )
             expect(page.url(), description).toEqual(expectedUrl)
         }


### PR DESCRIPTION
Avoids loading the entire page for AMP page tests - once the navigation is committed, we can check the URL is correct.