### PR TITLE
Update autofill to 6.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.5.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1874,7 +1874,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f403fad4f6ccf18a3900fc560f43067a527ac9f",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15443,7 +15443,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16722,8 +16722,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.4.3"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f403fad4f6ccf18a3900fc560f43067a527ac9f",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.5.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9a07d092c4d8dcad08d61aecb66607a0abc83654",
@@ -16738,7 +16738,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16767,7 +16767,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#dee49c3b01085eec1c6f26c8f199dc27d22ccb6b",
             "integrity": "sha512-qmTRVR6LLiTYDsup/z1ZPs6XtQZrqv5ErKkotQ7FoWIOxXUaldV5sfABsLfJe6hqaBqlR1nfZmOuiutghn6bJQ==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#dee49c3b01085eec1c6f26c8f199dc27d22ccb6b"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#d61691a2fdf9f4dc062a8d248fd1e78c20b5b892",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.5.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204538113123468/1204538113123468
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1


## Description
Updates Autofill to version [6.5.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1).

### Autofill 6.5.1 release notes
## What's Changed
* Disable pixel for all platforms but extension by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/309
* Fix release script for BSK by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/310

Included in 6.5.0:
- Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
- Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
- Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
- Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
- Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
- Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
- Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
- Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.0...6.5.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).