### PR TITLE
Update autofill to 6.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.5.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.6.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1874,8 +1874,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f403fad4f6ccf18a3900fc560f43067a527ac9f",
-            "integrity": "sha512-l4w6Tvmy+KHV5YEdZDrgx55HQNCC1Rfk0DuV8Bxo32DMmQcrEoEV83Fp79iMPoxgQVLLdpnfwfKDNyAAEjISdw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#466e3695cdc7839dcd74c45acda8b471a3e68fd5",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15472,7 +15471,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16751,14 +16750,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f403fad4f6ccf18a3900fc560f43067a527ac9f",
-            "integrity": "sha512-l4w6Tvmy+KHV5YEdZDrgx55HQNCC1Rfk0DuV8Bxo32DMmQcrEoEV83Fp79iMPoxgQVLLdpnfwfKDNyAAEjISdw==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8f403fad4f6ccf18a3900fc560f43067a527ac9f"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#466e3695cdc7839dcd74c45acda8b471a3e68fd5",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#6.6.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0340bae380ad480f420cce2b666da5e37f6b83d6",
             "integrity": "sha512-UVwtS/agsP/M+hResHloGsq59cKQXosI2R7iXO9n3UPUFJYq+imFmIICN9vzjhbu/O8yrVTnHJgsrEy0rR0LUw==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#0340bae380ad480f420cce2b666da5e37f6b83d6",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.16.0",
             "requires": {
                 "immutable-json-patch": "^5.1.2",
                 "seedrandom": "^3.0.5",
@@ -16769,7 +16767,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16798,7 +16796,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#dee49c3b01085eec1c6f26c8f199dc27d22ccb6b",
             "integrity": "sha512-qmTRVR6LLiTYDsup/z1ZPs6XtQZrqv5ErKkotQ7FoWIOxXUaldV5sfABsLfJe6hqaBqlR1nfZmOuiutghn6bJQ==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#dee49c3b01085eec1c6f26c8f199dc27d22ccb6b"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#d61691a2fdf9f4dc062a8d248fd1e78c20b5b892",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.5.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.6.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0


## Description
Updates Autofill to version [6.6.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.6.0).

### Autofill 6.6.0 release notes
## What's Changed
* Ema/fix release again by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/311
* Update Dax logo by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/312
* New subdomain matching rules by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/297
* Update release workflow by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/313


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.1...6.6.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).