### PR TITLE
Fix percent encoding errors for param stripping

### DIFF
--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -13,15 +13,11 @@ function ensureTrackingParametersConfig () {
         return true
     }
 
-    if (!tdsStorage.config ||
-        !tdsStorage.config.features ||
-        !tdsStorage.config.features.trackingParameters ||
-        !tdsStorage.config.features.trackingParameters.settings ||
-        !tdsStorage.config.features.trackingParameters.settings.parameters) {
+    if (!tdsStorage?.config?.features?.trackingParameters?.settings?.parameters) {
         return false
     }
 
-    trackingParameters = tdsStorage.config.features.trackingParameters.settings.parameters
+    trackingParameters = new Set(tdsStorage.config.features.trackingParameters.settings.parameters)
 
     return true
 }
@@ -50,17 +46,19 @@ function stripTrackingParameters (url) {
     }
 
     // Remove tracking parameters
+    // Note: We can't use URLSearchParams here because of issues with
+    // percent encoded parameters.
     const params = url.search.slice(1).split('&')
-    var paramsToKeep = []
+    let paramsToKeep = []
     for (const param of params) {
-        if (trackingParameters.includes(param.split('=')[0])) {
+        if (trackingParameters.has(param.split('=')[0])) {
             parametersRemoved = true
             continue
         }
 
         paramsToKeep.push(param)
     }
-    url.search = paramsToKeep.length > 0 ? '?' + paramsToKeep.join('&') : ''
+    url.search = paramsToKeep.length === 0 ? '' : '?' + paramsToKeep.join('&')
 
     return parametersRemoved
 }

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -55,7 +55,7 @@ function stripTrackingParameters (url) {
         if (searchString.includes(`${key}=`)) {
             // Remove the parameter from the search string.
             searchString = searchString.replace(new RegExp(`[?&]${key}=[^&]*`), '')
-            
+
             parametersRemoved = true
         }
     }

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -46,7 +46,10 @@ function stripTrackingParameters (url) {
     }
 
     // Remove tracking parameters
-    // Note: We can't use URLSearchParams here because of issues with
+    // Note: We can't use url.searchParams here because adding/removing parameters
+    //            with URLSearchParams adjusts the encoding of the other parameters.
+    //            See https://url.spec.whatwg.org/#urlsearchparams
+    // 
     // percent encoded parameters.
     const params = url.search.slice(1).split('&')
     let paramsToKeep = []

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -1,3 +1,5 @@
+const { t } = require('i18next')
+
 const Site = require('./classes/site').default
 const tdsStorage = require('./storage/tds').default
 
@@ -50,28 +52,17 @@ function stripTrackingParameters (url) {
     }
 
     // Remove tracking parameters
-    var searchString = url.search
-    for (const key of trackingParameters) {
-        const keyRegex = new RegExp(`[?&]${key}(=[^&]*)?(?=&|$)`)
-        while (keyRegex.test(searchString)) {
-            // Remove the parameter from the search string.
-            searchString = searchString.replace(keyRegex, '')
-
+    const params = url.search.slice(1).split('&')
+    var paramsToKeep = []
+    for (const param of params) {
+        if (trackingParameters.includes(param.split('=')[0])) {
             parametersRemoved = true
-        }
-    }
-    if (parametersRemoved) {
-        // Remove the leading '&' if necessary.
-        if (searchString[0] === '&') {
-            searchString = searchString.slice(1)
-        }
-        // Ensure that the search string starts with a '?'.
-        if (searchString.length > 0 && searchString[0] !== '?') {
-            searchString = `?${searchString}`
+            continue
         }
 
-        url.search = searchString
+        paramsToKeep.push(param)
     }
+    url.search = paramsToKeep.length > 0 ? '?' + paramsToKeep.join('&') : ''
 
     return parametersRemoved
 }

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -49,10 +49,10 @@ function stripTrackingParameters (url) {
     // Note: We can't use url.searchParams here because adding/removing parameters
     //            with URLSearchParams adjusts the encoding of the other parameters.
     //            See https://url.spec.whatwg.org/#urlsearchparams
-    // 
+    //
     // percent encoded parameters.
     const params = url.search.slice(1).split('&')
-    let paramsToKeep = []
+    const paramsToKeep = []
     for (const param of params) {
         if (trackingParameters.has(param.split('=')[0])) {
             parametersRemoved = true

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -1,5 +1,3 @@
-const { t } = require('i18next')
-
 const Site = require('./classes/site').default
 const tdsStorage = require('./storage/tds').default
 

--- a/shared/js/background/url-parameters.js
+++ b/shared/js/background/url-parameters.js
@@ -52,9 +52,10 @@ function stripTrackingParameters (url) {
     // Remove tracking parameters
     var searchString = url.search
     for (const key of trackingParameters) {
-        if (searchString.includes(`${key}=`)) {
+        const keyRegex = new RegExp(`[?&]${key}(=[^&]*)?(?=&|$)`)
+        while (keyRegex.test(searchString)) {
             // Remove the parameter from the search string.
-            searchString = searchString.replace(new RegExp(`[?&]${key}=[^&]*`), '')
+            searchString = searchString.replace(keyRegex, '')
 
             parametersRemoved = true
         }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston @kzar 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
This fixes url param stripping when parameters aren't properly percent decoded. Note I've also removed code that deals with Regex parameters as we no longer have these in our lists.

## Steps to test this PR:
Make sure to enable queryParameters in your local config.

Check the tests here: https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204621210866535