### PR TITLE
Allow message handlers to be registered dynamically

### DIFF
--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -5,7 +5,7 @@
  * if we do too much before adding it
  */
 import browser from 'webextension-polyfill'
-import * as messageHandlers from './message-handlers'
+import messageHandlers from './message-handlers'
 import { updateActionIcon } from './events/privacy-icon-indicator'
 import { flushSessionRules } from './dnr-session-rule-id'
 import { restoreDefaultClickToLoadRuleActions } from './dnr-click-to-load'

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -421,3 +421,61 @@ export async function isClickToLoadYoutubeEnabled () {
         tdsStorage?.config?.features?.clickToLoad?.settings?.Youtube?.state === 'enabled'
     )
 }
+
+/**
+ * Add a new message handler.
+ * @param {string} name
+ * @param {(options: any, sender: any, req: any) => any} func
+ */
+export function registerMessageHandler (name, func) {
+    if (messageHandlers[name]) {
+        throw new Error(`Attempt to re-register existing message handler ${name}`)
+    }
+    messageHandlers[name] = func
+}
+
+/**
+ * Default set of message handler functions used by the background message handler
+ */
+const messageHandlers = {
+    registeredContentScript,
+    resetTrackersData,
+    getExtensionVersion,
+    setList,
+    setLists,
+    allowlistOptIn,
+    getBrowser,
+    openOptions,
+    submitBrokenSiteReport,
+    getTab,
+    getPrivacyDashboardData,
+    getTopBlockedByPages,
+    getClickToLoadState,
+    getYouTubeVideoDetails,
+    getCurrentTab,
+    unblockClickToLoadContent,
+    updateYouTubeCTLAddedFlag,
+    setYoutubePreviewsEnabled,
+    updateSetting,
+    getSetting,
+    getAddresses,
+    sendJSPixel,
+    getAlias,
+    refreshAlias,
+    getTopBlocked,
+    getEmailProtectionCapabilities,
+    getIncontextSignupDismissedAt,
+    setIncontextSignupPermanentlyDismissedAt,
+    getUserData,
+    addUserData,
+    removeUserData,
+    logout,
+    getListContents,
+    setListContents,
+    reloadList,
+    debuggerMessage,
+    search,
+    openShareFeedbackPage,
+    isClickToLoadYoutubeEnabled
+}
+export default messageHandlers

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -435,7 +435,10 @@ export function registerMessageHandler (name, func) {
 }
 
 /**
- * Default set of message handler functions used by the background message handler
+ * Default set of message handler functions used by the background message handler.
+ *
+ * Don't add new listeners to this list, instead import and call registerMessageHandler in your
+ * feature's initialization code!
  */
 const messageHandlers = {
     registeredContentScript,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

## Description:
Adds an explicit default export from `message-handlers.js` that contains the default set of message handlers. We then also export a function that allows new handlers to be registered.

This will enable us to move handlers out of the central message handler file, and register handlers per-feature.
