### PR TITLE
Allow constants.js to be used in non-extension environments

### DIFF
--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -4,7 +4,10 @@ const browserInfo = parseUserAgentString()
 const trackerBlockingEndpointBase = 'https://staticcdn.duckduckgo.com/trackerblocking'
 
 function isMV3 () {
-    return chrome?.runtime.getManifest().manifest_version === 3
+    if (typeof chrome !== 'undefined') {
+        return chrome?.runtime.getManifest().manifest_version === 3
+    }
+    return false
 }
 
 function getConfigFileName () {


### PR DESCRIPTION


## Description:

#1989 regressed the `bundle-config` script, as `chrome` is missing when running in node. This PR fixes that.
