### PR TITLE
Update autofill to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.17.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1874,8 +1874,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3cdba80e529eec104e4f593468ba16c59d79093e",
-            "integrity": "sha512-6FTLmfLT8HzJGw51I1iRHfH+HSYOR/9mSbpPTSpHIvMU/VOhWuSUHJWk/f12y/3rx9WC5adDI5BGXIZtIiv9qA==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#d1558f7757b26f64364dd23d02d235c113d558ae",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15455,7 +15454,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16734,14 +16733,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3cdba80e529eec104e4f593468ba16c59d79093e",
-            "integrity": "sha512-6FTLmfLT8HzJGw51I1iRHfH+HSYOR/9mSbpPTSpHIvMU/VOhWuSUHJWk/f12y/3rx9WC5adDI5BGXIZtIiv9qA==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#3cdba80e529eec104e4f593468ba16c59d79093e"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#d1558f7757b26f64364dd23d02d235c113d558ae",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#7.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#87962a1a3fd9f166fa621c443caebeb09aa0f72e",
             "integrity": "sha512-CpcB45gLZEtI9T+lrcqpUQPklGAZRcFn2FfFNyd7G7Qqn3bZ3ublFxV3KNq9B6r8BaONQXyIcDb8AzkxAb6efg==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#87962a1a3fd9f166fa621c443caebeb09aa0f72e",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.17.0",
             "requires": {
                 "immutable-json-patch": "^5.1.2",
                 "seedrandom": "^3.0.5",
@@ -16752,7 +16750,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16780,7 +16778,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ab527819685c19bda90dc17a763de9933441f2b4",
             "integrity": "sha512-lKSpw+Pei7Jvkwe7iUCCbL1cXpzJ8jZT9jZKPVf7NYx+zyqkPUXbOJylDzc8v5HnIW+REDxNha+SV/XaXVvKUA==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#ab527819685c19bda90dc17a763de9933441f2b4"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#d61691a2fdf9f4dc062a8d248fd1e78c20b5b892",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.17.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.1.0


## Description
Updates Autofill to version [7.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.1.0).

### Autofill 7.1.0 release notes
## What's Changed
* Tons of form fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/322
* Email Protection for Windows + Windows compatibility patches by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/323
* Fix form submission overtriggering by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/324


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/7.0.1...7.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).