### PR TITLE
Update autofill to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.17.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -1874,7 +1874,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#d1558f7757b26f64364dd23d02d235c113d558ae",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#44cd844b6bb5d8ccfefbd6e025817d800c26ad76",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -15454,7 +15454,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16733,8 +16733,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#d1558f7757b26f64364dd23d02d235c113d558ae",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#7.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#44cd844b6bb5d8ccfefbd6e025817d800c26ad76",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#7.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#87962a1a3fd9f166fa621c443caebeb09aa0f72e",
@@ -16750,7 +16750,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16783,7 +16783,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#3adf7e1ce71c6941389fcc890264089727bb1773",
             "integrity": "sha512-eaqJAUYZXi50GuoQlP4x6fSsSmsTSg5sagimQjouKNTqCJRCwr7hx6EhjSBFu9b+1y+oAhgztAW8868FpEe7Xw==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#3adf7e1ce71c6941389fcc890264089727bb1773"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.2.4"
         },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.17.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0


## Description
Updates Autofill to version [7.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0).

### Autofill 7.2.0 release notes
## What's Changed
* Fix Windows UI line bug by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/325
* Remove separator above Duck Address whenever it's first item by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/329
* macOS support for in-context signup by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/317
* Other minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/328


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/7.1.0...7.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).