### PR TITLE
Remove in-context eligible pixel

### DIFF
--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -2,7 +2,6 @@ import browser from 'webextension-polyfill'
 
 import { getURL } from './pixels'
 import load from './load'
-import { daysInstalled } from './utils'
 const { getSetting, updateSetting } = require('./settings')
 const browserWrapper = require('./wrapper')
 const utils = require('./utils')
@@ -166,15 +165,6 @@ export const sendJSPixel = (options) => {
     case 'incontext_close_x':
         fireIncontextSignupPixel('incontext_close_x_extension')
         break
-    case 'email_incontext_eligible': {
-        const shouldFireIncontextEligibilityPixel = getSetting('shouldFireIncontextEligibilityPixel')
-        if (!shouldFireIncontextEligibilityPixel) return
-
-        const daysSinceInstallation = Math.ceil(daysInstalled())
-        fireIncontextSignupPixel('email_incontext_eligible_extension', { days_since_installation: daysSinceInstallation })
-        updateSetting('shouldFireIncontextEligibilityPixel', false)
-        break
-    }
     default:
         console.error('Unknown pixel name', pixelName)
     }

--- a/shared/js/background/email-utils.js
+++ b/shared/js/background/email-utils.js
@@ -166,7 +166,9 @@ export const sendJSPixel = (options) => {
         fireIncontextSignupPixel('incontext_close_x_extension')
         break
     default:
-        console.error('Unknown pixel name', pixelName)
+        browserWrapper.getFromSessionStorage('dev').then(isDev => {
+            if (isDev) console.error('Unknown pixel name', pixelName)
+        })
     }
 }
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
**Related task:** https://app.asana.com/0/0/1204132671693381/f


## Description:
<!-- Explain what is being changed, why, etc -->
Remove support for temporary pixel `email_incontext_eligible` now that it's no longer needed

This change can land as-is, but there's a complementary Autofill PR: https://github.com/duckduckgo/duckduckgo-autofill/pull/330

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
