### PR TITLE
Do not strip subdomains when referrer trimming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1994,8 +1994,7 @@
             "link": true
         },
         "node_modules/@duckduckgo/privacy-reference-tests": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#364cbb762ca98ebd535ed285ed503c7c647d071b",
-            "integrity": "sha512-7csRmadhmxZbEw7eK9QlTZQYVFDu743EjHOM9Mt8BNnlsLUVRw3EC/WI4fs8GzjIklwSq6jrAw20bhcNk8+3vw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#3c04aa5980539ba2852584d202d2b67c1ff32643",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/tracker-surrogates": {
@@ -15546,7 +15545,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -16877,12 +16876,12 @@
         "@duckduckgo/autofill": {
             "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#44cd844b6bb5d8ccfefbd6e025817d800c26ad76",
             "integrity": "sha512-cDrdRI1feC+vv/pvWbHHLoYh+0DX8SVW9h/e1iaye26FmF+LI9xSqhlQjseLmm4/e7ZG6mXpCnCAzJ6q/agv4Q==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#44cd844b6bb5d8ccfefbd6e025817d800c26ad76"
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#7.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#658da08e53cb0cc3dbf41042e7ea2c238ce4bc32",
             "integrity": "sha512-hQKGRxNcoCdk9Zoi619+1TldIYOG3TejY7WISvvoXrJHgjLvEIXdkp38IN2tWKzeEWSqi0QSW4uQnR5SvemS9g==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#658da08e53cb0cc3dbf41042e7ea2c238ce4bc32",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.22.0",
             "requires": {
                 "immutable-json-patch": "^5.1.2",
                 "seedrandom": "^3.0.5",
@@ -16893,7 +16892,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16919,14 +16918,13 @@
             }
         },
         "@duckduckgo/privacy-reference-tests": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#364cbb762ca98ebd535ed285ed503c7c647d071b",
-            "integrity": "sha512-7csRmadhmxZbEw7eK9QlTZQYVFDu743EjHOM9Mt8BNnlsLUVRw3EC/WI4fs8GzjIklwSq6jrAw20bhcNk8+3vw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#364cbb762ca98ebd535ed285ed503c7c647d071b"
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#3c04aa5980539ba2852584d202d2b67c1ff32643",
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#3adf7e1ce71c6941389fcc890264089727bb1773",
             "integrity": "sha512-eaqJAUYZXi50GuoQlP4x6fSsSmsTSg5sagimQjouKNTqCJRCwr7hx6EhjSBFu9b+1y+oAhgztAW8868FpEe7Xw==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#3adf7e1ce71c6941389fcc890264089727bb1773"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.2.4"
         },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",

--- a/shared/js/background/tracker-utils.js
+++ b/shared/js/background/tracker-utils.js
@@ -67,15 +67,9 @@ export function truncateReferrer (referrer, target) {
         return undefined
     }
 
-    let modifiedReferrer = referrer
-    if (isTracker(target) || (fromCname && isTracker(finalURL))) {
-        modifiedReferrer = utils.extractLimitedDomainFromURL(referrer, { keepSubdomains: false })
-    } else {
-        modifiedReferrer = utils.extractLimitedDomainFromURL(referrer, { keepSubdomains: true })
-    }
     // If extractLimitedDomainFromURL fails (for instance, invalid referrer URL), it
     // returns undefined, (in practice, don't modify the referrer), so sometimes this value could be undefined.
-    return modifiedReferrer
+    return utils.extractLimitedDomainFromURL(referrer, { keepSubdomains: true })
 }
 
 /**

--- a/unit-test/background/tracker-utils-tests.js
+++ b/unit-test/background/tracker-utils-tests.js
@@ -196,7 +196,7 @@ describe('Tracker Utilities', () => {
             name: 'target is a tracker, and referrer has a subdomain',
             referrer: 'http://subdomain.siteA.com/article/1',
             target: 'https://google-analytics.com/some/path',
-            expectedReferrer: 'http://sitea.com/'
+            expectedReferrer: 'http://subdomain.sitea.com/'
         },
         {
             name: 'target is not a tracker, referrer should keep subdomain',
@@ -244,7 +244,7 @@ describe('Tracker Utilities', () => {
             name: 'target is a tracker, referrer contains port',
             referrer: 'http://subdomain.siteA.com:4000/article/1',
             target: 'https://google-analytics.com/some/path',
-            expectedReferrer: 'http://sitea.com:4000/'
+            expectedReferrer: 'http://subdomain.sitea.com:4000/'
         },
         {
             name: 'target is a tracker, referrer is localhost',


### PR DESCRIPTION
We're removing the eTLD+1 referrer trimming feature for breakage and party reasons.