### PR TITLE
Add Facebook Click to Load breakage flags

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -130,6 +130,8 @@ export function breakageReportForTab ({
 
     const urlParametersRemoved = tab.urlParametersRemoved ? 'true' : 'false'
     const ctlYouTube = tab.ctlYouTube ? 'true' : 'false'
+    const ctlFacebookPlaceholderShown = tab.ctlFacebookPlaceholderShown ? 'true' : 'false'
+    const ctlFacebookLogin = tab.ctlFacebookLogin ? 'true' : 'false'
     const ampUrl = tab.ampUrl || undefined
     const upgradedHttps = tab.upgradedHttps
 
@@ -140,7 +142,9 @@ export function breakageReportForTab ({
         remoteConfigVersion,
         upgradedHttps: upgradedHttps.toString(),
         urlParametersRemoved,
-        ctlYouTube
+        ctlYouTube,
+        ctlFacebookPlaceholderShown,
+        ctlFacebookLogin
     })
 
     for (const [key, value] of Object.entries(requestCategories)) {

--- a/shared/js/background/classes/tab-state.js
+++ b/shared/js/background/classes/tab-state.js
@@ -38,7 +38,10 @@ export class TabState {
         this.dnrRuleIdsByDisabledClickToLoadRuleAction = {}
         /** @type {boolean} */
         this.ctlYouTube = false // True when at least one YouTube Click to Load placeholder was displayed in the tab.
-
+        /** @type {boolean} */
+        this.ctlFacebookPlaceholderShown = false
+        /** @type {boolean} */
+        this.ctlFacebookLogin = false
         /** @type {boolean} */
         this.allowlisted = false // user-allowlisted sites; applies to all privacy features
         /** @type {boolean} */

--- a/shared/js/background/classes/tab.js
+++ b/shared/js/background/classes/tab.js
@@ -194,6 +194,22 @@ class Tab {
         this._tabState.setValue('ctlYouTube', value)
     }
 
+    get ctlFacebookPlaceholderShown () {
+        return this._tabState.ctlFacebookPlaceholderShown
+    }
+
+    set ctlFacebookPlaceholderShown (value) {
+        this._tabState.setValue('ctlFacebookPlaceholderShown', value)
+    }
+
+    get ctlFacebookLogin () {
+        return this._tabState.ctlFacebookLogin
+    }
+
+    set ctlFacebookLogin (value) {
+        this._tabState.setValue('ctlFacebookLogin', value)
+    }
+
     /**
      * If given a valid adClick redirect, set the adClick to the tab.
      * @param {string} requestURL

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -216,6 +216,44 @@ export function updateYouTubeCTLAddedFlag (value, sender) {
     tab.ctlYouTube = Boolean(value)
 }
 
+/**
+ * @typedef updateFacebookCTLBreakageFlagsRequest
+ * @property {boolean} [ctlFacebookPlaceholderShown=false]
+ *   True if at least one Facebook Click to Load placeholder was shown on the
+ *   page.
+ * @property {boolean} [ctlFacebookLogin=false]
+ *   True if the user clicked to use a Facebook Click to Load login button.
+ */
+
+/**
+ * Sets the Facebook Click to Load breakage flag(s) to true for the page, which
+ * are then included should the user report the webpage as broken.
+ * Note: False values are ignored, the flags are only updated if value is true.
+ *       The flags are reset automatically when the user navigates away from
+ *       the page.
+ * @param {updateFacebookCTLBreakageFlagsRequest} flags
+ * @param {browser.Runtime.MessageSender} sender
+ */
+export function updateFacebookCTLBreakageFlags (
+    { ctlFacebookPlaceholderShown = false, ctlFacebookLogin = false },
+    sender
+) {
+    const tabId = sender?.tab?.id
+    if (typeof tabId === 'undefined') {
+        return
+    }
+
+    const tab = tabManager.get({ tabId })
+
+    if (ctlFacebookPlaceholderShown) {
+        tab.ctlFacebookPlaceholderShown = true
+    }
+
+    if (ctlFacebookLogin) {
+        tab.ctlFacebookLogin = true
+    }
+}
+
 export function setYoutubePreviewsEnabled (value, sender) {
     return updateSetting({ name: 'youtubePreviewsEnabled', value })
 }
@@ -458,6 +496,7 @@ const messageHandlers = {
     getCurrentTab,
     unblockClickToLoadContent,
     updateYouTubeCTLAddedFlag,
+    updateFacebookCTLBreakageFlags,
     setYoutubePreviewsEnabled,
     updateSetting,
     getSetting,

--- a/shared/js/content-scripts/content-scope-messaging.js
+++ b/shared/js/content-scripts/content-scope-messaging.js
@@ -4,7 +4,8 @@ const allowedMessages = [
     'openShareFeedbackPage',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
-    'updateYouTubeCTLAddedFlag'
+    'updateYouTubeCTLAddedFlag',
+    'updateFacebookCTLBreakageFlags'
 ]
 
 function getSecret () {

--- a/unit-test/background/classes/tab.js
+++ b/unit-test/background/classes/tab.js
@@ -112,7 +112,9 @@ describe('Tab', () => {
                 requestId: 123,
                 status: 200,
                 statusCode: null,
-                ctlYouTube: false
+                ctlYouTube: false,
+                ctlFacebookPlaceholderShown: false,
+                ctlFacebookLogin: false
             }
             expect(tabClone.site.enabledFeatures.length).toBe(14)
             expect(JSON.stringify(tabClone, null, 4)).toEqual(JSON.stringify(tabSnapshot, null, 4))


### PR DESCRIPTION
We'd like to get a better idea about how often the Facebook Click to
Load feature causes problems for users. We're adding "breakage flags"
to that end, which are included when a user reports a broken webpage.

**Reviewer:** @franfaccin 
**Depends on:** https://github.com/duckduckgo/content-scope-scripts/pull/610

## Steps to test this PR:
1. Build extension, taking care to include linked content-scope-scripts changes.
2. Open developer tools for extension background page, switch to network panel.
3. Test sending breakage reports, then inspect the sent reports using the networks panel.
4. Check that `ctlFacebookPlaceholderShown` breakage flag is only set to true if there was a placeholder shown on the page. And that `ctlFacebookLogin` is only set to true if the user has clicked a login button (even if they then abort the login flow).

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
