### PR TITLE
Only ship sourcemaps in dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,10 +174,11 @@ BROWSERIFY_GLOBAL_TARGETS += $(shell find node_modules/@duckduckgo/ -maxdepth 1 
 
 BROWSERIFY_BIN = node_modules/.bin/browserify
 BROWSERIFY = $(BROWSERIFY_BIN) -t babelify -t [ babelify --global  --only [ $(BROWSERIFY_GLOBAL_TARGETS) ] --plugins [ "./scripts/rewrite-meta" ] --presets [ @babel/preset-env ] ]
-ESBUILD = node_modules/.bin/esbuild --bundle --target=firefox91,chrome92 --define:BUILD_TARGET=\"$(browser)\" --sourcemap
+ESBUILD = node_modules/.bin/esbuild --bundle --target=firefox91,chrome92 --define:BUILD_TARGET=\"$(browser)\"
 # Ensure sourcemaps are included for the bundles during development.
 ifeq ($(type),dev)
   BROWSERIFY += -d
+  ESBUILD += --sourcemap
 endif
 
 ## Extension background/serviceworker script.


### PR DESCRIPTION
Sourcemaps tip the size of `background.js` to over 4mb, which the Firefox addon store refuses to analyze. Let's revert to only including source maps in dev builds.
