### PR TITLE
Remove Fire button permissions until we ship.

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -85,9 +85,6 @@
         "webNavigation",
         "cookies"
     ],
-    "optional_permissions": [
-        "browsingData"
-    ],
     "host_permissions": [
         "*://*/*"
     ],

--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -84,11 +84,7 @@
         "tabs",
         "storage",
         "<all_urls>",
-        "alarms",
-        "cookies"
-    ],
-    "optional_permissions": [
-        "browsingData"
+        "alarms"
     ],
     "web_accessible_resources": [
         "/web_accessible_resources/*",

--- a/integration-test/fire-button.spec.js
+++ b/integration-test/fire-button.spec.js
@@ -104,7 +104,7 @@ test.describe('Fire Button', () => {
         })
     })
 
-    test('getBurnOptions', async ({ context, backgroundPage }) => {
+    test.skip('getBurnOptions', async ({ context, backgroundPage }) => {
         await forExtensionLoaded(context)
         const fireButton = await getFireButtonHandle(backgroundPage)
         const pages = await openTabs(context)
@@ -198,7 +198,7 @@ test.describe('Fire Button', () => {
         }
     })
 
-    test.describe('burn', () => {
+    test.skip('burn', () => {
         // Skip these tests on MV3.
         // For these tests to work, we need to be able to successfully request the optional `browsingData`
         // permission at runtime (`requestBrowsingDataPermissions`). When running these tests in Playwright,


### PR DESCRIPTION
This will allow us to submit to stores without having to submit justifications for these APIs before we're actually using them.