### PR TITLE
Move newtab-tracker-stats tests to esbuild

### DIFF
--- a/unit-test/helpers/mock-browser-api.js
+++ b/unit-test/helpers/mock-browser-api.js
@@ -1,10 +1,16 @@
 globalThis.browser = {
     storage: {
         local: {
-            set: () => {},
+            set: (value) => {
+                browser.storage.local._setCalls.push(value)
+            },
             get: () => {
                 return {}
-            }
+            },
+            _setCalls: []
+        },
+        managed: {
+            get: () => {}
         }
     },
     browserAction: {

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -1,10 +1,16 @@
 const chrome = {
     storage: {
         local: {
-            set: () => {},
+            set: (value) => {
+                chrome.storage.local._setCalls.push(value)
+            },
             get: () => {
                 return {}
-            }
+            },
+            _setCalls: []
+        },
+        managed: {
+            get: () => {}
         }
     },
     browserAction: {


### PR DESCRIPTION

## Description:
<!-- Explain what is being changed, why, etc -->
Fixes an issue where we can't spy on `browserWrapper.syncToStorage` when using ESBuild to bundle the tests.