### PR TITLE
Also treat new tab page with ATB params as 'special'

### DIFF
--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -262,7 +262,7 @@ export default class Site {
 
         // Our new tab page URL that is hard-coded in the Chromium source.
         // See https://source.chromium.org/chromium/chromium/src/+/main:components/search_engines/prepopulated_engines.json
-        if (url === 'https://duckduckgo.com/chrome_newtab') {
+        if (url.startsWith('https://duckduckgo.com/chrome_newtab')) {
             return 'new tab'
         }
 


### PR DESCRIPTION
## Description:
- After clearing tabs from with the fire button, the privacy dashboard was showing a 'normal' view, rather than the 'special page' view we expect for the new tab page.
- Due to the way the redirect to the NTP happens in this case, we were picking up the URL with ATB params included.
- Our 'special page' detection code expected an exact match, so this URL wasn't detected as 'special'.
- This PR makes the matching accept parameters on the NTP url.