### PR TITLE
Fix checksum code for browsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ JS_BUNDLES = background.js base.js feedback.js options.js devtools-panel.js list
 BUILD_TARGETS = $(addprefix $(BUILD_DIR)/public/js/, $(JS_BUNDLES))
 
 ## Unit tests scripts.
-UNIT_TEST_SRC = unit-test/legacy/*.js unit-test/legacy/reference-tests/*.js unit-test/legacy/storage/*.js
+UNIT_TEST_SRC = unit-test/legacy/*.js unit-test/legacy/reference-tests/*.js
 build/test:
 	mkdir -p $@
 

--- a/shared/js/background/storage/https.js
+++ b/shared/js/background/storage/https.js
@@ -5,9 +5,9 @@ const settings = require('./../settings')
 
 /**
  * Calculate an sha256 checksum (in base64) of the provided base64 string
- * @param {string} data 
+ * @param {string} data
  */
-export async function checksum(data) {
+export async function checksum (data) {
     // Convert base64 string into a Uint8Array
     const binaryString = atob(data)
     const buffer = new Uint8Array(binaryString.length)

--- a/shared/js/background/storage/https.js
+++ b/shared/js/background/storage/https.js
@@ -3,6 +3,27 @@ const load = require('./../load')
 const constants = require('../../../data/constants')
 const settings = require('./../settings')
 
+/**
+ * Calculate an sha256 checksum (in base64) of the provided base64 string
+ * @param {string} data 
+ */
+export async function checksum(data) {
+    // Convert base64 string into a Uint8Array
+    const binaryString = atob(data)
+    const buffer = new Uint8Array(binaryString.length)
+    for (let i = 0; i < binaryString.length; i++) {
+        buffer[i] = binaryString.charCodeAt(i)
+    }
+    // Calculate SHA-256 of the buffer
+    const sha256Buffer = new Uint8Array(await crypto.subtle.digest('SHA-256', buffer))
+    // Convert the buffer back into base64
+    let binary = ''
+    for (let i = 0; i < sha256Buffer.byteLength; i++) {
+        binary += String.fromCharCode(sha256Buffer[i])
+    }
+    return btoa(binary)
+}
+
 class HTTPSStorage {
     constructor () {
         // @ts-ignore - TypeScript is not following the Dexie import property.
@@ -124,26 +145,12 @@ class HTTPSStorage {
         })
     }
 
-    hasCorrectChecksum (data) {
+    async hasCorrectChecksum (data) {
         // not everything has a checksum
-        if (!data.checksum) return Promise.resolve(true)
+        if (!data.checksum) return true
 
-        // TODO: rewrite this check without needing a Buffer polyfill
-        if (typeof Buffer === 'undefined') {
-            return Promise.resolve(true)
-        }
-
-        // need a buffer to send to crypto.subtle
-        const buffer = Buffer.from(data.data, 'base64')
-
-        return crypto.subtle.digest('SHA-256', buffer).then(arrayBuffer => {
-            const sha256 = Buffer.from(arrayBuffer).toString('base64')
-            if (data.checksum.sha256 && data.checksum.sha256 === sha256) {
-                return true
-            } else {
-                return false
-            }
-        })
+        const sha256 = await checksum(data.data)
+        return data.checksum.sha256 && data.checksum.sha256 === sha256
     }
 }
 export default new HTTPSStorage()

--- a/unit-test/background/checksum.js
+++ b/unit-test/background/checksum.js
@@ -1,0 +1,12 @@
+import { checksum } from "../../shared/js/background/storage/https";
+import httpsBloom from './../data/httpsBloom.json'
+
+describe('checksum', () => {
+    it('calculates the sha256 checksum of data', async () => {
+        expect(await checksum('test')).toEqual('ZheqiKcua1JriMvO2jiKe1Kg6FYUihLZuEKc0qU6PqQ=')
+    })
+
+    it('correctly calculates the checksum of a bloom filter', async () => {
+        expect(await checksum(httpsBloom.data)).toEqual(httpsBloom.checksum.sha256)
+    })
+})

--- a/unit-test/background/storage/checksum.js
+++ b/unit-test/background/storage/checksum.js
@@ -1,4 +1,4 @@
-import { checksum } from "../../../shared/js/background/storage/https";
+import { checksum } from '../../../shared/js/background/storage/https'
 import httpsBloom from './../../data/httpsBloom.json'
 
 describe('legacy checksum', () => {

--- a/unit-test/background/storage/checksum.js
+++ b/unit-test/background/storage/checksum.js
@@ -1,7 +1,7 @@
-import { checksum } from "../../shared/js/background/storage/https";
-import httpsBloom from './../data/httpsBloom.json'
+import { checksum } from "../../../shared/js/background/storage/https";
+import httpsBloom from './../../data/httpsBloom.json'
 
-describe('checksum', () => {
+describe('legacy checksum', () => {
     it('calculates the sha256 checksum of data', async () => {
         expect(await checksum('test')).toEqual('ZheqiKcua1JriMvO2jiKe1Kg6FYUihLZuEKc0qU6PqQ=')
     })

--- a/unit-test/background/storage/https.js
+++ b/unit-test/background/storage/https.js
@@ -1,5 +1,3 @@
-require('../../helpers/mock-browser-api')
-
 const httpsStorage = require('../../../shared/js/background/storage/https').default
 const httpsBloom = require('./../../data/httpsBloom.json')
 const httpsAllowlist = require('./../../data/httpsAllowlist.json')


### PR DESCRIPTION
## Description:
- The code to check the checksum of HTTPs bloom filters was disabled after we stopped including a `Buffer` polyfill.
- This also prevented us migrating the test for this to ESBuild.
- This PR replaces the `Buffer` usage for browser-compatible JS, so we can reenabe this check, and move the https test out of the legacy folder.