### PR TITLE
Remove unused referrer attribute on arguments object

### DIFF
--- a/shared/js/background/helpers/arguments-object.js
+++ b/shared/js/background/helpers/arguments-object.js
@@ -17,7 +17,6 @@ export function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
     // Clone site so we don't retain any site changes
     // @ts-ignore
     const site = tabClone.site
-    const referrer = tab?.referrer || ''
     let cookie = {}
 
     // Special case for iframes that are blank we check if it's also enabled
@@ -67,7 +66,6 @@ export function getArgumentsObject (tabId, sender, documentUrl, sessionKey) {
         stringExemptionLists: utils.getBrokenScriptLists(),
         sessionKey,
         site,
-        referrer,
         platform: constants.platform,
         locale: getUserLocale(),
         assets: {


### PR DESCRIPTION
## Description:
 - Due to referrer-trimming feature changes, we no longer need to send a `referrer` attribute with the arguments we sent to the content script.
 - This PR removes that.
 - Depends on https://github.com/duckduckgo/content-scope-scripts/pull/645