### PR TITLE
Handle debug flags sent from C-S-S

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -70,10 +70,6 @@ function constructUrl (querystring, truncate) {
             searchParams.delete(key)
         }
     })
-    if (searchParams.has('debugFlags')) {
-        extraParams += `&debugFlags=${searchParams.get('debugFlags')}`
-        searchParams.delete('debugFlags')
-    }
     url += `${searchParams.toString()}${extraParams}`
     return url
 }
@@ -138,7 +134,7 @@ export function breakageReportForTab ({
     const ctlFacebookLogin = tab.ctlFacebookLogin ? 'true' : 'false'
     const ampUrl = tab.ampUrl || undefined
     const upgradedHttps = tab.upgradedHttps
-    const debugFlags = tab.debugFlags.map(encodeURIComponent).join(',')
+    const debugFlags = tab.debugFlags.join(',')
 
     const brokenSiteParams = new URLSearchParams({
         siteUrl,

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -70,6 +70,10 @@ function constructUrl (querystring, truncate) {
             searchParams.delete(key)
         }
     })
+    if (searchParams.has('debugFlags')) {
+        extraParams += `&debugFlags=${searchParams.get('debugFlags')}`
+        searchParams.delete('debugFlags')
+    }
     url += `${searchParams.toString()}${extraParams}`
     return url
 }
@@ -134,6 +138,7 @@ export function breakageReportForTab ({
     const ctlFacebookLogin = tab.ctlFacebookLogin ? 'true' : 'false'
     const ampUrl = tab.ampUrl || undefined
     const upgradedHttps = tab.upgradedHttps
+    const debugFlags = tab.debugFlags.map(encodeURIComponent).join(',')
 
     const brokenSiteParams = new URLSearchParams({
         siteUrl,
@@ -153,6 +158,7 @@ export function breakageReportForTab ({
 
     if (ampUrl) brokenSiteParams.set('ampUrl', ampUrl)
     if (category) brokenSiteParams.set('category', category)
+    if (debugFlags) brokenSiteParams.set('debugFlags', debugFlags)
     if (description) brokenSiteParams.set('description', description)
 
     return fire(brokenSiteParams.toString())

--- a/shared/js/background/classes/tab-state.js
+++ b/shared/js/background/classes/tab-state.js
@@ -48,6 +48,8 @@ export class TabState {
         this.allowlistOptIn = false
         /** @type {boolean} */
         this.denylisted = false
+        /** @type {string[]} */
+        this.debugFlags = []
         // Whilst restoring, prevent the tab data being stored
         if (!restoring) {
             Storage.backup(this)

--- a/shared/js/background/classes/tab.js
+++ b/shared/js/background/classes/tab.js
@@ -210,6 +210,14 @@ class Tab {
         this._tabState.setValue('ctlFacebookLogin', value)
     }
 
+    get debugFlags () {
+        return this._tabState.debugFlags
+    }
+
+    set debugFlags (value) {
+        this._tabState.setValue('debugFlags', value)
+    }
+
     /**
      * If given a valid adClick redirect, set the adClick to the tab.
      * @param {string} requestURL

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -464,6 +464,13 @@ export async function isClickToLoadYoutubeEnabled () {
     )
 }
 
+export function addDebugFlag (message, sender, req) {
+    const tab = tabManager.get({ tabId: sender.tab.id })
+    const flags = new Set(tab.debugFlags)
+    flags.add(message.flag)
+    tab.debugFlags = [...flags]
+}
+
 /**
  * Add a new message handler.
  * @param {string} name
@@ -522,6 +529,7 @@ const messageHandlers = {
     debuggerMessage,
     search,
     openShareFeedbackPage,
-    isClickToLoadYoutubeEnabled
+    isClickToLoadYoutubeEnabled,
+    addDebugFlag
 }
 export default messageHandlers

--- a/shared/js/content-scripts/content-scope-messaging.js
+++ b/shared/js/content-scripts/content-scope-messaging.js
@@ -2,6 +2,7 @@ const allowedMessages = [
     'getClickToLoadState',
     'getYouTubeVideoDetails',
     'openShareFeedbackPage',
+    'addDebugFlag',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
     'updateYouTubeCTLAddedFlag',

--- a/unit-test/background/classes/tab.js
+++ b/unit-test/background/classes/tab.js
@@ -114,7 +114,8 @@ describe('Tab', () => {
                 statusCode: null,
                 ctlYouTube: false,
                 ctlFacebookPlaceholderShown: false,
-                ctlFacebookLogin: false
+                ctlFacebookLogin: false,
+                debugFlags: []
             }
             expect(tabClone.site.enabledFeatures.length).toBe(14)
             expect(JSON.stringify(tabClone, null, 4)).toEqual(JSON.stringify(tabSnapshot, null, 4))


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @shakyShane 
**CC:** @jonathanKingston 
**Depends on:** https://github.com/duckduckgo/content-scope-scripts/pull/648

## Description:
MVP infra for generic debug flags for C-S-S features. This is not yet a full Messaging implementation, which should come in later stages of the project.

## Steps to test this PR:
0. Add a log to the breakage report, or set up a proxy to see the breakage pixel URL
1. Build the extension with C-S-S changes from https://github.com/duckduckgo/content-scope-scripts/pull/648
2. Open any page with enabled protections (e.g. example.com)
3. Trigger the protections:
  - `navigator.hardwareConcurrency`
  - `(await navigator.getBattery()).charging` (Chromium only)
4. Send a breakage report form
5. Verify that `debugFlags` parameter is present in the pixel URL

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205073793816813