### PR TITLE
Generate static MV3 rulesets for tracker blocking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,16 @@ cd -
 npm run bundle-config
 ```
 
+### Updating the MV3 blocklists
+
+Manifest v3 (MV3) builds of the extension contain bundled static declarativeNetRequest rulesets and corresponding block lists for Tracker Blocking. Both the default (aka current)
+and a fallback blocklist are included. The fallback blocklist serves as a backup in case the current blocklist is catastrophically broken. To ensure that builds are reproducible,
+the current and fallback blocklist versions are defined in `shared/data/etags.json`. The blocklists are fetched and rulesets generated automatically when the extension is built.
+
+To update the blocklist versions, use the `npm run update-mv3-blocklists` command. Remember to then commit the changes to `shared/data/etags.json` and rebuild the extension.
+
+**Note: The migration to static Tracker Blocking rulesets is in progress. They are not created or used, but will be soon.**
+
 ### Development flow
 
 The `shared` directory contains JS, CSS, and images that are shared by all browsers for things like the options

--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,48 @@ ifeq ('$(browser)','chrome-mv3')
   BUILD_TARGETS += $(BUILD_DIR)/data/bundled/smarter-encryption-rules.json
 endif
 
+## Generate Tracker Blocking declarativeNetRequest rulesets for MV3 builds.
+
+# Necessary since "&:" grouped target syntax is not supported currently with
+# versions (< 4.3) of Make shipped with macOS. See $(LAST_COPY) comment above
+# for more context.
+LAST_MV3_BLOCKLIST_FETCH = build/.last-mv3-blocklist-fetch
+LAST_MV3_RULESET_BUILD = build/.last-mv3-ruleset-build-$(browser)-$(type)
+
+$(LAST_MV3_BLOCKLIST_FETCH): shared/data/etags.json
+	node scripts/fetchMV3Blocklists.mjs
+	touch $@
+
+.SECONDARY:
+$(INTERMEDIATES_DIR)/current-mv3-tds.json $(INTERMEDIATES_DIR)/fallback-mv3-tds.json: $(LAST_MV3_BLOCKLIST_FETCH)
+	touch $@
+
+$(BUILD_DIR)/data/bundled/current-mv3-tds.json: $(INTERMEDIATES_DIR)/current-mv3-tds.json
+	cp $< $@
+
+$(BUILD_DIR)/data/bundled/fallback-mv3-tds.json: $(INTERMEDIATES_DIR)/fallback-mv3-tds.json
+	cp $< $@
+
+$(LAST_MV3_RULESET_BUILD): $(INTERMEDIATES_DIR)/current-mv3-tds.json $(INTERMEDIATES_DIR)/fallback-mv3-tds.json $(INTERMEDIATES_DIR)/surrogates.json
+	npx ddg2dnr tds $(INTERMEDIATES_DIR)/current-mv3-tds.json $(INTERMEDIATES_DIR)/surrogates.json \
+	  $(BUILD_DIR)/data/bundled/current-tds-rules.json $(BUILD_DIR)/data/bundled/current-ctl-allowing-rules.json
+	npx ddg2dnr tds $(INTERMEDIATES_DIR)/fallback-mv3-tds.json $(INTERMEDIATES_DIR)/surrogates.json \
+	  $(BUILD_DIR)/data/bundled/fallback-tds-rules.json $(BUILD_DIR)/data/bundled/fallback-ctl-allowing-rules.json
+	touch $@
+
+# TODO: Uncomment this for the switch to static tracker blocking declarativeNetRequest rulesets.
+# ifeq ('$(browser)','chrome-mv3')
+#   BUILD_TARGETS += $(LAST_MV3_RULESET_BUILD)
+#   BUILD_TARGETS += $(BUILD_DIR)/data/bundled/current-mv3-tds.json $(BUILD_DIR)/data/bundled/fallback-mv3-tds.json
+# endif
+
+# Generate the list of "surrogate" (stub) scripts.
 $(BUILD_DIR)/data/surrogates.txt: $(BUILD_DIR)/web_accessible_resources $(LAST_COPY)
 	node scripts/generateListOfSurrogates.js -i $</ > $@
+
+.SECONDARY:
+$(INTERMEDIATES_DIR)/surrogates.json: $(BUILD_DIR)/web_accessible_resources $(LAST_COPY)
+	node scripts/generateListOfSurrogates.js --json -i $</ > $@
 
 BUILD_TARGETS += $(BUILD_DIR)/data/surrogates.txt
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "beta-firefox": "make beta-firefox browser=firefox type=release",
         "release-chrome": "make browser=chrome type=release && make chrome-release-zip",
         "release-chrome-mv3": "make browser=chrome-mv3 type=release && make chrome-mv3-release-zip",
-        "beta-chrome-mv3": "make chrome-mv3-beta browser=chrome-mv3 type=release"
+        "beta-chrome-mv3": "make chrome-mv3-beta browser=chrome-mv3 type=release",
+        "update-mv3-blocklists": "node scripts/updateMV3Blocklists.mjs"
     },
     "devDependencies": {
         "@fingerprintjs/fingerprintjs": "^3.4.2",

--- a/packages/ddg2dnr/README.md
+++ b/packages/ddg2dnr/README.md
@@ -28,7 +28,7 @@ Generate the TDS ruleset:
 
 ```bash
 npm run tds ../tds-input.json ../supported-surrogates-input.json ../tds-ruleset-output.json \
-        [../match-details-by-rule-id-output.json]
+        [../allowing-rules-by-ctl-action-output.json] [../match-details-by-rule-id-output.json]
 ```
 
 Note:

--- a/packages/ddg2dnr/cli.js
+++ b/packages/ddg2dnr/cli.js
@@ -38,11 +38,12 @@ async function main () {
         }
         break
     case 'tds':
-        if (args.length < 3 || args.length > 4) {
+        if (args.length < 3 || args.length > 5) {
             console.error(
                 'Usage: npm run tds',
                 './tds-input.json ./supported-surrogates-input.json ',
                 './tds-ruleset-output.json ',
+                '[./allowing-rules-by-ctl-action-output.json]',
                 '[./match-details-by-rule-id-output.json]'
             )
         } else {
@@ -50,27 +51,29 @@ async function main () {
                 tdsFilePath,
                 supportedSurrogatesPath,
                 rulesetFilePath,
+                allowingRulesByCtlActionFilePath,
                 mappingFilePath
             ] = args
 
             const browser = new PuppeteerInterface()
             const isRegexSupported = browser.isRegexSupported.bind(browser)
 
-            const { ruleset, matchDetailsByRuleId } =
-                  await generateTdsRuleset(
-                      JSON.parse(
-                          fs.readFileSync(tdsFilePath, { encoding: 'utf8' })
-                      ),
-                      new Set(
-                          JSON.parse(
-                              fs.readFileSync(
-                                  supportedSurrogatesPath, { encoding: 'utf8' }
-                              )
-                          )
-                      ),
-                      '/web_accessible_resources/',
-                      isRegexSupported
-                  )
+            const {
+                allowingRulesByClickToLoadAction, ruleset, matchDetailsByRuleId
+            } = await generateTdsRuleset(
+                JSON.parse(
+                    fs.readFileSync(tdsFilePath, { encoding: 'utf8' })
+                ),
+                new Set(
+                    JSON.parse(
+                        fs.readFileSync(
+                            supportedSurrogatesPath, { encoding: 'utf8' }
+                        )
+                    )
+                ),
+                '/web_accessible_resources/',
+                isRegexSupported
+            )
 
             browser.closeBrowser()
 
@@ -78,6 +81,13 @@ async function main () {
                 rulesetFilePath,
                 JSON.stringify(ruleset, null, '\t')
             )
+
+            if (allowingRulesByCtlActionFilePath) {
+                fs.writeFileSync(
+                    allowingRulesByCtlActionFilePath,
+                    JSON.stringify(allowingRulesByClickToLoadAction, null, '\t')
+                )
+            }
 
             if (mappingFilePath) {
                 fs.writeFileSync(

--- a/scripts/bundleConfig.mjs
+++ b/scripts/bundleConfig.mjs
@@ -2,12 +2,13 @@ import fetch from 'node-fetch'
 import fs from 'fs'
 import config from '../shared/data/constants.js'
 
-const outputEtagFile = './shared/data/etags.json'
+import { writeEtags } from './utils.mjs'
+
 const bundlePath = './shared/data/bundled/'
 const configProps = config.tdsLists.find((c) => c.name === 'config')
-const etags = {}
 
 async function getConfig (name, url) {
+    const etags = {}
     const response = await fetch(url)
     if (!response.ok) {
         throw new Error(`Failed to load tds list ${name}: ${url}`)
@@ -19,11 +20,12 @@ async function getConfig (name, url) {
     const urlObject = new URL(url)
     const fileName = urlObject.pathname.split('/').pop()
     fs.writeFileSync(`${bundlePath}/${fileName}`, fileText)
+    return etags
 }
 
 async function fetchConfigs () {
-    await getConfig('config', configProps.url)
-    fs.writeFileSync(outputEtagFile, JSON.stringify(etags))
+    const etags = await getConfig('config', configProps.url)
+    writeEtags(etags)
     console.log('Config imported successfully')
 }
 

--- a/scripts/fetchMV3Blocklists.mjs
+++ b/scripts/fetchMV3Blocklists.mjs
@@ -1,0 +1,47 @@
+import { dirname } from 'path'
+import { mkdirSync, writeFileSync } from 'fs'
+
+import { md5sum, readEtags } from './utils.mjs'
+
+const currentTdsPath = './build/.intermediates/current-mv3-tds.json'
+const fallbackTdsPath = './build/.intermediates/fallback-mv3-tds.json'
+
+const etagTdsURL =
+      etag => `https://staticcdn.duckduckgo.com/trackerblocking/tds/by-hash/tds-${etag}.json`
+
+async function download (url, path) {
+    const response = await fetch(url)
+    if (!response.ok) {
+        throw new Error('Failed to fetch MV3 blocklist from ' + url)
+    }
+    const fileText = await response.text()
+    writeFileSync(path, fileText)
+}
+
+async function ensureBlocklists () {
+    const {
+        'current-mv3-tds-etag': targetCurrentEtag,
+        'fallback-mv3-tds-etag': targetFallbackEtag
+    } = readEtags()
+
+    if (!targetCurrentEtag || !targetFallbackEtag) {
+        throw new Error('Missing MV3 blocklist entries in etags.json')
+    }
+
+    const existingCurrentEtag = md5sum(currentTdsPath)
+    const existingFallbackEtag = md5sum(fallbackTdsPath)
+
+    if (existingCurrentEtag && existingCurrentEtag === targetCurrentEtag &&
+        existingFallbackEtag && existingFallbackEtag === targetFallbackEtag) {
+        console.log('No need to fetch MV3 blocklists, already up to date.')
+        return
+    }
+
+    mkdirSync(dirname(currentTdsPath), { recursive: true })
+    await download(etagTdsURL(targetCurrentEtag), currentTdsPath)
+    await download(etagTdsURL(targetFallbackEtag), fallbackTdsPath)
+
+    console.log('Fetched MV3 blocklists successfully.')
+}
+
+ensureBlocklists()

--- a/scripts/generateListOfSurrogates.js
+++ b/scripts/generateListOfSurrogates.js
@@ -12,6 +12,11 @@ if (!fs.existsSync(argv.i)) {
 
 const files = fs.readdirSync(argv.i)
 
-files.forEach(file => {
-    console.log(`domain.com/${file} application/javascript\n`)
-})
+if (argv.json) {
+    console.log(JSON.stringify(files, null, 2))
+} else {
+    // Legacy format used by the extension at runtime.
+    files.forEach(file => {
+        console.log(`domain.com/${file} application/javascript\n`)
+    })
+}

--- a/scripts/updateMV3Blocklists.mjs
+++ b/scripts/updateMV3Blocklists.mjs
@@ -1,0 +1,52 @@
+import { dirname } from 'path'
+
+import { readEtags, writeEtags } from './utils.mjs'
+
+function listConstants (listName) {
+    return {
+        url: `https://staticcdn.duckduckgo.com/trackerblocking/v6/${listName}/extension-mv3-tds.json`,
+        path: `./build/.intermediates/${listName}-mv3-tds.json`,
+        etagKey: `${listName}-mv3-tds-etag`
+    }
+}
+
+async function fetchBlocklistEtag (url) {
+    const response = await fetch(url)
+    if (!response.ok) {
+        throw new Error('Failed to fetch MV3 blocklist from ' + url)
+    }
+
+    return response.headers.get('etag')?.split('"')[1]
+}
+
+async function updateBlocklists () {
+    const existingEtags = readEtags()
+
+    let changes = false
+    const latestEtags = {}
+    for (const listName of ['current', 'fallback']) {
+        const { url, path, etagKey } = listConstants(listName)
+
+        const existingEtag = existingEtags[etagKey]
+        const latestEtag = await fetchBlocklistEtag(url)
+        latestEtags[etagKey] = latestEtag
+
+        if (!latestEtag) {
+            throw new Error('Failed to check latest MV3 blocklist etags')
+        }
+
+        if (latestEtag !== existingEtag) {
+            console.log(`Updating ${listName} MV3 blocklist to ${latestEtag}`)
+            changes = true
+        }
+    }
+
+    if (changes) {
+        writeEtags(latestEtags)
+    }
+    else {
+        console.log('MV3 blocklists already up to date, no update necessary.')
+    }
+}
+
+updateBlocklists()

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,0 +1,57 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { createHash } from 'node:crypto'
+
+const etagFilePath = './shared/data/etags.json'
+
+/**
+ * Reads the shared/data/etags.json file, and returns the stored etag values. If
+ * the file does not yet exist an empty Object is returned.
+ * Note: For convenience, all stored etags are returned. But take care to
+ *       pull out only relevant etags. That way those etags can be updated later
+ *       without overwriting any changes to unrelated etags.
+ * @return {Record<string, string>}
+ */
+export function readEtags () {
+    try {
+        return JSON.parse(readFileSync(etagFilePath))
+    } catch (e) {
+        return { }
+    }
+}
+
+/**
+ * Updates the shared/data/etags.json file with the provided etag values.
+ * Creates the file if it does not already exist. Ignores non-string values
+ * provided and preserves any existing values in the file that weren't updated.
+ * Note: It is not safe to use this function concurrently with anything that
+ *       might also write to the etags file.
+ * @param {Record<string, string|undefined>} newEtags
+ */
+export function writeEtags (newEtags) {
+    const etags = readEtags()
+    for (let [key, value] of Object.entries(newEtags)) {
+        if (typeof value === 'string') {
+            etags[key] = value
+        }
+    }
+    writeFileSync(etagFilePath, JSON.stringify(etags, null, 2))
+}
+
+/**
+ * Reads the file and returns a MD5 checksum formatted as a hex string. If the
+ * file can't be read, null is returned.
+ * @param {string} path
+ * @return {string?}
+ */
+export function md5sum (path) {
+    let contents
+    try {
+        contents = readFileSync(path)
+    } catch (e) {
+        return null
+    }
+
+    const hash = createHash('md5')
+    hash.update(contents)
+    return hash.digest('hex')
+}

--- a/shared/data/etags.json
+++ b/shared/data/etags.json
@@ -1,1 +1,5 @@
-{"config-etag":"W/\"cc137ac829435e649d6132e9c87cfffe\""}
+{
+  "config-etag": "W/\"cc137ac829435e649d6132e9c87cfffe\"",
+  "current-mv3-tds-etag": "3c222272c0e8376cded30b095e62ea51",
+  "fallback-mv3-tds-etag": "da18c835eadd0a76dbe9b09b7c4e8608"
+}


### PR DESCRIPTION
Generate static MV3 rulesets for tracker blocking

So far, we have managed to keep the necessary declarativeNetRequest
rules for tracker blocking and related features to below the 5,000
dynamic rule limit[1]. However, as we expand the block list and our
protections, the limit is approaching. At the time of writing we're up
to around 4,000 dynamic rules, and that is trending upwards.

Furthermore, for our Safari MV3 port, we will need even more rules for
our protections, since rule conditions such as requestDomains and
excludedRequestDomains are not yet supported.

Therefore, we're going to move to static declarativeNetRequest
rulesets for tracker blocking. As a first step, let's set up the
instrumentation to fetch and update the current/fallback[2] blocklists,
and to generate the corresponding static rulesets.

1 - https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#property-MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES
2 - During the technical design phase, we decided to add a fallback
    blocklist to MV3 builds as well as the current blocklist. That
    way, if there is a catastrophic problem, we should have a way to
    revert to an older and hopefully less broken blocklist.

**Reviewer:** @sammacbeth 
**CC:** @jdorweiler 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
- Check the `npm run bundle-config` command works as before.
- Check that the `npm run update-mv3-blocklists` successfully updates etags.json with the latest current/fallback blocklist etag. If you tweak one of the etags in `shared/data/etags.json` before running the command you should see the command updating it back, but otherwise it should say that the lists are up to date already.
- Check that building the extension for Chrome MV3 (e.g. `npm run dev-chrome-mv3`) successfully fetches the blocklists and generates the ruleset files in `build/chrome-mv3/dev/data/bundled`:
  - `current-mv3-tds.json` - Current blocklist
  - `fallback-mv3-tds.json` - Fallback blocklist
  - `current-ctl-allowing-rules.json`, `fallback-ctl-allowing-rules.json` - CTL allowing declarativeNetRequest rules by rule action for the corresponding blocklist.
  - current-tds-rules.json`, `fallback-tds-rules.json` - declarativeNetRequest rules for tracker blocking for the corresponding blocklist.  

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
