### PR TITLE
Force trigger config reload when patching config in tests

### DIFF
--- a/integration-test/helpers/testConfig.js
+++ b/integration-test/helpers/testConfig.js
@@ -82,6 +82,7 @@ export async function loadTestConfig (bgPage, testConfigFilename) {
             globalThis.configBackup[pathString] = target[lastPathPart]
             target[lastPathPart] = pageTestConfig[pathString]
         }
+        return globalThis.dbg.tds._internalOnListUpdate('config', globalThis.dbg.tds.config)
     }, {
         pageTestConfig: testConfig,
         parsePathString: parsePath.toString()

--- a/integration-test/storage-blocking.spec.js
+++ b/integration-test/storage-blocking.spec.js
@@ -98,7 +98,7 @@ test.describe('Storage blocking Tests', () => {
             await backgroundWait.forAllConfiguration(backgroundPage)
             await loadTestConfig(backgroundPage, 'storage-blocking.json')
             await loadTestTds(backgroundPage, 'mock-tds.json')
-            // await routeFromLocalhost(page)
+            await routeFromLocalhost(page)
 
             // reset allowlists
             await backgroundPage.evaluate(async (domain) => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
     testDir: './integration-test',
     /* Maximum time one test can run for. */
-    timeout: 60 * 1000,
+    timeout: 20 * 1000,
     expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
     testDir: './integration-test',
     /* Maximum time one test can run for. */
-    timeout: 20 * 1000,
+    timeout: 30 * 1000,
     expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.


### PR DESCRIPTION
- In some integration tests we patch the config object stored in `tdsStorage` directly.
- For MV3, we might not catch this config change unless the config updated event is fired.
- This PR triggers this event manually after patching, so MV3 rules will be correctly generated.
- This should fix some intemittent test failures, where config patches weren't picked up.