### PR TITLE
Add counteract experiment atb allocation

### DIFF
--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -63,7 +63,7 @@ test.describe('install workflow', () => {
             const atb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
             const setAtb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
             const extiSent = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('extiSent'))
-            const atbPattern = new RegExp("^" + mockAtb.version + "(vk|vj)$");
+            const atbPattern = new RegExp('^' + mockAtb.version + '(vk|vj)$')
 
             // check the extension's internal state is correct
             expect(atb).toMatch(atbPattern)

--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -63,9 +63,10 @@ test.describe('install workflow', () => {
             const atb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
             const setAtb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
             const extiSent = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('extiSent'))
+            const atbPattern = new RegExp("^" + mockAtb.version + "(vk|vj)$");
 
             // check the extension's internal state is correct
-            expect(atb).toEqual(mockAtb.version)
+            expect(atb).toMatch(atbPattern)
             expect(setAtb).toEqual(atb)
             expect(extiSent).toBeTruthy()
 

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -183,8 +183,8 @@ const ATB = (() => {
                     })
 
                     // in case there is no assigned atb variant, enroll into Chrome Counteract experiment
-                    if (!atb && settings.getSetting(atb) && settings.getSetting(atb).atb && utils.getBrowserName() === 'chrome') {
-                        atb = ATB.getChromeCounteractExpATB(settings.getSetting(atb).atb)
+                    if (!atb && settings.getSetting('atb') && utils.getBrowserName() === 'chrome') {
+                        atb = ATB.getChromeCounteractExpATB(settings.getSetting('atb'))
                     }
 
                     if (atb) {

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -5,6 +5,7 @@
 import browser from 'webextension-polyfill'
 
 const settings = require('./settings')
+const utils = require('./utils')
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string')
 const load = require('./load')
 const browserWrapper = require('./wrapper')
@@ -168,65 +169,10 @@ const ATB = (() => {
             return new URLSearchParams()
         },
 
-        /**
-         * Takes an optional date object and returns an object with ATB majorVersion, minorVersion, and version string
-         * The majorVersion rolls over every Wed at 00:00:00 ET
-         * The minorVersion rolls over every night at midnight ET
-         *
-         * @typedef {Object} AtbVersionInfo
-         * @property {number} majorVersion - # of weeks since noon EST on 2/24/16
-         * @property {number} minorVersion - # of days into the current week
-         * @property {string} version - the version string combining both major and minor version. Format: `v${majorVersion}-${minorVersion}`
-         *
-         * @return {AtbVersionInfo}
-         */
-        getATBVersionInfo: () => {
-            const date = new Date()
-            const localTime = date.getTime()
-
-            // convert local to UTC:
-            const utcTime = localTime + date.getTimezoneOffset() * ONE_MINUTE
-
-            // convert to approximation of est using 5 hour offset so we
-            // can compare to the DST start/stop date in eastern time and
-            // determine whether it's DST or not.
-            const est = new Date(utcTime + ONE_HOUR * -5)
-
-            // First determine DST start/end day for Eastern Timezone.
-            // It's always the 2nd Sunday in March. In 2016 it's 3/13/16 and 11/6/16, In 2017 it's 3/12/17 and 11/5/17, etc.
-            const dstStartDay = 13 - ((est.getFullYear() - 2016) % 6)
-            const dstStopDay = 6 - ((est.getFullYear() - 2016) % 6)
-
-            // Once we have start/stop day for the current year, we can check whether the current day (based on est) is
-            // within the EDT window:
-            const isDST =
-              (est.getMonth() > 2 ||
-                (est.getMonth() === 2 && est.getDate() >= dstStartDay)) &&
-              (est.getMonth() < 10 ||
-                (est.getMonth() === 10 && est.getDate() < dstStopDay))
-
-            // finally we need to adjust the epoch based on whether we're in EST or EDT, since
-            // the constant ATB_EPOCH is in EST, when we're in EDT we need to subtract an
-            // hour otherwise we'll be off by 1 hour when we try to calc the major/minor version #'s:
-            const epoch = isDST ? ATB_EPOCH - ONE_HOUR : ATB_EPOCH
-
-            // time in ms since DST adjusted epoch:
-            const timeSinceATBEpoch = localTime - epoch
-
-            const majorVersion = Math.ceil(timeSinceATBEpoch / ONE_WEEK)
-            const minorVersion = Math.ceil((timeSinceATBEpoch % ONE_WEEK) / ONE_DAY)
-
-            return {
-                minorVersion,
-                majorVersion,
-                version: 'v' + majorVersion + '-' + minorVersion
-            }
-        },
-
-        getChromeCounteractExpATB: (atbString) => {
+        getChromeCounteractExpATB: (atb) => {
             const variant = 'v'
             const atbVariant = Math.random() < 0.5 ? 'k' : 'j'
-            return `${atbString}${variant}${atbVariant}`
+            return `${atb}${variant}${atbVariant}`
         },
 
         updateATBValues: () => {
@@ -243,9 +189,9 @@ const ATB = (() => {
                         return !!atb
                     })
 
-                    // in case there is no assigned atb, enroll into Chrome Counteract experiment
-                    if (!atb) {
-                        atb = ATB.getChromeCounteractExpATB(ATB.getATBVersionInfo().version)
+                    // in case there is no assigned atb variant, enroll into Chrome Counteract experiment
+                    if (!atb && settings.getSetting(atb) && settings.getSetting(atb).atb && utils.getBrowserName() === 'chrome') {
+                        atb = ATB.getChromeCounteractExpATB(settings.getSetting(atb).atb)
                     }
 
                     if (atb) {

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -217,15 +217,15 @@ const ATB = (() => {
             const minorVersion = Math.ceil((timeSinceATBEpoch % ONE_WEEK) / ONE_DAY)
 
             return {
-                minorVersion: minorVersion,
-                majorVersion: majorVersion,
+                minorVersion,
+                majorVersion,
                 version: 'v' + majorVersion + '-' + minorVersion
             }
         },
 
         getChromeCounteractExpATB: (atbString) => {
             const variant = 'v'
-            const atbVariant = Math.random() < 0.5 ? 'k' : 'k'
+            const atbVariant = Math.random() < 0.5 ? 'k' : 'j'
             return `${atbString}${variant}${atbVariant}`
         },
 

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -16,13 +16,6 @@ const { generateDNRRule } = require('@duckduckgo/ddg2dnr/lib/utils')
 const ATB_ERROR_COHORT = 'v1-1'
 const ATB_FORMAT_RE = /(v\d+-\d(?:[a-z_]{2})?)$/
 
-// 00:00:00 EST on 2/24/16
-const ATB_EPOCH = 1456290000000
-const ONE_WEEK = 604800000
-const ONE_DAY = 86400000
-const ONE_HOUR = 3600000
-const ONE_MINUTE = 60000
-
 // list of accepted params in ATB url
 const ACCEPTED_URL_PARAMS = ['natb', 'cp', 'npi']
 

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -254,8 +254,8 @@ describe('complex install workflow cases', () => {
         return atb.updateATBValues()
             .then(() => {
                 validateExtiWasHit('v112-2')
-                expect(settings.getSetting('atb')).toEqual('v112-2')
-                expect(settings.getSetting('set_atb')).toEqual('v112-2')
+                expect(settings.getSetting('atb')).toMatch(/v112-2v[jk]/)
+                expect(settings.getSetting('set_atb')).toMatch(/v112-2v[jk]/)
             })
     })
     it('should handle the install process correctly if there\'s DDG pages open that pass an ATB param', () => {
@@ -282,8 +282,8 @@ describe('complex install workflow cases', () => {
         return atb.updateATBValues()
             .then(() => {
                 validateExtiWasHit('v112-2')
-                expect(settings.getSetting('atb')).toEqual('v112-2')
-                expect(settings.getSetting('set_atb')).toEqual('v112-2')
+                expect(settings.getSetting('atb')).toMatch(/v112-2v[jk]/)
+                expect(settings.getSetting('set_atb')).toMatch(/v112-2v[jk]/)
             })
     })
 })


### PR DESCRIPTION
Add counteract experiment atb allocation

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
@sammacbeth @sballesteros 

<!-- Optional fields
**CC:** @moollaza 
**Depends on:** 
-->

## Description:
Allocates users who installed the extension but haven't been assigned any atb into the counteract experiment.


## Steps to test this PR:
1. `npm run dev-chrome`
2. In Chrome, install the extension (the dev version), wait for extension-success page to open, verify that either `atb=v388-2vk` or `atb=v388-2vj` is present in the URL.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
