### PR TITLE
Update autofill to 8.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.30.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b1160df954eea20cd4cdf9356afc369751981b16",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#40bcd0d347b51d14e8114f191df2817d8dcb4284",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11497,8 +11497,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b1160df954eea20cd4cdf9356afc369751981b16",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.0.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#40bcd0d347b51d14e8114f191df2817d8dcb4284",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.1.2"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a4f35ad23ac4a0eb9b36b94f1f2aa0f0ebf2855d",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.30.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2


## Description
Updates Autofill to version [8.1.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.1.2).

### Autofill 8.1.2 release notes
## What's Changed
* Ema/fix script naming by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/364
* Minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/365
* Send a breakage report flag when autofill is "activated" on the page by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/363
* Fix extension bugs by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/366
* Add regression test by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/367

## New Contributors
* @muodov made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/363

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.1...8.1.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).