### PR TITLE
Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     target-branch: "main"
     labels:
       - "dependencies"
+    groups:
+      external-dependencies:
+        exclude-patterns:
+         - "puppeteer"
+         - "@duckduckgo/*"
+         - "privacy-test-pages"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

This PR configures dependabot to group PRs for non-internal packages.