### PR TITLE
Force set list values to false on Site initialization

### DIFF
--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -130,7 +130,7 @@ export default class Site {
         const globalLists = ['allowlisted', 'allowlistOptIn', 'denylisted']
         globalLists.forEach((name) => {
             const list = settings.getSetting(name) || {}
-            this.setListValue(name, list[this.domain])
+            this.setListValue(name, list[this.domain] || false)
         })
     }
 


### PR DESCRIPTION
When recreating a Site object with an existing TabState object, we were not resetting allow- and deny-list values when the URL changed. This means that an allowlisted site would have that state persisted to other sites after a navigation.

We can fix this by force setting the value to false when creating the Site object.