### PR TITLE
Fix dependabot grouping syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,12 @@ updates:
       - "dependencies"
     groups:
       external-dependencies:
+        patterns:
+          - "*"
         exclude-patterns:
-         - "puppeteer"
-         - "@duckduckgo/*"
-         - "privacy-test-pages"
+          - "puppeteer"
+          - "@duckduckgo/*"
+          - "privacy-test-pages"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes #2201 : `patterns` is required.