### PR TITLE
Update AMP protection with strict http checking

### DIFF
--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -200,7 +200,7 @@ async function fetchAMPURL (site, url) {
             return null
         }
 
-        const newSite = new Site(firstCanonicalLink.href)
+        const newSite = new Site(newUrl.href)
 
         if (isSiteExcluded(newSite)) {
             return null

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -55,8 +55,10 @@ function isHttpUrl (url) {
  */
 function isSiteExcluded (site) {
     if (site.specialDomainName || !site.isFeatureEnabled(featureName)) {
-        return null
+        return true
     }
+
+    return false
 }
 
 /**
@@ -79,10 +81,12 @@ function extractAMPURL (site, url) {
         const match = url.match(regexPattern)
         let needsScheme = false
         if (match && match.length > 1) {
-            if (!isHttpUrl(url)) {
+            const targetUrl = match[1]
+            console.log(targetUrl)
+            if (!isHttpUrl(targetUrl)) {
                 try {
                     // eslint-disable-next-line no-unused-vars
-                    const newUrl = new URL(`https://${match[1]}`)
+                    const newUrl = new URL(`https://${targetUrl}`)
                     // Avoid using the direct result of the URL constructor
                     // to prevent encoding issues causing unwanted redirects
                     needsScheme = true
@@ -91,9 +95,9 @@ function extractAMPURL (site, url) {
                 }
             }
 
-            const newSite = new Site(needsScheme ? `https://${match[1]}` : match[1])
+            const newSite = new Site(needsScheme ? `https://${targetUrl}` : targetUrl)
 
-            if (!isSiteExcluded(newSite)) {
+            if (isSiteExcluded(newSite)) {
                 return null
             }
 

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -91,6 +91,7 @@ function extractAMPURL (site, url) {
                     // to prevent encoding issues causing unwanted redirects
                     needsScheme = true
                 } catch {
+                    // If the URL constructor throws an error, then the URL is invalid
                     return null
                 }
             }

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -56,10 +56,10 @@ function extractAMPURL (site, url) {
                 if (!newUrl.protocol.startsWith('http')) {
                     return null
                 }
-            } catch (e) {
+            } catch {
                 try {
                     newUrl = new URL(`https://${match[1]}`)
-                } catch (e) {
+                } catch {
                     return null
                 }
             }
@@ -169,14 +169,14 @@ async function fetchAMPURL (site, url) {
 
     if (firstCanonicalLink && firstCanonicalLink instanceof HTMLLinkElement) {
         // Only follow http(s) links
-        let newUrl;
+        let newUrl
         try {
             newUrl = new URL(firstCanonicalLink.href)
             if (!newUrl.protocol.startsWith('http')) {
                 return null
             }
         } catch {
-            return null;
+            return null
         }
 
         const newSite = new Site(newUrl.href)

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -200,7 +200,7 @@ async function fetchAMPURL (site, url) {
             return null
         }
 
-        const newSite = new Site(newUrl.href)
+        const newSite = new Site(firstCanonicalLink.href)
 
         if (isSiteExcluded(newSite)) {
             return null

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -49,7 +49,11 @@ function extractAMPURL (site, url) {
     for (const regexPattern of ampSettings.linkFormats) {
         const match = url.match(regexPattern)
         if (match && match.length > 1) {
-            const newSite = new Site(match[1].startsWith('http') ? match[1] : `https://${match[1]}`)
+            let newUrl = match[1]
+            if (newUrl.match(/^.+\:\/\//) && !newUrl.startsWith('http')) {
+                return null    
+            }
+            const newSite = new Site(newUrl.startsWith('http') ? newUrl : `https://${newUrl}`)
 
             if (newSite.specialDomainName || !newSite.isFeatureEnabled(featureName)) {
                 return null
@@ -153,6 +157,11 @@ async function fetchAMPURL (site, url) {
     const firstCanonicalLink = doc.querySelector('[rel="canonical"]')
 
     if (firstCanonicalLink && firstCanonicalLink instanceof HTMLLinkElement) {
+        // Only follow http(s) links
+        if (!firstCanonicalLink.href.startsWith('http')) {
+            return null
+        }
+
         const newSite = new Site(firstCanonicalLink.href)
 
         if (newSite.specialDomainName || !newSite.isFeatureEnabled(featureName)) {

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -49,22 +49,26 @@ function extractAMPURL (site, url) {
     for (const regexPattern of ampSettings.linkFormats) {
         const match = url.match(regexPattern)
 
-        let newUrl
+        let needsScheme = false
         if (match && match.length > 1) {
             try {
-                newUrl = new URL(match[1])
+                const newUrl = new URL(match[1])
                 if (!newUrl.protocol.startsWith('http')) {
                     return null
                 }
             } catch {
                 try {
-                    newUrl = new URL(`https://${match[1]}`)
+                    // eslint-disable-next-line no-unused-vars
+                    const newUrl = new URL(`https://${match[1]}`)
+                    // Avoid using the direct result of the URL constructor
+                    // to prevent encoding issues causing unwanted redirects
+                    needsScheme = true
                 } catch {
                     return null
                 }
             }
 
-            const newSite = new Site(newUrl.href)
+            const newSite = new Site(needsScheme ? `https://${match[1]}` : match[1])
 
             if (newSite.specialDomainName || !newSite.isFeatureEnabled(featureName)) {
                 return null
@@ -169,9 +173,8 @@ async function fetchAMPURL (site, url) {
 
     if (firstCanonicalLink && firstCanonicalLink instanceof HTMLLinkElement) {
         // Only follow http(s) links
-        let newUrl
         try {
-            newUrl = new URL(firstCanonicalLink.href)
+            const newUrl = new URL(firstCanonicalLink.href)
             if (!newUrl.protocol.startsWith('http')) {
                 return null
             }
@@ -179,7 +182,7 @@ async function fetchAMPURL (site, url) {
             return null
         }
 
-        const newSite = new Site(newUrl.href)
+        const newSite = new Site(firstCanonicalLink.href)
 
         if (newSite.specialDomainName || !newSite.isFeatureEnabled(featureName)) {
             return null

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -77,7 +77,6 @@ function extractAMPURL (site, url) {
 
     for (const regexPattern of ampSettings.linkFormats) {
         const match = url.match(regexPattern)
-
         let needsScheme = false
         if (match && match.length > 1) {
             if (!isHttpUrl(url)) {

--- a/shared/js/background/amp-protection.js
+++ b/shared/js/background/amp-protection.js
@@ -49,9 +49,9 @@ function extractAMPURL (site, url) {
     for (const regexPattern of ampSettings.linkFormats) {
         const match = url.match(regexPattern)
         if (match && match.length > 1) {
-            let newUrl = match[1]
-            if (newUrl.match(/^.+\:\/\//) && !newUrl.startsWith('http')) {
-                return null    
+            const newUrl = match[1]
+            if (newUrl.match(/^.+:\/\//) && !newUrl.startsWith('http')) {
+                return null
             }
             const newSite = new Site(newUrl.startsWith('http') ? newUrl : `https://${newUrl}`)
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
See https://app.asana.com/0/414235014887631/1205292391529323/f for context.

This PR enforces strict checking for http links in AMP protection. Deep extraction has been updated to check if the extracted link is http and discards it otherwise. However deep extraction is currently disabled in the extension. I've made the same update to the simple link extraction case for google.com domains. For instance https://www.google.com/amp/s/javascript://example.com should redirect to a 404 page.

## Steps to test this PR:
1. Smoke test this page: https://privacy-test-pages.glitch.me/privacy-protections/amp/
2. Check https://privacy-test-pages.glitch.me/privacy-protections/amp/ redirects to a 404 page.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
