### PR TITLE
Update autofill to 8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#40bcd0d347b51d14e8114f191df2817d8dcb4284",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11408,7 +11408,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11498,13 +11498,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#40bcd0d347b51d14e8114f191df2817d8dcb4284",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.1.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#13ba2572f7012ff80da673044a4b7b8c8d006cf1",
             "integrity": "sha512-Pes/NemxxeAFfl7v23qp33vcNEoDve6zNK3CeJ+qimYKI1ShciUbkHTZ/zaXc0wWxYybWdi/BueXHCwAURuBwQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#13ba2572f7012ff80da673044a4b7b8c8d006cf1",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.34.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "seedrandom": "^3.0.5",
@@ -11515,7 +11515,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0


## Description
Updates Autofill to version [8.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0).

### Autofill 8.2.0 release notes
## What's Changed
* Updates for iOS in-context signup support by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/347
* Trigger tooltip option on pointer up by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/333


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.2...8.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).