### PR TITLE
Update autofill to 8.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.3.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,8 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
-            "integrity": "sha512-sPE6gm67vsxoZEg9CdV6kRCn5uXCvWbGphQR3T0lHFD0n6PkKw1cc63Syjh6lt4OmBVsXY3vLbtMYAupeX0N1g==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21aa20e272b7de06e471c6e646d25e26a5887b60",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11022,7 +11021,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11112,14 +11111,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
-            "integrity": "sha512-sPE6gm67vsxoZEg9CdV6kRCn5uXCvWbGphQR3T0lHFD0n6PkKw1cc63Syjh6lt4OmBVsXY3vLbtMYAupeX0N1g==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21aa20e272b7de06e471c6e646d25e26a5887b60",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60611066fe8db8ae597d21a6ae731ed5985f0f88",
             "integrity": "sha512-qFg/V8QrYAMmsYnpEmwXp3+EH4BS7iccotY2aaHCFblIqpiqz8/czJp+RzWVNG7Q9siZf8mve2k2U6zu0SU7wQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#60611066fe8db8ae597d21a6ae731ed5985f0f88",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.35.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "seedrandom": "^3.0.5",
@@ -11130,7 +11128,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -11152,7 +11150,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#0d23f76801c2e73ae7d5ed7daa4af4aca5beec73",
             "integrity": "sha512-VStkOksiGgdNqFmuNudvba9sBLzJ2gUmDAFaxamPV9UvTJhwkxJgXre01/USzW9PTRu8cwvE1H7ZwEH9N8QcRA==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#0d23f76801c2e73ae7d5ed7daa4af4aca5beec73"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#5ee6961fccbf7bf9311d42d26836617400c4eae6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.3.0


## Description
Updates Autofill to version [8.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.3.0).

### Autofill 8.3.0 release notes
## What's Changed
* Update password-related json files (2023-08-30) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/378
* Speed up tests and other perf improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/381


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.2.0...8.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).