### PR TITLE
Update autofill to 8.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.3.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21aa20e272b7de06e471c6e646d25e26a5887b60",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#f3eccad8647fdba2b5d180a02a0513c61375b8fb",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11125,8 +11125,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21aa20e272b7de06e471c6e646d25e26a5887b60",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.3.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#f3eccad8647fdba2b5d180a02a0513c61375b8fb",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60611066fe8db8ae597d21a6ae731ed5985f0f88",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.3.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.0


## Description
Updates Autofill to version [8.4.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.0).

### Autofill 8.4.0 release notes
## What's Changed
* Improve non-English matching by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/374


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.3.0...8.4.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).