### PR TITLE
Update autofill to 8.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#f3eccad8647fdba2b5d180a02a0513c61375b8fb",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#55466f10a339843cb79a27af62d5d61c030740b2",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11125,8 +11125,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#f3eccad8647fdba2b5d180a02a0513c61375b8fb",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#55466f10a339843cb79a27af62d5d61c030740b2",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60611066fe8db8ae597d21a6ae731ed5985f0f88",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1


## Description
Updates Autofill to version [8.4.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1).

### Autofill 8.4.1 release notes
## What's Changed
* Precompile regexes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/382
* Add perf tests by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/383
* deps: remove deprecated content-scope-utils by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/384
* Update dependencies by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/368
* Fix perf regressions by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/385


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.0...8.4.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).