### PR TITLE
Update autofill to 8.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.2",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#55466f10a339843cb79a27af62d5d61c030740b2",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6dd7d696d4e666cedb2f1890a46fe53615226646",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11036,7 +11036,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11126,8 +11126,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#55466f10a339843cb79a27af62d5d61c030740b2",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6dd7d696d4e666cedb2f1890a46fe53615226646",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.2"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60611066fe8db8ae597d21a6ae731ed5985f0f88",
@@ -11143,7 +11143,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -11170,7 +11170,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#acf0c0fd89502af696a112126178511b84f21e72",
             "integrity": "sha512-V3tHscLDhf3QP//tq3RXA7l/rYDXLGnL0BnCXanhaQw7j2cKg1uMbUj78u2MG8yS3OqErPkiMMFsra+ZkYuurA==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#acf0c0fd89502af696a112126178511b84f21e72"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.2.6"
         },
         "@esbuild/android-arm": {
             "version": "0.19.3",
@@ -16835,7 +16835,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#582b1a6d690a572931d694b69339d19a51ae5deb",
             "integrity": "sha512-g+CNKf4nSYuhku8ivSQr69a0Vgg5CECkHi8VA/RUyOCsxEQEtZlr0VHSZwRoOV32hSwhwJbbcWL+2Aigh4E1xQ==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#582b1a6d690a572931d694b69339d19a51ae5deb",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.2.2",
             "requires": {
                 "body-parser": "^1.20.1",
                 "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.2


## Description
Updates Autofill to version [8.4.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.2).

### Autofill 8.4.2 release notes
## What's Changed
* Ema/perf followups by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/386
* Fix handler regression by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/392
* Bump markdown-it from 13.0.1 to 13.0.2 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/388
* Revert mutation observer for forms by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/396


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.1...8.4.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).