### PR TITLE
Update autofill to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.39.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6dd7d696d4e666cedb2f1890a46fe53615226646",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11237,7 +11237,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11327,13 +11327,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6dd7d696d4e666cedb2f1890a46fe53615226646",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#8.4.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#9.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#aa279a3b006a0b1e009707311283c7fcaed24fb7",
             "integrity": "sha512-Al2OR2BI3nCUr8lgSIi8nI2Yegu5VC8zNp+ahk6elpSy5SErvVjbWYTln0C+0anWCB8Ogwd9wcr6EZc+h8iD4A==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#aa279a3b006a0b1e009707311283c7fcaed24fb7",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.39.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "seedrandom": "^3.0.5",
@@ -11344,7 +11344,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -11371,7 +11371,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0cdd37272c9cb8721b67ddcfde0dd9d00269662f",
             "integrity": "sha512-10tbdyPjjVuDjUQk1M2+PuceqBl/8zZgrX6/kWzBLWKOVwLVJCWZSmBfU2MxtZ6zPltAo4k3LoWY81eIOhhFdw==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#0cdd37272c9cb8721b67ddcfde0dd9d00269662f"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.2.7"
         },
         "@esbuild/android-arm": {
             "version": "0.19.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.4.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.39.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.0.0


## Description
Updates Autofill to version [9.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.0.0).

### Autofill 9.0.0 release notes
## What's Changed
* Set up in-context signup for Android by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/397


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.2...9.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).