### PR TITLE
Remove Chrome Counteract Exp code

### DIFF
--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -63,10 +63,9 @@ test.describe('install workflow', () => {
             const atb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('atb'))
             const setAtb = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('set_atb'))
             const extiSent = await backgroundPage.evaluate(() => globalThis.dbg.settings.getSetting('extiSent'))
-            const atbPattern = new RegExp('^' + mockAtb.version + '(vk|vj)?$')
 
             // check the extension's internal state is correct
-            expect(atb).toMatch(atbPattern)
+            expect(atb).toEqual(mockAtb.version)
             expect(setAtb).toEqual(atb)
             expect(extiSent).toBeTruthy()
 

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -3,10 +3,8 @@
  * Please see https://duck.co/help/privacy/atb for more information.
  */
 import browser from 'webextension-polyfill'
-import { getUserLocale } from './i18n.js'
 
 const settings = require('./settings')
-const utils = require('./utils')
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string')
 const load = require('./load')
 const browserWrapper = require('./wrapper')
@@ -159,14 +157,7 @@ const ATB = (() => {
             return new URLSearchParams()
         },
 
-        getChromeCounteractExpATB: (atb) => {
-            const variant = 'v'
-            const atbVariant = Math.random() < 0.5 ? 'k' : 'j'
-            return `${atb}${variant}${atbVariant}`
-        },
-
         updateATBValues: () => {
-            const browserInfo = parseUserAgentString()
             // wait until settings is ready to try and get atb from the page
             return settings.ready()
                 .then(ATB.setInitialVersions)
@@ -179,15 +170,6 @@ const ATB = (() => {
                         atb = params.has('atb') && params.get('atb')
                         return !!atb
                     })
-
-                    // in case there is no assigned atb variant, enroll into Chrome Counteract experiment
-                    if (!atb &&
-                        settings.getSetting('atb') &&
-                        utils.getBrowserName() === 'chrome' &&
-                        getUserLocale() === 'en' &&
-                        browserInfo.os !== 'l') {
-                        atb = ATB.getChromeCounteractExpATB(settings.getSetting('atb'))
-                    }
 
                     if (atb) {
                         settings.updateSetting('atb', atb)

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -254,8 +254,8 @@ describe('complex install workflow cases', () => {
         return atb.updateATBValues()
             .then(() => {
                 validateExtiWasHit('v112-2')
-                expect(settings.getSetting('atb')).toMatch(/v112-2(v[jk])?/)
-                expect(settings.getSetting('set_atb')).toMatch(/v112-2(v[jk])?/)
+                expect(settings.getSetting('atb')).toEqual('v112-2')
+                expect(settings.getSetting('set_atb')).toEqual('v112-2')
             })
     })
     it('should handle the install process correctly if there\'s DDG pages open that pass an ATB param', () => {
@@ -282,8 +282,8 @@ describe('complex install workflow cases', () => {
         return atb.updateATBValues()
             .then(() => {
                 validateExtiWasHit('v112-2')
-                expect(settings.getSetting('atb')).toMatch(/v112-2(v[jk])?/)
-                expect(settings.getSetting('set_atb')).toMatch(/v112-2(v[jk])?/)
+                expect(settings.getSetting('atb')).toEqual('v112-2')
+                expect(settings.getSetting('set_atb')).toEqual('v112-2')
             })
     })
 })


### PR DESCRIPTION
**Reviewer:**
@jonathanKingston 

## Description:
Removes code added in https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2145, https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2160, 


## Steps to test this PR:
- Close any tabs for duckduckgo.com
- Build + install extension
- Post-install page (/extension-success) should open
- Confirm that no ATB letters are part of the `atb=` value

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
