### PR TITLE
Update autofill to 9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.41.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,8 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
-            "integrity": "sha512-jHjV3SxqOH7iHjlLX6yi+J4grkMtPmtwGNcVimNxCgJ/8uFA+k+lndeQycbYthgM6OrNfstPf8abdFqRg8nHzw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3b8211a59020c875422c65937e41f9b2536606e1",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11166,7 +11165,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11256,14 +11255,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff",
-            "integrity": "sha512-jHjV3SxqOH7iHjlLX6yi+J4grkMtPmtwGNcVimNxCgJ/8uFA+k+lndeQycbYthgM6OrNfstPf8abdFqRg8nHzw==",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#c8e895c8fd50dc76e8d8dc827a636ad77b7f46ff"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3b8211a59020c875422c65937e41f9b2536606e1",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#9.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e467598d20d55b5b32a8988f2ad6df336331d2b9",
             "integrity": "sha512-Esb4Dtb/pHG7IwWeq0a0k58uem5PqPwYQaU8QgR6o7u/ZrbV5GpvPkf9GttQI2Em0SmtohSFzYEGNc5DjUTdfA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#e467598d20d55b5b32a8988f2ad6df336331d2b9",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.41.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "seedrandom": "^3.0.5",
@@ -11274,7 +11272,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -11285,7 +11283,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#77e0d89399286697b29ee120f3f4f2bbec3618bc",
             "integrity": "sha512-ksQz52OOn0Vt2/oEnzX5qSBBmwlGiZygkoQ5H1cDtdB8x/GNFoq9b8U8FnlsT9M9gzmsxVs5p7jL6MRwsluL5Q==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#77e0d89399286697b29ee120f3f4f2bbec3618bc"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#2.0.1"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -11301,7 +11299,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#abd6067fac9693cc5a43d48931b111ca08cb0d5a",
             "integrity": "sha512-ZlkSuYY8MMnIFfAj7buXhPcDcon4f8ymWsGimhiB9R6KKpYi1j35ZkiWFGK1QLqbSHAChECxq9a/18BmSdHFJg==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#abd6067fac9693cc5a43d48931b111ca08cb0d5a"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.2.9"
         },
         "@esbuild/android-arm": {
             "version": "0.19.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.41.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0


## Description
Updates Autofill to version [9.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0).

### Autofill 9.1.0 release notes
## What's Changed
* Re-enable mutObs with better safeguards by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/403
* Bump zod from 3.22.2 to 3.22.4 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/395
* Workaround for pcsretirement by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/406


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/9.0.0...9.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).