### PR TITLE
Revert "Disable local proxying for adclick attribution tests"

### DIFF
--- a/integration-test/click-attribution.spec.js
+++ b/integration-test/click-attribution.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from './helpers/playwrightHarness'
 import backgroundWait from './helpers/backgroundWait'
 import testCases from 'privacy-test-pages/adClickFlow/shared/testCases.json'
+import { routeFromLocalhost } from './helpers/testPages'
 
 if (testCases.length === 0) {
     throw new Error('No test cases found')
@@ -50,6 +51,8 @@ test.describe('Ad click blocking', () => {
         // Allow to filter to one test case
         const itMethod = testCase.only ? test.only : test
         itMethod(testCase.name, async ({ context }) => {
+            // route requests from all pages in this test to our local test server
+            await routeFromLocalhost(context)
             let page = await context.newPage()
             for (const step of testCase.steps) {
                 if (step.action.type === 'navigate') {

--- a/integration-test/helpers/testPages.js
+++ b/integration-test/helpers/testPages.js
@@ -2,7 +2,12 @@ const testPageHosts = new Set([
     'privacy-test-pages.site',
     'broken.third-party.site',
     'good.third-party.site',
-    'bad.third-party.site'
+    'bad.third-party.site',
+    'convert.ad-company.site',
+    // 'www.search-company.site',
+    // 'www.ad-company.site', - redirects to these domains via route overriding seem to hang, so this one has to hit the real server
+    'www.publisher-company.site',
+    'www.payment-company.site'
 ])
 
 export const TEST_SERVER_ORIGIN = 'http://127.0.0.1:3000'


### PR DESCRIPTION
Reverts duckduckgo/duckduckgo-privacy-extension#2285

This change was to fix test failures, but we want to re-enable this long-term.