### PR TITLE
MV3: Request content-script config on first tick

### DIFF
--- a/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
+++ b/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
@@ -1151,9 +1151,6 @@
                 "privilegedDomains": [
                     {
                         "domain": "duckduckgo.com"
-                    },
-                    {
-                        "domains": "privacy-test-pages.site"
                     }
                 ]
             }

--- a/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
+++ b/integration-test/data/staticcdn/trackerblocking/config/v2/extension-chromemv3-config.json
@@ -1146,7 +1146,17 @@
         "navigatorInterface": {
             "exceptions": [],
             "state": "enabled",
-            "hash": "e25bc15aae118274e8d4481baf2033dd"
+            "hash": "e25bc15aae118274e8d4481baf2033dd",
+            "settings": {
+                "privilegedDomains": [
+                    {
+                        "domain": "duckduckgo.com"
+                    },
+                    {
+                        "domains": "privacy-test-pages.site"
+                    }
+                ]
+            }
         },
         "nonTracking3pCookies": {
             "settings": {

--- a/integration-test/navigator-interface.spec.js
+++ b/integration-test/navigator-interface.spec.js
@@ -3,9 +3,15 @@ import backgroundWait from './helpers/backgroundWait'
 import { TEST_SERVER_ORIGIN } from './helpers/testPages'
 
 test.describe('navigatorInterface', () => {
-    test('injects navigator.duckduckgo interface into pages', async ({ backgroundPage, page, context }) => {
+    test('injects navigator.duckduckgo interface into pages', async ({ backgroundPage, page, context, manifestVersion }) => {
         await backgroundWait.forExtensionLoaded(context)
         await backgroundWait.forAllConfiguration(backgroundPage)
+        if (manifestVersion === 3) {
+            // wait for content-script registration to complete
+            await backgroundPage.evaluate(() => {
+                return globalThis.components.scriptInjection.ready
+            })
+        }
         await page.goto('https://privacy-test-pages.site/features/navigator-interface.html')
         expect(await page.locator('#interface').innerText()).toBe('interface: true')
         expect(await page.locator('#isDuckDuckGo').innerText()).toBe('isDuckDuckGo: true')

--- a/shared/data/bundled/extension-config.json
+++ b/shared/data/bundled/extension-config.json
@@ -4410,9 +4410,6 @@
                 "privilegedDomains": [
                     {
                         "domain": "duckduckgo.com"
-                    },
-                    {
-                        "domains": "privacy-test-pages.site"
                     }
                 ]
             },

--- a/shared/data/bundled/extension-config.json
+++ b/shared/data/bundled/extension-config.json
@@ -4410,6 +4410,9 @@
                 "privilegedDomains": [
                     {
                         "domain": "duckduckgo.com"
+                    },
+                    {
+                        "domains": "privacy-test-pages.site"
                     }
                 ]
             },


### PR DESCRIPTION
The navigator-interface test is often flakey on MV3. This seems to be because, on a slow machine, extension startup and content-script registration are slow. The means that we actually load the test page before the content-scripts are registered.

Now that we exposed MV3 content-script registration via a component, we can wait for that to complete before loading the test page.