### PR TITLE
switch to true|false for protectionsState param

### DIFF
--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -200,7 +200,7 @@ export async function breakageReportForTab ({
         ctlYouTube,
         ctlFacebookPlaceholderShown,
         ctlFacebookLogin,
-        protectionsState: tab.site.isFeatureEnabled('contentBlocking') ? '1' : '0'
+        protectionsState: tab.site.isFeatureEnabled('contentBlocking')
     })
 
     for (const [key, value] of Object.entries(requestCategories)) {

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -156,7 +156,7 @@ describe('Broken Site Reporting tests / protections state', () => {
         spyOnProperty(tab.site, 'enabledFeatures').and.returnValue(['contentBlocking'])
 
         const params = await submit(tab)
-        expect(params.get('protectionsState')).toEqual('1')
+        expect(params.get('protectionsState')).toEqual('true')
     })
     it('sends 1 when site is denylisted', async () => {
         const tab = new Tab({ url: 'https://example.com' })
@@ -165,7 +165,7 @@ describe('Broken Site Reporting tests / protections state', () => {
         spyOnProperty(tab.site, 'denylisted').and.returnValue(true)
 
         const params = await submit(tab)
-        expect(params.get('protectionsState')).toEqual('1')
+        expect(params.get('protectionsState')).toEqual('true')
     })
     it('sends 0 when site is allowlisted', async () => {
         const tab = new Tab({ url: 'https://example.com' })
@@ -173,7 +173,7 @@ describe('Broken Site Reporting tests / protections state', () => {
         spyOnProperty(tab.site, 'allowlisted').and.returnValue(true)
 
         const params = await submit(tab)
-        expect(params.get('protectionsState')).toEqual('0')
+        expect(params.get('protectionsState')).toEqual('false')
     })
     it('sends 0 when contentBlocking is not enabled', async () => {
         const tab = new Tab({ url: 'https://example.com' })
@@ -182,7 +182,7 @@ describe('Broken Site Reporting tests / protections state', () => {
         spyOnProperty(tab.site, 'enabledFeatures').and.returnValue([])
 
         const params = await submit(tab)
-        expect(params.get('protectionsState')).toEqual('0')
+        expect(params.get('protectionsState')).toEqual('false')
     })
     it('sends 0 when domain is in unprotectedTemporary', async () => {
         const tab = new Tab({ url: 'https://example.com' })
@@ -191,6 +191,6 @@ describe('Broken Site Reporting tests / protections state', () => {
         spyOnProperty(tab.site, 'isBroken').and.returnValue(true)
 
         const params = await submit(tab)
-        expect(params.get('protectionsState')).toEqual('0')
+        expect(params.get('protectionsState')).toEqual('false')
     })
 })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->
https://app.asana.com/0/0/1205915950517975/f

**Reviewer:** @GuiltyDolphin @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Switching to true|false instead of 1|0 for cross-platform consistency. See the parent task https://app.asana.com/0/1201141132935289/1205644489547731


## Steps to test this PR:
- [ ] Submit the breakage form with protections on
- [ ] Verify that the breakage form pixel param `protectionsState` is the string `true`
- [ ] Submit the breakage form with protections off
- [ ] Verify that the breakage form pixel param `protectionsState` is the string `false`


## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
