### PR TITLE
Update autofill to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.42.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3b8211a59020c875422c65937e41f9b2536606e1",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#93677cc02cfe650ce7f417246afd0e8e972cd83e",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11255,8 +11255,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3b8211a59020c875422c65937e41f9b2536606e1",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#9.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#93677cc02cfe650ce7f417246afd0e8e972cd83e",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2d20aa39264155a87a5de942ff8d6b760d1e7842",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.42.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.0


## Description
Updates Autofill to version [10.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.0).

### Autofill 10.0.0 release notes
## What's Changed
* Don't call getAvailableInputTypes from topFrame by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/411
* Super small fix by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/412
* Send getRuntimeConfiguration to native on macOS by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/379


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/9.1.0...10.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).