### PR TITLE
Update autofill to 10.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.53.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#93677cc02cfe650ce7f417246afd0e8e972cd83e",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#dbecae0df07650a21b5632a92fa2e498c96af7b5",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11183,7 +11183,7 @@
             },
             "devDependencies": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "packages/privacy-grade": {
@@ -11273,13 +11273,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#93677cc02cfe650ce7f417246afd0e8e972cd83e",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#dbecae0df07650a21b5632a92fa2e498c96af7b5",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#27163de217ad2beeea791112a2568576b73389d9",
             "integrity": "sha512-CwC4KrBmeQcuWJakbs5Cpz4BzgH2hQPWQ65gDnUM2lxWweSWKoKefBXWQ3U5VvWmQMllRneF9nc0W1a8/rGMMg==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#27163de217ad2beeea791112a2568576b73389d9",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.53.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11291,7 +11291,7 @@
             "version": "file:packages/ddg2dnr",
             "requires": {
                 "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -11317,7 +11317,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#ba0d8cefe4432723ec75b998241efd2454dff35a",
             "integrity": "sha512-eBuAc2uMRfZ1P/pfeQ5IE/qzKB7cw30+8b01xT3GOehm/+NhTwjCO8+/LqE3jOWzYW6C9S8u0lTQmtaB+wjBcQ==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#ba0d8cefe4432723ec75b998241efd2454dff35a"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.3.0"
         },
         "@esbuild/android-arm": {
             "version": "0.19.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.53.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.1


## Description
Updates Autofill to version [10.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.1).

### Autofill 10.0.1 release notes
## What's Changed
* Tweak pulldown menu copy on desktop by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/433
* Update password-related json files (2023-12-06) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/434


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.0...10.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).