### PR TITLE
Prevent extension crash when omnibox API is not available.

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -19,6 +19,7 @@ import { onStartup } from './startup'
 import FireButton from './components/fire-button'
 import TabTracker from './components/tab-tracking'
 import MV3ContentScriptInjection from './components/mv3-content-script-injection'
+import OmniboxSearch from './components/omnibox-search'
 import initDebugBuild from './devbuild'
 import initReloader from './devbuild-reloader'
 import tabManager from './tab-manager'
@@ -40,7 +41,8 @@ settings.ready().then(() => {
  * }}
  */
 const components = {
-    tabTracking: new TabTracker({ tabManager })
+    tabTracking: new TabTracker({ tabManager }),
+    omnibox: new OmniboxSearch()
 }
 
 // Chrome-only components

--- a/shared/js/background/components/omnibox-search.js
+++ b/shared/js/background/components/omnibox-search.js
@@ -1,0 +1,20 @@
+import browser from 'webextension-polyfill'
+import { getOsName } from '../utils'
+
+export default class OmniboxSearch {
+    constructor () {
+        this.apiAvailable = !!browser.omnibox
+        if (this.apiAvailable) {
+            // search via omnibox
+            browser.omnibox.onInputEntered.addListener(async function (text) {
+                const tabs = await browser.tabs.query({
+                    currentWindow: true,
+                    active: true
+                })
+                browser.tabs.update(tabs[0].id, {
+                    url: 'https://duckduckgo.com/?q=' + encodeURIComponent(text) + '&bext=' + getOsName() + 'cl'
+                })
+            })
+        }
+    }
+}

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -274,17 +274,6 @@ browser.tabs.onActivated.addListener(() => {
     browserWrapper.notifyPopup({ closePopup: true })
 })
 
-// search via omnibox
-browser.omnibox.onInputEntered.addListener(async function (text) {
-    const tabs = await browser.tabs.query({
-        currentWindow: true,
-        active: true
-    })
-    browser.tabs.update(tabs[0].id, {
-        url: 'https://duckduckgo.com/?q=' + encodeURIComponent(text) + '&bext=' + utils.getOsName() + 'cl'
-    })
-})
-
 /**
  * MESSAGES
  */


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Guards our use of `browser.omnibox` so the extension doesn't crash when this API is missing. This is the case in Firefox on Android and for Safari MV3 extensions.

I've also moved this code into its own component, as part of ongoing work to clean up `events.js`.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
