### PR TITLE
ddg2dnr: share reference-tests dependency version with parent project.

### DIFF
--- a/packages/ddg2dnr/package.json
+++ b/packages/ddg2dnr/package.json
@@ -5,8 +5,7 @@
     "repository": "duckduckgo/ddg2dnr",
     "bin": "cli.js",
     "devDependencies": {
-        "mocha": "10.2.0",
-        "privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#c179445"
+        "mocha": "10.2.0"
     },
     "scripts": {
         "extension-configuration": "node cli.js extension-configuration",


### PR DESCRIPTION
I noticed that the reference-test version in ddg2dnr was out of sync with the parent project. Removing it from ddg2dnr's package.json will cause the version to be inherited from the extension.