### PR TITLE
Update autofill to 10.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.54.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#dbecae0df07650a21b5632a92fa2e498c96af7b5",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#5597bc17709c8acf454ecaad4f4082007986242a",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -8108,12 +8108,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/privacy-reference-tests": {
-            "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/privacy-test-pages": {
             "resolved": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#582b1a6d690a572931d694b69339d19a51ae5deb",
             "integrity": "sha512-g+CNKf4nSYuhku8ivSQr69a0Vgg5CECkHi8VA/RUyOCsxEQEtZlr0VHSZwRoOV32hSwhwJbbcWL+2Aigh4E1xQ==",
@@ -11042,8 +11036,7 @@
                 "ddg2dnr": "cli.js"
             },
             "devDependencies": {
-                "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "mocha": "10.2.0"
             }
         },
         "packages/privacy-grade": {
@@ -11133,13 +11126,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#dbecae0df07650a21b5632a92fa2e498c96af7b5",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#5597bc17709c8acf454ecaad4f4082007986242a",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.2"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ddc9aef4a9753c0ff9ae19c3ae9139cca1448127",
             "integrity": "sha512-UpEs3XYxb5W/JvOEevGxtdWzhJGMvz2Q/JIzAXpD0Jd2nq/DDz9YQee/rWyyCKHtdxZyxB5EF801WjI05k7hWQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#ddc9aef4a9753c0ff9ae19c3ae9139cca1448127",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.54.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11150,8 +11143,7 @@
         "@duckduckgo/ddg2dnr": {
             "version": "file:packages/ddg2dnr",
             "requires": {
-                "mocha": "10.2.0",
-                "privacy-reference-tests": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4"
+                "mocha": "10.2.0"
             }
         },
         "@duckduckgo/jsbloom": {
@@ -16827,11 +16819,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
-        },
-        "privacy-reference-tests": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c17944584aa6b78c72675af04facd003ba2f97e4",
-            "dev": true,
-            "from": "privacy-reference-tests@github:duckduckgo/privacy-reference-tests#c179445"
         },
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#582b1a6d690a572931d694b69339d19a51ae5deb",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.54.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.2


## Description
Updates Autofill to version [10.0.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.2).

### Autofill 10.0.2 release notes
## What's Changed
* Copy change by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/443
* Update password-related json files (2023-12-13) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/442


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.1...10.0.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).