### PR TITLE
Update autofill to 10.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -186,7 +186,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#5597bc17709c8acf454ecaad4f4082007986242a",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11312,13 +11312,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#5597bc17709c8acf454ecaad4f4082007986242a",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.3"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bb027f14bec7fbb1a85d308139e7a66686da160e",
             "integrity": "sha512-s4hPm51R9jhuezWyqNBlbf78QeY6A4MXQcV59eotydu+eADjyU3dl8sfT5qdc3H4u4nVvSX5YRdGy60EFChonQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#bb027f14bec7fbb1a85d308139e7a66686da160e",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.59.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3


## Description
Updates Autofill to version [10.0.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3).

### Autofill 10.0.3 release notes
## What's Changed
* Use the default branch when checking out repos by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/444
* Password update flows by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/453
* Bump @types/jest from 29.5.5 to 29.5.11 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/439
* Update password-related json files (2023-12-21) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/454
* Move test forms out of src by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/457
* Move integration tests around by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/455
* Fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/467
* Update password-related json files (2024-01-11) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/466


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.2...10.0.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).