### PR TITLE
Update autofill to 10.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -186,7 +186,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#03d3e3a959dd75afbe8c59b5a203ea676d37555d",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11313,8 +11313,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.0.3"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#03d3e3a959dd75afbe8c59b5a203ea676d37555d",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bb027f14bec7fbb1a85d308139e7a66686da160e",
@@ -11352,7 +11352,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#6b7ad1e7f15270f9dfeb58a272199f4d57c3eb22",
             "integrity": "sha512-8KV/5SbvKYOWuPs+UifjktM3ioXcn7gNRr+zsYMBNtBEqMYetyCLTgJhrByrujD7flF2SG3yC5akHwrQA9NSZA==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#6b7ad1e7f15270f9dfeb58a272199f4d57c3eb22"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#ba0d8cefe4432723ec75b998241efd2454dff35a",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.1.0


## Description
Updates Autofill to version [10.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.1.0).

### Autofill 10.1.0 release notes
## What's Changed
* Support shadow dom by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/485
* New batch of fixes + integration test improvements by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/489
* Update password-related json files (2024-01-17) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/474
* Bump playwright from 1.38.1 to 1.40.1 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/458
* Update password-related json files (2024-01-26) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/484
* Bump json-schema-to-typescript from 13.1.1 to 13.1.2 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/479


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.3...10.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).