### PR TITLE
Add @node/types to fix playwright type issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,10 @@
             },
             "devDependencies": {
                 "@fingerprintjs/fingerprintjs": "^4.2.1",
-                "@playwright/test": "^1.39.0",
-                "@types/chrome": "0.0.256",
+                "@playwright/test": "^1.41.2",
+                "@types/chrome": "^0.0.256",
                 "@types/jasmine": "^4.3.5",
+                "@types/node": "^20.11.17",
                 "@types/webextension-polyfill": "^0.10.7",
                 "asana": "github:Asana/node-asana",
                 "duckduckgo-colors": "0.0.1",
@@ -900,12 +901,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-            "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+            "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.39.0"
+                "playwright": "1.41.2"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -1034,9 +1035,12 @@
             "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
         "node_modules/@types/node": {
-            "version": "18.11.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+            "version": "20.11.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+            "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -8082,12 +8086,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-            "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+            "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.39.0"
+                "playwright-core": "1.41.2"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -8100,9 +8104,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-            "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+            "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
@@ -10147,6 +10151,11 @@
                 "through": "^2.3.8"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
         "node_modules/unique-string": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -11607,12 +11616,12 @@
             "optional": true
         },
         "@playwright/test": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-            "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+            "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
             "dev": true,
             "requires": {
-                "playwright": "1.39.0"
+                "playwright": "1.41.2"
             }
         },
         "@pnpm/network.ca-file": {
@@ -11720,9 +11729,12 @@
             "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
         "@types/node": {
-            "version": "18.11.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+            "version": "20.11.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+            "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -16865,19 +16877,19 @@
             }
         },
         "playwright": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-            "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+            "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2",
-                "playwright-core": "1.39.0"
+                "playwright-core": "1.41.2"
             }
         },
         "playwright-core": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-            "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+            "version": "1.41.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+            "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
             "dev": true
         },
         "postcss": {
@@ -18380,6 +18392,11 @@
                 "buffer": "^5.2.1",
                 "through": "^2.3.8"
             }
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "unique-string": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     },
     "devDependencies": {
         "@fingerprintjs/fingerprintjs": "^4.2.1",
-        "@playwright/test": "^1.39.0",
-        "@types/chrome": "0.0.256",
+        "@playwright/test": "^1.41.2",
+        "@types/chrome": "^0.0.256",
         "@types/jasmine": "^4.3.5",
+        "@types/node": "^20.11.17",
         "@types/webextension-polyfill": "^0.10.7",
         "asana": "github:Asana/node-asana",
         "duckduckgo-colors": "0.0.1",


### PR DESCRIPTION
We're not able to bump the version of `@playwright/test` due to errors when running `tsc` (see https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2433). To fix it we need a definition of `Symbol` from `@types/node`.