### PR TITLE
Fix blocked request filtering in the dev-tools panel UI

### DIFF
--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -94,6 +94,10 @@
       display: revert; /* To avoid clashing with .block in base.css */
     }
 
+    .block[hidden] {
+      display: none;
+    }
+
     .redirect {
       background-color: #FDD20A;
     }


### PR DESCRIPTION
Apparently base.css is clashing with the devtools-panel stylesheet,
causing rows for blocked requests to be displayed incorrectly. The
workaround for that appears to have prevented the rows from being
hidden, when the toggle to show blocked requests is used. Without
digging more deeply into it for now, let's just ensure that blocked
requests are hidden with a more specific selector.

**Reviewer:** @GuiltyDolphin 
**CC:** @tagawa, @laghee 