### PR TITLE
Improve unit test usability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ watch:
 ## unit-test: Run the unit tests.
 ESBUILD_TESTS = unit-test/background/*.js unit-test/background/**/*.js unit-test/ui/**/*.js unit-test/shared-utils/*.js
 unit-test:
-	$(ESBUILD) --outdir=build/test --inject:./unit-test/inject-chrome-shim.js $(ESBUILD_TESTS)
+	$(ESBUILD) --sourcemap=inline --outdir=build/test --inject:./unit-test/inject-chrome-shim.js $(ESBUILD_TESTS)
 	node_modules/.bin/karma start karma.conf.js
 
 .PHONY: unit-test

--- a/unit-test/README.md
+++ b/unit-test/README.md
@@ -12,3 +12,10 @@ Tests can be run as follows:
  - `npm test`: Run all tests (both node and browser).
  - `npm run test.unit`: Run only browser-based unit tests.
  - `npm run test.node`: Run only node-based unit tests.
+
+## Notes
+
+- To reduce the amount of noise when running the tests, `console.log()` and
+  `console.debug()` output is suppressed. If you need to log something to the
+  console while working on the tests use `console.warn()` or `console.error()`
+  instead.


### PR DESCRIPTION
The unit tests were a little tricky to work with, for failures the
wrong line numbers were given and console.log() didn't work. Let's try
to improve the situation:

1. Have the unit tests bundled with inline sourcemaps, that can then
   be used to report the line numbers correctly.
2. Add a note to the unit test's README to mention to use
   console.warn() or console.error() instead of console.log().

Note: Unfortunately adding inline sourcemaps seems to slow down
      Karma/Jasmine quite a bit. In the future, we might consider
      using a faster test runner, or one that supports external
      sourcemaps.

**Reviewer:** @sammacbeth 
**CC:** @jdorweiler 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Ensure the unit tests still pass.
2. Add an error throw or failing assertion to one of the unit tests.
3. Re run the unit tests and make sure the reported line numbers are correct.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
