### PR TITLE
Update autofill to 10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.64.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#03d3e3a959dd75afbe8c59b5a203ea676d37555d",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6493e296934bf09277c03df45f11f4619711cb24",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11197,13 +11197,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#03d3e3a959dd75afbe8c59b5a203ea676d37555d",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6493e296934bf09277c03df45f11f4619711cb24",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#36ddba2cbac52a41b9a9275af06d32fa8a56d2d7",
             "integrity": "sha512-ceteGsE7i3peR4NofsLLiPMSmGStWV3K6aOHGcMKGhio3hgadisyU6Hs/DkCghJFbpo2g16hYuUk5Lw+dvrzTA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#36ddba2cbac52a41b9a9275af06d32fa8a56d2d7",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4.64.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11225,7 +11225,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#c67d268bf234760f49034a0fe7a6137a1b216b05",
             "integrity": "sha512-/+2PSjfAB5nhJ1XTslllH2P8ysyIvSD9weYD/GrPghGk/eEzvkVV7KCV1VdhO5muWX9Su5PwMLs1OslMQ0G2EA==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#c67d268bf234760f49034a0fe7a6137a1b216b05"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#3.2.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -11237,12 +11237,12 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#a603ff9af22ca3ff7ce2e7ffbfe18c447d9f23e8",
             "integrity": "sha512-RAFi4ZghE26XXwn4HOSDQgzbHbRAB8fUVxyBRhXKFV6pgl4JclSLatrAlIwYG9i/PyIrF8hDmhc+0Q+0HyCw9A==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#a603ff9af22ca3ff7ce2e7ffbfe18c447d9f23e8"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#57b338a69e8b7554f005904c40d8536303433d4f",
             "integrity": "sha512-qjeDJNoOXwdkge1P6Lm4S5OyRkT4S/8vNevEH738i45d848uXAwA8WwVxxauE87ep/u5ja5HZQQgtENe5BYurA==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#57b338a69e8b7554f005904c40d8536303433d4f"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.3.1"
         },
         "@esbuild/aix-ppc64": {
             "version": "0.20.1",
@@ -16940,7 +16940,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#340bca2b1e917d16e1489976a25b919370556bc5",
             "integrity": "sha512-3T1ZmtxhqwCQPFhQ5ieyk335e2WpAyXAboxAvD8l6+oEWLhNDDLXAP8SNQ3wM+AbXp0pbbMQgMNGqOJg3Iix1Q==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#340bca2b1e917d16e1489976a25b919370556bc5",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.3.0",
             "requires": {
                 "body-parser": "^1.20.1",
                 "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.64.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.2.0


## Description
Updates Autofill to version [10.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.2.0).

### Autofill 10.2.0 release notes
## What's Changed
* Remove unused Android UA check by @jonathanKingston in https://github.com/duckduckgo/duckduckgo-autofill/pull/494
* fix tracker radar kit reference by @brindy in https://github.com/duckduckgo/duckduckgo-autofill/pull/505
* Update password-related json files (2024-03-04) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/518
* separate 'third party provider' feature by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/252
* marking flaky tests by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/524
* remove device-specifc 'isEnabled' checks by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/523
* fixing some flaky tests by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/526
* Fixes bugs for Lufthansa, Twitter, Rumble by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/529
* Update Github action dependency by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/531

## New Contributors
* @brindy made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/505

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.1.0...10.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).