### PR TITLE
Custom config override

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -24,6 +24,7 @@ import OmniboxSearch from './components/omnibox-search'
 import InternalUserDetector from './components/internal-user-detector'
 import TDSStorage from './components/tds'
 import TrackersGlobal from './components/trackers'
+import DebuggerConnection from './components/debugger-connection'
 import initDebugBuild from './devbuild'
 import initReloader from './devbuild-reloader'
 import tabManager from './tab-manager'
@@ -57,7 +58,8 @@ const components = {
     internalUser: new InternalUserDetector({ settings }),
     tabTracking: new TabTracker({ tabManager }),
     tds,
-    trackers: new TrackersGlobal({ tds })
+    trackers: new TrackersGlobal({ tds }),
+    debugger: new DebuggerConnection({ tds })
 }
 
 // Chrome-only components

--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -1,0 +1,56 @@
+import { getFromSessionStorage, removeFromSessionStorage, setToSessionStorage } from '../wrapper'
+
+/**
+ * @typedef {import('./tds').default} TDSStorage
+ */
+
+export default class DebuggerConnection {
+    /**
+     * @param {{
+    *  tds: TDSStorage
+    * }} options
+     */
+    constructor ({ tds }) {
+        this.init()
+        this.tds = tds
+    }
+
+    async init () {
+        const [configURLOverride, debuggerConnection] = await Promise.all([
+            getFromSessionStorage('configURLOverride'),
+            getFromSessionStorage('debuggerConnection')
+        ])
+        this.configURLOverride = configURLOverride
+        this.debuggerConnectionEnabled = debuggerConnection
+        if (this.configURLOverride && this.debuggerConnectionEnabled) {
+            const url = new URL('/status', this.configURLOverride)
+            let lastUpdate = 0
+            this.eventSource = new EventSource(url.href)
+            this.eventSource.onmessage = event => {
+                const status = JSON.parse(event.data)
+                console.log('debugger message', status)
+                if (status.lastBuild > lastUpdate) {
+                    lastUpdate = status.lastBuild
+                    this.tds.config.checkForUpdates(true)
+                }
+            }
+        }
+    }
+
+    async enableDebugging (url, debuggerConnection = false) {
+        await Promise.all([
+            setToSessionStorage('configURLOverride', url),
+            setToSessionStorage('debuggerConnection', debuggerConnection)
+        ])
+        this.init()
+        this.tds.config.checkForUpdates(true)
+    }
+
+    async disableDebugging () {
+        await Promise.all([
+            removeFromSessionStorage('configURLOverride'),
+            removeFromSessionStorage('debuggerConnection')
+        ])
+        this.eventSource?.close()
+    }
+}

--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -30,6 +30,7 @@ export default class DebuggerConnection {
             return this.enableDebugging(configURLOverride, debuggerConnection)
         })
         registerMessageHandler('disableDebugging', this.disableDebugging.bind(this))
+        registerMessageHandler('forceReloadConfig', this.forceReloadConfig.bind(this))
     }
 
     async init () {
@@ -57,6 +58,10 @@ export default class DebuggerConnection {
             setToSessionStorage('debuggerConnection', debuggerConnection)
         ])
         this.init()
+        this.forceReloadConfig()
+    }
+
+    async forceReloadConfig () {
         this.tds.config.checkForUpdates(true)
     }
 

--- a/shared/js/background/components/resource-loader.js
+++ b/shared/js/background/components/resource-loader.js
@@ -7,7 +7,7 @@ import { createAlarm } from '../wrapper'
  *
  * @typedef {object} ResourceConfig
  * @property {ResourceName} name
- * @property {string} [remoteUrl]
+ * @property {string | (() => Promise<string>)} [remoteUrl]
  * @property {string} [localUrl]
  * @property {number} [updateIntervalMinutes]
  * @property {'json'|'text'} [format]
@@ -85,8 +85,9 @@ export default class ResourceLoader extends EventTarget {
 
     async checkForUpdates (force) {
         await this.settings.ready()
+        const remoteUrl = this.remoteUrl instanceof Function ? await this.remoteUrl() : this.remoteUrl
         const loadFromDb = this._loadFromDB.bind(this)
-        const loadFromRemote = this._loadFromURL.bind(this, this.remoteUrl)
+        const loadFromRemote = this._loadFromURL.bind(this, remoteUrl)
         const loadFromLocal = this._loadFromURL.bind(this, this.localUrl, true)
         let loadOrder = []
         if (this.remoteUrl && Date.now() - this.lastUpdate < this.updateIntervalMinutes * 1000 * 60 && !force) {

--- a/shared/js/background/components/tds.js
+++ b/shared/js/background/components/tds.js
@@ -38,7 +38,7 @@ export default class TDSStorage {
             name: 'config',
             remoteUrl: getConfigUrl,
             localUrl: '/data/bundled/extension-config.json',
-            updateIntervalMinutes: 1
+            updateIntervalMinutes: 15
         }, { settings })
     }
 

--- a/shared/js/background/components/tds.js
+++ b/shared/js/background/components/tds.js
@@ -1,9 +1,21 @@
 import ResourceLoader from './resource-loader.js'
 import constants from '../../../data/constants'
+import { getFromSessionStorage } from '../wrapper.js'
 
 /**
  * @typedef {import('../settings.js')} Settings
  */
+
+/**
+ * @returns {Promise<string>}
+ */
+async function getConfigUrl () {
+    const override = await getFromSessionStorage('configURLOverride')
+    if (override) {
+        return override
+    }
+    return constants.tdsLists[2].url
+}
 
 export default class TDSStorage {
     /**
@@ -24,9 +36,9 @@ export default class TDSStorage {
         }, { settings })
         this.config = new ResourceLoader({
             name: 'config',
-            remoteUrl: constants.tdsLists[2].url,
+            remoteUrl: getConfigUrl,
             localUrl: '/data/bundled/extension-config.json',
-            updateIntervalMinutes: 15
+            updateIntervalMinutes: 1
         }, { settings })
     }
 

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -37,8 +37,7 @@ export default function initDebugBuild () {
         setListContents,
         getListContents,
         companies: Companies,
-        ntts: createNewtabTrackerStatsDebugApi(),
-        setToSessionStorage: browserWrapper.setToSessionStorage
+        ntts: createNewtabTrackerStatsDebugApi()
     }
 
     // mark this as a dev build

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -37,7 +37,8 @@ export default function initDebugBuild () {
         setListContents,
         getListContents,
         companies: Companies,
-        ntts: createNewtabTrackerStatsDebugApi()
+        ntts: createNewtabTrackerStatsDebugApi(),
+        setToSessionStorage: browserWrapper.setToSessionStorage
     }
 
     // mark this as a dev build

--- a/shared/js/ui/views/internal-options.js
+++ b/shared/js/ui/views/internal-options.js
@@ -55,6 +55,7 @@ InternalOptionsView.prototype = window.$.extend({}, ViewParent.prototype, {
             [this.$setconfigurl, 'click', this._clickSetting],
             [this.$configurl, 'input', this._onURLChange]
         ])
+        this._onURLChange()
     },
     _buttonState: function () {
         const currentValue = this.model.debuggingSettings?.configURLOverride

--- a/shared/js/ui/views/internal-options.js
+++ b/shared/js/ui/views/internal-options.js
@@ -32,7 +32,7 @@ function template () {
                 <li>
                     <p class="options-info">Custom config URL</p>
                     <input class="allowlist-url js-options-config-url" type="text" placeholder="Privacy Configuration URL" value="${this.model.debuggingSettings?.configURLOverride}" />
-                    <button class="allowlist-add float-right js-options-set-config-url" ${buttonDisabled ? 'disabled' : ''}>${buttonText}</button>
+                    <button class="custom-config-button float-right js-options-set-config-url" ${buttonDisabled ? 'disabled' : ''}>${buttonText}</button>
                 </li>
             </ul>
         </section>`

--- a/shared/js/ui/views/internal-options.js
+++ b/shared/js/ui/views/internal-options.js
@@ -12,11 +12,15 @@ class Model extends ModelParent {
 
     async getState () {
         this.isInternalUser = await this.sendMessage('isInternalUser')
+        this.debuggingSettings = await this.sendMessage('getDebuggingSettings')
     }
 }
 
 function template () {
     if (this.model.isInternalUser) {
+        const buttonState = this._buttonState()
+        const buttonText = buttonState.split(' ')[0]
+        const buttonDisabled = buttonState.endsWith('disabled')
         return bel`<section class="options-content__allowlist divider-bottom">
             <h2 class="menu-title">Internal settings</h2>
             <ul class="default-list">
@@ -24,6 +28,11 @@ function template () {
                     <p class="menu-paragraph">
                         Internal-only settings for debugging the extension.
                     </p>
+                </li>
+                <li>
+                    <p class="options-info">Custom config URL</p>
+                    <input class="allowlist-url js-options-config-url" type="text" placeholder="Privacy Configuration URL" value="${this.model.debuggingSettings?.configURLOverride}" />
+                    <button class="allowlist-add float-right js-options-set-config-url" ${buttonDisabled ? 'disabled' : ''}>${buttonText}</button>
                 </li>
             </ul>
         </section>`
@@ -36,11 +45,58 @@ export default function InternalOptionsView (ops) {
     this.template = ops.template = template
     this.pageView = ops.pageView
     ViewParent.call(this, ops)
-    this.model.getState().then(() => {
-        this._rerender()
-    })
+    this.reload()
 }
 
 InternalOptionsView.prototype = window.$.extend({}, ViewParent.prototype, {
-
+    setup: function () {
+        this._cacheElems('.js-options', ['config-url', 'set-config-url'])
+        this.bindEvents([
+            [this.$setconfigurl, 'click', this._clickSetting],
+            [this.$configurl, 'input', this._onURLChange]
+        ])
+    },
+    _buttonState: function () {
+        const currentValue = this.model.debuggingSettings?.configURLOverride
+        const inputValue = this.$configurl?.val() || currentValue
+        let inputIsValidUrl = false
+        try {
+            inputIsValidUrl = !!(new URL(inputValue))
+        } catch (e) {}
+        if (!currentValue) {
+            return inputIsValidUrl ? 'Set' : 'Set disabled'
+        }
+        if (inputValue === currentValue) {
+            return 'Clear'
+        }
+        return inputIsValidUrl ? 'Update' : 'Update disabled'
+    },
+    _clickSetting: async function () {
+        const buttonState = this._buttonState()
+        const inputValue = this.$configurl?.val()
+        if (buttonState === 'Set' || buttonState === 'Update') {
+            // enable and set
+            await this.model.sendMessage('enableDebugging', {
+                configURLOverride: inputValue,
+                debuggerConnection: true
+            })
+        } else if (buttonState === 'Clear') {
+            await this.model.sendMessage('disableDebugging')
+        }
+        this.reload()
+    },
+    _onURLChange: function () {
+        const buttonState = this._buttonState()
+        const buttonText = buttonState.split(' ')[0]
+        const buttonDisabled = buttonState.endsWith('disabled')
+        this.$setconfigurl.attr('disabled', buttonDisabled)
+        this.$setconfigurl.text(buttonText)
+    },
+    reload: function () {
+        this.model.getState().then(() => {
+            this.unbindEvents()
+            this._rerender()
+            this.setup()
+        })
+    }
 })

--- a/shared/js/ui/views/internal-options.js
+++ b/shared/js/ui/views/internal-options.js
@@ -19,8 +19,8 @@ class Model extends ModelParent {
 function template () {
     if (this.model.isInternalUser) {
         const buttonState = this._buttonState()
-        const buttonText = buttonState.split(' ')[0]
         const buttonDisabled = buttonState.endsWith('disabled')
+        const buttonText = buttonDisabled ? buttonState.slice(0, buttonState.length - 9) : buttonState
         return bel`<section class="options-content__allowlist divider-bottom">
             <h2 class="menu-title">Internal settings</h2>
             <ul class="default-list">
@@ -66,8 +66,11 @@ InternalOptionsView.prototype = window.$.extend({}, ViewParent.prototype, {
         if (!currentValue) {
             return inputIsValidUrl ? 'Set' : 'Set disabled'
         }
-        if (inputValue === currentValue) {
+        if (!this.$configurl?.val()) {
             return 'Clear'
+        }
+        if (inputValue === currentValue) {
+            return 'Reload now'
         }
         return inputIsValidUrl ? 'Update' : 'Update disabled'
     },
@@ -82,6 +85,8 @@ InternalOptionsView.prototype = window.$.extend({}, ViewParent.prototype, {
             })
         } else if (buttonState === 'Clear') {
             await this.model.sendMessage('disableDebugging')
+        } else if (buttonState === 'Reload now') {
+            await this.model.sendMessage('forceReloadConfig')
         }
         this.reload()
     },

--- a/shared/scss/options.scss
+++ b/shared/scss/options.scss
@@ -35,3 +35,11 @@
     height: 30px;
     padding: 0px 0px 1px 0px;
 }
+
+button:disabled {
+    background-color: $color--light-slate;
+}
+
+.js-options-set-config-url {
+    height: 36px !important;
+}

--- a/shared/scss/options.scss
+++ b/shared/scss/options.scss
@@ -43,3 +43,15 @@ button:disabled {
 .js-options-set-config-url {
     height: 36px !important;
 }
+
+.custom-config-button {
+    width: 120px;
+    height: 30px;
+    border-radius: 4px;
+    background-color: $blue;
+    line-height: 1.5;
+    text-align: center;
+    color: $white;
+    margin-left: 7px;
+    cursor: pointer;
+}


### PR DESCRIPTION

## Description:
Allows the config URL to be overridden for a session.
 - Also opens a connection to the debugger server to trigger updates on the config is changed.
 - Adds an option to the settings menu to allow set/unset of this config URL.

![Screenshot 2024-03-27 at 13 36 45](https://github.com/duckduckgo/duckduckgo-privacy-extension/assets/248111/3143644d-05c7-41a2-9362-34bbce8410fa)

## Steps to test this PR:
1. Visit use-login.duckduckgo.com and login to get recognised as an internal user.
2. Open the settings page.
3. The 'Custom config URL' setting should be displayed.
4. Type in a URL and hit 'Set'. The config at that URL should be loaded.
5. In settings, click 'Clear' to return back to the original config URL.

