### PR TITLE
Update autofill to 10.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.3.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6493e296934bf09277c03df45f11f4619711cb24",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3d293c541266e290b83d11b6e1e960f0edfbed4b",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11197,13 +11197,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6493e296934bf09277c03df45f11f4619711cb24",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.2.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#3d293c541266e290b83d11b6e1e960f0edfbed4b",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#10.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#edd96481d49b094c260f9a79e078abdbdd3a83fb",
             "integrity": "sha512-7dg526OIszXMTko/EHvxgKYNhAKvcmK1QlWcLBCrTjfhuhqgAk6bl9d0lwdFE+5z/JeAryruESoDrIjysxZ3TA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#edd96481d49b094c260f9a79e078abdbdd3a83fb",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#5.6.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11242,7 +11242,7 @@
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",
             "integrity": "sha512-DvpngvAXXLH/KxOsSeyHSU2Q5tmG4ZEGAzUtwwjUwrT9O6ChLcRf5TqzCuw1e2NuzBlHo7ZGAF/4vndf10eHBA==",
-            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623"
+            "from": "@duckduckgo/tracker-surrogates@github:duckduckgo/tracker-surrogates#1.3.2"
         },
         "@esbuild/aix-ppc64": {
             "version": "0.20.1",
@@ -16940,7 +16940,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#94f9ca1081c0bd773194c940e9b2c05b9b374da4",
             "integrity": "sha512-TN5vVb6OJ2PaTJzuW2VhAMHAIifQMB/qYuinDdo4a7iK8ndxT/Fhenk6IqrY1YeSFdbzJyMCeayO6u27W+yQAA==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#94f9ca1081c0bd773194c940e9b2c05b9b374da4",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.3.1",
             "requires": {
                 "body-parser": "^1.20.1",
                 "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.3.0


## Description
Updates Autofill to version [10.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.3.0).

### Autofill 10.3.0 release notes
## What's Changed
* update CSS selectors by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/546


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.2.0...10.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).