### PR TITLE
Update autofill to 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8b046b1f89c580217346876f08319c642cc698c7",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6053999d6af384a716ab0ce7205dbab5d70ed1b3",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11196,8 +11196,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8b046b1f89c580217346876f08319c642cc698c7",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6053999d6af384a716ab0ce7205dbab5d70ed1b3",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#edd96481d49b094c260f9a79e078abdbdd3a83fb",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.1


## Description
Updates Autofill to version [11.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.1).

### Autofill 11.0.1 release notes
## What's Changed
* Fix regression by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/549
* Major version change 11.0.0 only affecting Android.
* Android: enable iframe support by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/536


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/11.0.0...11.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).