### PR TITLE
Support debugger server on subpath endpoints

### DIFF
--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -38,7 +38,7 @@ export default class DebuggerConnection {
         this.configURLOverride = configURLOverride
         this.debuggerConnectionEnabled = debuggerConnection
         if (this.configURLOverride && this.debuggerConnectionEnabled) {
-            const url = new URL('/status', this.configURLOverride)
+            const url = new URL('./status', this.configURLOverride)
             let lastUpdate = 0
             this.eventSource = new EventSource(url.href)
             this.eventSource.onmessage = event => {


### PR DESCRIPTION
The protections debugger can now also be run on a non-root path of the server (https://github.com/duckduckgo/privacy-protections-debugger/pull/21), so this PR updates the debugger connection code so we hit the correct `/status` endpoint (including the path to the debugger instance we're loading the config from).