### PR TITLE
Increase the minimum supported browser versions

### DIFF
--- a/browsers/chrome-mv3/manifest.json
+++ b/browsers/chrome-mv3/manifest.json
@@ -9,7 +9,7 @@
         "128": "img/icon_128.png"
     },
     "manifest_version": 3,
-    "minimum_chrome_version": "102.0",
+    "minimum_chrome_version": "121.0",
     "action": {
         "default_icon": "img/icon_browser_action.png",
         "default_popup": "dashboard/html/browser.html"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -3,7 +3,7 @@
     "applications": {
         "gecko": {
             "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
-            "strict_min_version": "91.0"
+            "strict_min_version": "102.0"
         }
     },
     "default_locale": "en",


### PR DESCRIPTION
Our policy is to have the minimum supported Firefox version be the
previous ESR release, which is currently version 102[1].

For the Chrome MV3 migration, we'll be making use of the recent
increase of the dynamic declarativeNetRequest rule limit[2] that came
in with version 121[3].

Note: Increasing the minimum supported browser versions for Chrome MV2
      builds isn't important now, since we'll be migrating Chrome
      users to MV3 shortly.

1 - https://endoflife.date/firefox
2 - https://issues.chromium.org/issues/40282671
3 - https://chromium.googlesource.com/chromium/src/+/cbcff7e25340834b9ef92cdb05e20ab4f3a34564/chrome/VERSION

**Reviewer:** @sammacbeth
