### PR TITLE
Fix the onboarding flow for the Chrome MV3 build

### DIFF
--- a/integration-test/onboarding.spec.js
+++ b/integration-test/onboarding.spec.js
@@ -2,7 +2,7 @@ import { test, expect } from './helpers/playwrightHarness'
 import backgroundWait from './helpers/backgroundWait'
 
 test.describe('onboarding', () => {
-    test('should manage the onboarding state and inject a script that calls window.onFirstSearchPostExtensionInstall on the first search post extension', async ({ context, backgroundPage, page }) => {
+    test('should manage the onboarding state and inject a script that calls window.onFirstSearchPostExtensionInstall on the first search post extension', async ({ manifestVersion, context, backgroundPage, page }) => {
         await backgroundWait.forExtensionLoaded(context)
 
         const params = await backgroundPage.evaluate(() => {
@@ -18,11 +18,13 @@ test.describe('onboarding', () => {
         await page.bringToFront()
         await page.goto('https://duckduckgo.com/?q=hello')
 
-        const hasScriptHandle = await page.waitForFunction(() => {
-            const scripts = document.querySelectorAll('script:not([src])')
-            return Array.from(scripts).some((s) => s.textContent.includes('window.onFirstSearchPostExtensionInstall'))
-        }, { polling: 'mutation' })
-        expect(hasScriptHandle).toBeTruthy()
+        if (manifestVersion === 2) {
+            const hasScriptHandle = await page.waitForFunction(() => {
+                const scripts = document.querySelectorAll('script:not([src])')
+                return Array.from(scripts).some((s) => s.textContent.includes('window.onFirstSearchPostExtensionInstall'))
+            }, { polling: 'mutation' })
+            expect(hasScriptHandle).toBeTruthy()
+        }
 
         const nextParams = await backgroundPage.evaluate(() => {
             return {
@@ -40,12 +42,6 @@ test.describe('onboarding', () => {
 
         await page.bringToFront()
         await page.goto('https://duckduckgo.com/?q=hello')
-
-        // we wait that the onboarding content script is injected
-        await page.waitForFunction(() => {
-            const scripts = document.querySelectorAll('script:not([src])')
-            return Array.from(scripts).some((s) => s.textContent.includes('window.onFirstSearchPostExtensionInstall'))
-        }, { polling: 'mutation' })
 
         const data = await page.evaluate(() => {
             return new Promise((resolve) => {
@@ -69,12 +65,6 @@ test.describe('onboarding', () => {
         await backgroundWait.forExtensionLoaded(context)
 
         await page.goto('https://duckduckgo.com/?q=hello')
-
-        // we wait that the onboarding content script is injected
-        await page.waitForFunction(() => {
-            const scripts = document.querySelectorAll('script:not([src])')
-            return Array.from(scripts).some((s) => s.textContent.includes('window.onFirstSearchPostExtensionInstall'))
-        }, { polling: 'mutation' })
 
         await page.evaluate(() => {
             globalThis.postMessage({ type: 'rescheduleCounterMessagingRequest' }, globalThis.location.origin)

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -142,6 +142,20 @@ async function onboardingMessaging ({ transitionQualifiers, tabId }) {
         })
     }
 
+    if (manifestVersion === 3) {
+        browserWrapper.executeScript({
+            target: { tabId },
+            func: onboarding.onDocumentEndMainWorld,
+            args: [{
+                isAddressBarQuery,
+                showWelcomeBanner,
+                showCounterMessaging
+            }],
+            injectImmediately: false,
+            world: 'MAIN'
+        })
+    }
+
     browserWrapper.executeScript({
         target: { tabId },
         func: onboarding.onDocumentEnd,
@@ -151,7 +165,8 @@ async function onboardingMessaging ({ transitionQualifiers, tabId }) {
             showCounterMessaging,
             browserName,
             duckDuckGoSerpHostname: constants.duckDuckGoSerpHostname,
-            extensionId: browserWrapper.getExtensionId()
+            extensionId: browserWrapper.getExtensionId(),
+            manifestVersion
         }],
         injectImmediately: false
     })


### PR DESCRIPTION
The onboarding code has some logic to display a welcome banner the
first time the user performs a DuckDuckGo search after installing the
extension. Until now, that code did not work for Chrome MV3 builds,
since it attempted to inject a script into the "main world" by
appending a <script> element - that does not work with MV3 due to the
stricter Content-Security-Policy used. Let's use the
scripting.executeScript API instead to inject the required code into
the "main world".

Note: This code is somewhat convoluted and could likely be simplified
      in the future. But for now, with the upcoming MV3 migration
      deadline, let's make the minimum changes required to get this
      working!

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sballesteros, @sammacbeth 

## Steps to test this PR:
1. Install the extension
2. Ensure DDG is the default browser if you're running Linux
3. Perform a search from the URL bar
4. Ensure the purple onboarding banner is displayed and a CSP warning isn't shown in the console
5. Perform another search from the URL bar and ensure the onboarding banner is not displayed this time

Note: Test _both_ with MV2 and MV3 builds of the extension!

