### PR TITLE
Avoid including old smarter_encryption.txt file in builds silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ integration-test/artifacts/
 shared/tracker-surrogates/
 shared/content-scope-scripts/
 unit-test/data/reference-tests/
-shared/data/smarter_encryption.txt
 shared/data/bundled/smarter-encryption-rules.json
 /test-results/
 /playwright-report/


### PR DESCRIPTION
In the past, we wrote shared/data/smarter_encryption.txt when building
the extension and added it to the .gitignore to ensure it wasn't
accidentally included in the repository. Unfortunately however, this
means that if the file exists, it will be somewhat hidden yet be
included in builds. This is a problem given the file's >5MB
size. Let's remove the path from .gitignore, so that the file will be
noticed by developers and removed.

**Reviewer:** @sammacbeth 