### PR TITLE
Ensure onFirstSearchPostExtensionInstallCalls is called correctly

### DIFF
--- a/shared/js/background/onboarding.js
+++ b/shared/js/background/onboarding.js
@@ -121,10 +121,12 @@ function onDocumentEndMainWorld ({
 
             if (window.onFirstSearchPostExtensionInstall) {
                 const { documentStartData } = e.data
-                window.onFirstSearchPostExtensionInstall(
-                    { isAddressBarQuery, showWelcomeBanner, showCounterMessaging },
-                    documentStartData
-                )
+                window.onFirstSearchPostExtensionInstall({
+                    isAddressBarQuery,
+                    showWelcomeBanner,
+                    showCounterMessaging,
+                    ...documentStartData
+                })
             }
         }
     })


### PR DESCRIPTION
**Reviewer:** @sammacbeth 
**CC:** @sballesteros 

When fixing the onboarding flow for the Chrome MV3 build[1], I made a
mistake. For MV3 builds, the page's onFirstSearchPostExtensionInstall
function was being called like:

    onFirstSearchPostExtensionInstall({
        isAddressBarQuery: false,
        showCounterMessaging: true,
        showWelcomeBanner: true
    }, {
        hadFocusOnStart: true
    })

Instead of like:

    onFirstSearchPostExtensionInstall({
        hadFocusOnStart: true,
        isAddressBarQuery: false,
        showCounterMessaging: true,
        showWelcomeBanner: true
    })

(I had missed a subtle Object.assign call.)

Let's fix that here, and also add test coverage for that call to catch
similar mistakes in the future.

1 - https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/2e4441d633715b455e24fa9311af19b2aeb05230

## Automated tests:
- [ ] Unit tests
- [x] Integration tests