### PR TITLE
Wait for user allowlisting to apply before reloading the website

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -50,8 +50,11 @@ export function setList (options) {
  * @param {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').SetListOptions} options
  */
 export async function setLists (options) {
+    // TODO: Consider making these tabManager.setList calls concurrently with
+    //       Promise.all, but first verify that works in practice (e.g. with
+    //       simultaneous DNR rule updates).
     for (const listItem of options.lists) {
-        tabManager.setList(listItem)
+        await tabManager.setList(listItem)
     }
 
     try {


### PR DESCRIPTION
The popup UI (e.g. privacy dashboard) lets users disable protections
for a website. When the user clicks the toggle button, the website is
allowlisted and reloaded. With MV3, this requires a
declarativeNetRequest rule update which doesn't happen instantly. We
need to take care for that rule update to finish before reloading the
page, because otherwise some requests might still be blocked after the
reload.

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Navigate to https://privacy-test-pages.site/privacy-protections/request-blocking/
2. Click to allowlist the website using the popup UI
3. Immediately click to run the tests after the page reloads
4. Ensure that the requests are now allowed.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
