### PR TITLE
Protection debugging over websocket

### DIFF
--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -62,6 +62,9 @@ export default class DebuggerConnection {
                         this.subscribedTabs.add(tabId)
                         this.forwardDebugMessagesForTab(tabId)
                     }
+                } else if (messageType === 'reloadTab') {
+                    const { tabId } = payload
+                    browser.tabs.reload(tabId)
                 }
             })
             this.socket.addEventListener('close', () => {

--- a/shared/js/background/components/internal-user-detector.js
+++ b/shared/js/background/components/internal-user-detector.js
@@ -1,3 +1,4 @@
+/* global DEBUG */
 import browser from 'webextension-polyfill'
 import { registerMessageHandler } from '../message-handlers'
 
@@ -9,7 +10,7 @@ const SETTINGS_KEY = 'isInternalUser'
  * @param {import('../settings.js')} settings
  */
 export function isInternalUser (settings) {
-    return settings.getSetting(SETTINGS_KEY) || false
+    return settings.getSetting(SETTINGS_KEY) || DEBUG
 }
 
 export default class InternalUserDetector {

--- a/shared/js/background/devtools.js
+++ b/shared/js/background/devtools.js
@@ -133,7 +133,6 @@ function connected (port) {
 }
 
 export function postMessage (tabId, action, message) {
-    console.log('postmessage', action, debugHandlers)
     if (ports.has(tabId)) {
         ports.get(tabId).postMessage(JSON.stringify({ tabId, action, message }))
     }

--- a/shared/js/background/devtools.js
+++ b/shared/js/background/devtools.js
@@ -13,9 +13,14 @@ const { removeBroken } = require('./utils')
 //       background ServiceWorker will become active again and the onConnect
 //       event will fire again.
 const ports = new Map()
+const debugHandlers = new Map()
 
 export function init () {
     browser.runtime.onConnect.addListener(connected)
+}
+
+export function registerDebugHandler (tabId, fn) {
+    debugHandlers.set(tabId, fn)
 }
 
 /**
@@ -128,11 +133,15 @@ function connected (port) {
 }
 
 export function postMessage (tabId, action, message) {
+    console.log('postmessage', action, debugHandlers)
     if (ports.has(tabId)) {
         ports.get(tabId).postMessage(JSON.stringify({ tabId, action, message }))
+    }
+    if (debugHandlers.has(tabId)) {
+        debugHandlers.get(tabId)({ tabId, action, message })
     }
 }
 
 export function isActive (tabId) {
-    return ports.has(tabId)
+    return ports.has(tabId) || debugHandlers.has(tabId)
 }


### PR DESCRIPTION
**Reviewer:** @kzar @shakyShane 

## Description:
Improves the config debugging to also open a websocket to a https://github.com/duckduckgo/privacy-protections-debugger server. Over this connection the following can happen:
- The browser can forward tab data to be shown in the debugger.
- The debugger can send commands, such as requesting a reload of a specific tab.
- The debugger can register to get devtools logging for a specific tab.
- The extension can forward `devtools` messages to the debugger.

## Steps to test this PR:
1. Build the extension in dev mode.
2. Checkout and run https://github.com/duckduckgo/privacy-protections-debugger locally.
3. Go to the extension settings, and put in the local 'Custom config URL' (e.g. `http://localhost:3000/config`).
4. In the debugger, go to the 'Logs' tab. You should see the extension connected, and tabs shown.
5. Chose a tab, and load a page in it. You should see requests shown in the UI.

