### PR TITLE
Update autofill to 11.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.12.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,7 +176,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6053999d6af384a716ab0ce7205dbab5d70ed1b3",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11289,13 +11289,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6053999d6af384a716ab0ce7205dbab5d70ed1b3",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.2"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1bb3bc5eb565735051f342a87b5405d4374876c7",
             "integrity": "sha512-XKhaH504Ce2jLGnJqO43jDaPdsI8Yk2Nypq6Gb++vhj2leG5CPsKXtJ4mLbdWfl+2SCNcxkMY18aDzM0b+EH9A==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#1bb3bc5eb565735051f342a87b5405d4374876c7",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#5.12.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11317,7 +11317,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#14b13d0c3db38f471ce4ba1ecb502ee1986c84d7",
             "integrity": "sha512-mPkHypK45ShamEyc26z1t9u3bRIcALF3VL6GgCDJULTKIvlC7HeWrT9N+7Bf2fBwY2W5piP6JSQ+T45DdP4MxA==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#14b13d0c3db38f471ce4ba1ecb502ee1986c84d7"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#3.5.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.12.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.2


## Description
Updates Autofill to version [11.0.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.2).

### Autofill 11.0.2 release notes
## What's Changed
* Minor fix to websites by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/554
* More minor fixes to websites by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/555


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/11.0.1...11.0.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).