### PR TITLE
Fix websocket URL for non-localhost debugger instances.

### DIFF
--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -43,7 +43,8 @@ export default class DebuggerConnection {
         this.configURLOverride = configURLOverride
         this.debuggerConnectionEnabled = debuggerConnection
         if (this.configURLOverride && this.debuggerConnectionEnabled) {
-            const url = new URL('./debugger/extension', this.configURLOverride.replace(/http:/, 'ws:').replace(/https:/, 'wss:'))
+            const url = new URL('./debugger/extension', this.configURLOverride)
+            url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
             url.searchParams.append('browserName', getBrowserName())
             url.searchParams.append('version', getExtensionVersion())
             let lastUpdate = 0

--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -43,14 +43,13 @@ export default class DebuggerConnection {
         this.configURLOverride = configURLOverride
         this.debuggerConnectionEnabled = debuggerConnection
         if (this.configURLOverride && this.debuggerConnectionEnabled) {
-            const url = new URL('./debugger/extension', this.configURLOverride.replace(/https?:/, 'ws:'))
+            const url = new URL('./debugger/extension', this.configURLOverride.replace(/http:/, 'ws:').replace(/https:/, 'wss:'))
             url.searchParams.append('browserName', getBrowserName())
             url.searchParams.append('version', getExtensionVersion())
             let lastUpdate = 0
             this.socket = new WebSocket(url.href)
             this.socket.addEventListener('message', (event) => {
                 const { messageType, payload } = JSON.parse(event.data)
-                console.log('debugger message', event.data)
                 if (messageType === 'status') {
                     if (payload.lastBuild > lastUpdate) {
                         lastUpdate = payload.lastBuild
@@ -60,7 +59,7 @@ export default class DebuggerConnection {
                     const { tabId } = payload
                     if (!this.subscribedTabs.has(tabId)) {
                         this.subscribedTabs.add(tabId)
-                        this.forwardDebugMessagesForTab(tabId)
+                        this.forwardDebugMessagesForTab(parseInt(tabId, 10))
                     }
                 } else if (messageType === 'reloadTab') {
                     const { tabId } = payload

--- a/shared/js/background/components/debugger-connection.js
+++ b/shared/js/background/components/debugger-connection.js
@@ -57,10 +57,10 @@ export default class DebuggerConnection {
                         this.tds.config.checkForUpdates(true)
                     }
                 } else if (messageType === 'subscribe') {
-                    const { tabId } = payload
-                    if (!this.subscribedTabs.has(tabId)) {
+                    const tabId = parseInt(payload.tabId, 10)
+                    if (!this.subscribedTabs.has(tabId) && !isNaN(tabId)) {
                         this.subscribedTabs.add(tabId)
-                        this.forwardDebugMessagesForTab(parseInt(tabId, 10))
+                        this.forwardDebugMessagesForTab(tabId)
                     }
                 } else if (messageType === 'reloadTab') {
                     const { tabId } = payload


### PR DESCRIPTION

**Reviewer:** @kzar 

## Description:

- Fix debugger websocket connection for secure contexts.
- Ensure `tabId` is treated as a number.

