### PR TITLE
include same-entity none-trackers

### DIFF
--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -79,6 +79,11 @@ test.describe('Test request blocking', () => {
         expect(extensionTrackersCount).toBeGreaterThanOrEqual(testCount)
 
         expect(extensionTrackers).toEqual({
+            'privacy-test-pages.site': {
+                urls: {},
+                count: 0,
+                displayName: 'privacy-test-pages.site'
+            },
             'Test Site for Tracker Blocking': {
                 displayName: 'Bad Third Party Site',
                 prevalence: 0.1,

--- a/packages/privacy-grade/src/classes/trackers.js
+++ b/packages/privacy-grade/src/classes/trackers.js
@@ -351,9 +351,6 @@ class Trackers {
         const sameEntity = (requestOwner && websiteOwner) ? requestOwner === websiteOwner : requestData.siteDomain === requestData.urlToCheckDomain
 
         if (!tracker) {
-            if (sameEntity) {
-                return null
-            }
             const owner = {
                 name: requestOwner || requestData.urlToCheckDomain || 'unknown',
                 displayName: requestOwner || requestData.urlToCheckDomain || 'Unknown'


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

https://app.asana.com/0/1201141132935289/1207506709815881/f

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Other platforms keep track of 3rd party requests, even when they are the same entity. See: https://app.asana.com/0/1201141132935289/1207506709815881/f


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->
- Visit Microsoft.com
- Open the Privacy Dashboard
- You should see requests in the '3rd party' section from domains like `live.com` or other Microsoft properties
  - these do not currently show.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207550488916516