### PR TITLE
Update autofill to 12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.18.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,7 +176,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#18dd599f8c39e0c293768ec23316e36b683b3960",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11176,13 +11176,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#18dd599f8c39e0c293768ec23316e36b683b3960",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#12.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1f563c01d5da4777120b672d7473c36947a0c727",
             "integrity": "sha512-xH4e65COTtfsKhlZHe8vb+YTEyvEubQNw7gP1WkimrwDTDjevmFPhdzOk4TWDKNin4RakGUngGvwG/1we2UzRg==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#1f563c01d5da4777120b672d7473c36947a0c727",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#5.18.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11204,7 +11204,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#25b8903191a40b21b09525085fe325ae3386092e",
             "integrity": "sha512-Ry34jcIoTSZoSjvZxFgzqG+eduBNhnpO0T9gT71HyVG+rqQcEBp4R2EAst4UyKjDN7Hmyu9ulpsd7trB6ymjnw==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#25b8903191a40b21b09525085fe325ae3386092e"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#3.6.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.18.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.0


## Description
Updates Autofill to version [12.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.0).

### Autofill 12.0.0 release notes
* Major version bump to 12.0.0 caused by #396, which impacts only Android.
* This release also translates the autofill experience to the following language codes:
    * bg
    * cs
    * da
    * de
    * el
    * en
    * es
    * et
    * fi
    * fr
    * hr
    * hu
    * it
    * lt
    * lv
    * nb
    * nl
    * pl
    * pt
    * ro
    * ru
    * sk
    * sl
    * sv
    * tr


## What's Changed
* Ema/more minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/556
* l10n: extract remaining strings to prepare for localization by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/558
* l10n: pull translated strings into separate JSON files by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/559
* Update password-related json files (2024-05-13) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/561
* Update password-related json files (2024-05-19) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/569
* vcs: ignore .helix directory by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/565
* l10n: remove placeholder from 'Manage ${ITEM}…' string by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/560
* real-world: remove expected failure from clientssp.fnfis.com test by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/563
* real-world: remove expected failure for agile.appian.com by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/567
* autofill: left-align HTML autofill buttons by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/571
* l10n: add translated messages by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/572
* passwords: require a digit in passwords generated from default rules by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/562
* classifiers: fix another batch of test page expected username failures by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/573
* Update password-related json files (2024-05-30) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/577
* Update password-related json files (2024-05-31) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/578
* l10n: update translations based on ship review feedback by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/581
* android: Revert "Android: enable iframe support (#536)" by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/582

## New Contributors
* @sjbarag made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/558

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/11.0.2...12.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).