### PR TITLE
Update autofill to 12.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,7 +176,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11182,13 +11182,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#10aeff1ec7f533d1705233a9b14f9393a699b1c0",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#11.0.2"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#12.0.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4689746e42b24c40c18896d697ea02b854e90d35",
             "integrity": "sha512-MRpNEmXR7mDECbfMUvCN3W139RmpqYM5lHKut7+n/bw39ewtO4kYPNryeQzXIB+Tkc8tP5Zon0G0FVOoPY5FJw==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#4689746e42b24c40c18896d697ea02b854e90d35",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#5.21.0",
             "requires": {
                 "immutable-json-patch": "^5.1.3",
                 "parse-address": "^1.1.2",
@@ -11210,7 +11210,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#25b8903191a40b21b09525085fe325ae3386092e",
             "integrity": "sha512-Ry34jcIoTSZoSjvZxFgzqG+eduBNhnpO0T9gT71HyVG+rqQcEBp4R2EAst4UyKjDN7Hmyu9ulpsd7trB6ymjnw==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#25b8903191a40b21b09525085fe325ae3386092e"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#3.6.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1


## Description
Updates Autofill to version [12.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1).

### Autofill 12.0.1 release notes
## What's Changed
* generation: ensure password gen feature flag is respected by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/583

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.0.0...12.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).