### PR TITLE
Add pixels to the ad click attribution mechanism

### DIFF
--- a/integration-test/data/click-attribution-pixels.js
+++ b/integration-test/data/click-attribution-pixels.js
@@ -1,0 +1,198 @@
+// Expected pixel requests fired for each test case.
+// TODO: Move this into the shared testCases.json file.
+//       See https://github.com/duckduckgo/privacy-test-pages/blob/main/adClickFlow/shared/testCases.json
+exports.expectedPixels = [
+    // Ad 1 - No ad_domain parameter, so no pixels.
+    { },
+
+    // Ad 2 - No ad_domain parameter, so no pixels.
+    { },
+
+    // Ad 3 - No ad_domain parameter, so no pixels.
+    { },
+
+    // Ad 4 - No ad_domain parameter, so no pixels.
+    { },
+
+    // Ad 5
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Clicked ad with empty ad_domain parameter and two requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'heuristic_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            },
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '1'
+                }
+            }
+        ]
+    },
+
+    // Ad 6
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Clicked ad with empty ad_domain parameter and two requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'heuristic_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            },
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '1'
+                }
+            }
+        ]
+    },
+
+    // Ad 7
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Click ad with populated ad_domain parameter that matches. Two
+        // requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'matched',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            },
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '1'
+                }
+            }
+        ]
+    },
+
+    // Ad 8
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Click ad with populated ad_domain parameter that matches. Two
+        // requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'matched',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            },
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '1'
+                }
+            }
+        ]
+    },
+
+    // Ad 5 - "Single-site, new-tab, session"
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Clicked ad with empty ad_domain parameter and two requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'heuristic_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            }
+        ],
+        // Navigated to another page, two more requests allowed.
+        3: [
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '2'
+                }
+            }
+        ]
+    },
+
+    // Ad 5 - "Single-site, new-tab, session, variant two"
+    {
+        // Navigated to search page.
+        1: [
+        ],
+        // Clicked ad with empty ad_domain parameter and two requests allowed.
+        2: [
+            {
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'heuristic_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            },
+            {
+                name: 'm_ad_click_active',
+                params: { }
+            }
+        ],
+        // Navigated to another page, two more requests allowed.
+        3: [
+            // After 24 hours the aggregate pixel fires.
+            {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '2'
+                }
+            }
+        ]
+    }
+]

--- a/integration-test/data/staticcdn/trackerblocking/v6/current/extension-mv3-tds.json
+++ b/integration-test/data/staticcdn/trackerblocking/v6/current/extension-mv3-tds.json
@@ -1,5 +1,33 @@
 {
     "trackers": {
+        "ad-company.example": {
+            "domain": "ad-company.example",
+            "owner": {
+                "name": "Ad Company Example",
+                "displayName": "Ad Company Example",
+                "url": "http://ad-company.example"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 2,
+            "cookies": 0.1,
+            "categories": [],
+            "rules": [],
+            "default": "block"
+        },
+        "ad-company.site": {
+            "domain": "ad-company.site",
+            "owner": {
+                "name": "Ad Company",
+                "displayName": "Ad Company",
+                "url": "http://ad-company.site"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 2,
+            "cookies": 0.1,
+            "categories": [],
+            "rules": [],
+            "default": "block"
+        },
         "bad.third-party.site": {
             "domain": "bad.third-party.site",
             "owner": {
@@ -31,6 +59,20 @@
         }
     },
     "entities": {
+        "Ad Company Example": {
+            "displayName": "Ad Company Example",
+            "prevalence": 0.1,
+            "domains": [
+                "ad-company.example"
+            ]
+        },
+        "Ad Company": {
+            "displayName": "Ad Company",
+            "prevalence": 0.1,
+            "domains": [
+                "ad-company.site"
+            ]
+        },
         "Test Site for Tracker Blocking": {
             "displayName": "Test Site for Tracker Blocking",
             "prevalence": 0.1,
@@ -42,6 +84,8 @@
     },
     "cnames": [],
     "domains": {
+        "ad-company.example": "Ad Company Example",
+        "ad-company.site": "Ad Company",
         "bad.third-party.site": "Test Site for Tracker Blocking",
         "broken.third-party.site": "Test Site for Tracker Blocking"
     }

--- a/integration-test/data/staticcdn/trackerblocking/v6/current/extension-tds.json
+++ b/integration-test/data/staticcdn/trackerblocking/v6/current/extension-tds.json
@@ -1,5 +1,33 @@
 {
     "trackers": {
+        "ad-company.example": {
+            "domain": "ad-company.example",
+            "owner": {
+                "name": "Ad Company Example",
+                "displayName": "Ad Company Example",
+                "url": "http://ad-company.example"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 2,
+            "cookies": 0.1,
+            "categories": [],
+            "rules": [],
+            "default": "block"
+        },
+        "ad-company.site": {
+            "domain": "ad-company.site",
+            "owner": {
+                "name": "Ad Company",
+                "displayName": "Ad Company",
+                "url": "http://ad-company.site"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 2,
+            "cookies": 0.1,
+            "categories": [],
+            "rules": [],
+            "default": "block"
+        },
         "bad.third-party.site": {
             "domain": "bad.third-party.site",
             "owner": {
@@ -31,6 +59,20 @@
         }
     },
     "entities": {
+        "Ad Company Example": {
+            "displayName": "Ad Company Example",
+            "prevalence": 0.1,
+            "domains": [
+                "ad-company.example"
+            ]
+        },
+        "Ad Company": {
+            "displayName": "Ad Company",
+            "prevalence": 0.1,
+            "domains": [
+                "ad-company.site"
+            ]
+        },
         "Test Site for Tracker Blocking": {
             "displayName": "Test Site for Tracker Blocking",
             "prevalence": 0.1,
@@ -42,6 +84,8 @@
     },
     "cnames": [],
     "domains": {
+        "ad-company.example": "Ad Company Example",
+        "ad-company.site": "Ad Company",
         "bad.third-party.site": "Test Site for Tracker Blocking",
         "broken.third-party.site": "Test Site for Tracker Blocking"
     }

--- a/integration-test/fire-button.spec.js
+++ b/integration-test/fire-button.spec.js
@@ -134,7 +134,7 @@ test.describe('Fire Button', () => {
                 name: 'Last7days',
                 descriptionStats: {
                     clearHistory: true,
-                    cookies: 3, // gets the number of domains with cookies set
+                    cookies: 2, // gets the number of domains with cookies set
                     duration: 'week',
                     openTabs: 6, // gets all open tabs that will be cleared
                     pinnedTabs: 0

--- a/integration-test/helpers/pixels.js
+++ b/integration-test/helpers/pixels.js
@@ -1,0 +1,22 @@
+import { logPageRequests } from './requests'
+import {
+    _formatPixelRequestForTesting
+} from '../../shared/js/shared-utils/pixels'
+
+function requestIsPixel (request) {
+    return request?.url?.hostname === 'improving.duckduckgo.com'
+}
+
+function formatPixelRequest (request) {
+    return _formatPixelRequestForTesting(request.url)
+}
+
+export function logPixels (page, pixelRequests, filter) {
+    return logPageRequests(
+        page,
+        pixelRequests,
+        requestIsPixel,
+        formatPixelRequest,
+        filter
+    )
+}

--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -103,7 +103,8 @@ export const test = base.extend({
                     body: JSON.stringify(mockAtb)
                 })
             }
-            if (url.startsWith('https://duckduckgo.com/exti')) {
+            if (url.startsWith('https://duckduckgo.com/exti') ||
+                url.startsWith('https://improving.duckduckgo.com/')) {
                 return route.fulfill({
                     status: 200,
                     body: ''

--- a/shared/js/background/classes/ad-click-attribution-policy.js
+++ b/shared/js/background/classes/ad-click-attribution-policy.js
@@ -6,6 +6,8 @@ import {
     generateDNRRule
 } from '@duckduckgo/ddg2dnr/lib/utils'
 
+import settings from '../settings'
+import { sendPixelRequest } from '../pixels'
 const { getFeatureSettings, getBaseDomain } = require('../utils')
 const browserWrapper = require('../wrapper')
 const { getNextSessionRuleId } = require('../dnr-session-rule-id')
@@ -77,7 +79,13 @@ export class AdClickAttributionPolicy {
         const linkFormat = this.getMatchingLinkFormat(resourceURL)
         if (!linkFormat) return
 
-        const adClick = new AdClick(this.navigationExpiration, this.totalExpiration, this.allowlist)
+        const adClick = new AdClick(
+            this.navigationExpiration,
+            this.totalExpiration,
+            this.allowlist,
+            this.heuristicDetectionEnabled,
+            this.domainDetectionEnabled
+        )
 
         if (manifestVersion === 3) {
             adClick.createDNR(tab.id)
@@ -89,14 +97,16 @@ export class AdClickAttributionPolicy {
                 const parsedParameterDomain = getBaseDomain(parameterDomain)
                 if (parsedParameterDomain) {
                     adClick.setAdBaseDomain(parsedParameterDomain)
-                    return adClick
+                    adClick.parameterAdBaseDomain = parsedParameterDomain
                 }
             }
         }
-        if (this.heuristicDetectionEnabled) {
+
+        if (this.heuristicDetectionEnabled && !adClick.parameterAdBaseDomain) {
             adClick.adClickRedirect = true
-            return adClick
         }
+
+        return adClick
     }
 
     /**
@@ -123,10 +133,18 @@ export class AdClick {
     /**
      * @param {number} navigationExpiration in seconds
      * @param {number} totalExpiration in seconds
+     * @param {any} allowlist
+     * @param {boolean} heuristicDetectionEnabled
+     * @param {boolean} domainDetectionEnabled
      */
-    constructor (navigationExpiration, totalExpiration, allowlist) {
-        /** @type {string | null} */
+    constructor (
+        navigationExpiration, totalExpiration, allowlist,
+        heuristicDetectionEnabled, domainDetectionEnabled
+    ) {
+        /** @type {string?} */
         this.adBaseDomain = null
+        /** @type {string?} */
+        this.parameterAdBaseDomain = null
         this.adClickRedirect = false
         this.navigationExpiration = navigationExpiration
         this.totalExpiration = totalExpiration
@@ -134,15 +152,28 @@ export class AdClick {
         this.clickExpires = Date.now() + (this.navigationExpiration * 1000)
         this.allowlist = allowlist
         this.adClickDNR = null
+        this.heuristicDetectionEnabled = heuristicDetectionEnabled
+        this.domainDetectionEnabled = domainDetectionEnabled
+        this.adClickDetectedPixelSent = false
+        this.adClickActivePixelSent = false
     }
 
     clone () {
-        const adClick = new AdClick(this.navigationExpiration, this.totalExpiration, this.allowlist)
+        const adClick = new AdClick(
+            this.navigationExpiration,
+            this.totalExpiration,
+            this.allowlist,
+            this.heuristicDetectionEnabled,
+            this.domainDetectionEnabled
+        )
         adClick.adBaseDomain = this.adBaseDomain
+        adClick.parameterAdBaseDomain = this.parameterAdBaseDomain
         adClick.adClickRedirect = this.adClickRedirect
         adClick.expires = this.expires
         adClick.clickExpires = Date.now() + (this.navigationExpiration * 1000)
         adClick.adClickDNR = this.adClickDNR
+        adClick.adClickDetectedPixelSent = this.adClickDetectedPixelSent
+        adClick.adClickActivePixelSent = this.adClickActivePixelSent
         return adClick
     }
 
@@ -162,12 +193,21 @@ export class AdClick {
     }
 
     static restore (adClick) {
-        const restoredAdClick = new AdClick(adClick.navigationExpiration, adClick.totalExpiration, adClick.allowlist)
+        const restoredAdClick = new AdClick(
+            adClick.navigationExpiration,
+            adClick.totalExpiration,
+            adClick.allowlist,
+            adClick.heuristicDetectionEnabled,
+            adClick.domainDetectionEnabled
+        )
         restoredAdClick.adBaseDomain = adClick.adBaseDomain
+        restoredAdClick.parameterAdBaseDomain = adClick.parameterAdBaseDomain
         restoredAdClick.adClickRedirect = adClick.adClickRedirect
         restoredAdClick.expires = adClick.expires
         restoredAdClick.clickExpires = adClick.clickExpires
         restoredAdClick.adClickDNR = adClick.adClickDNR
+        restoredAdClick.adClickDetectedPixelSent = adClick.adClickDetectedPixelSent
+        restoredAdClick.adClickActivePixelSent = adClick.adClickActivePixelSent
         return restoredAdClick
     }
 
@@ -181,6 +221,44 @@ export class AdClick {
         if (this.adClickDNR) {
             this.updateDNRInitiator(domain)
         }
+    }
+
+    /**
+     * Send this AdClick's 'm_ad_click_detected' pixel request, if it hasn't
+     * been sent already.
+     * @param {string?} heuristicAdBaseDomain
+     */
+    sendAdClickDetectedPixel (heuristicAdBaseDomain) {
+        if (this.adClickDetectedPixelSent) {
+            return
+        }
+
+        // Clear heuristic domain if it shouldn't be used. Not technically
+        // necessary, but helps with the unit tests.
+        if (!this.heuristicDetectionEnabled && heuristicAdBaseDomain) {
+            heuristicAdBaseDomain = null
+        }
+
+        let domainDetection = 'none'
+
+        if (this.parameterAdBaseDomain && heuristicAdBaseDomain) {
+            if (this.parameterAdBaseDomain === heuristicAdBaseDomain) {
+                domainDetection = 'matched'
+            } else {
+                domainDetection = 'mismatch'
+            }
+        } else if (this.parameterAdBaseDomain) {
+            domainDetection = 'serp_only'
+        } else if (heuristicAdBaseDomain) {
+            domainDetection = 'heuristic_only'
+        }
+
+        sendPixelRequest('m_ad_click_detected', {
+            domainDetection,
+            heuristicDetectionEnabled: this.heuristicDetectionEnabled ? '1' : '0',
+            domainDetectionEnabled: this.domainDetectionEnabled ? '1' : 0
+        })
+        this.adClickDetectedPixelSent = true
     }
 
     /**
@@ -222,7 +300,26 @@ export class AdClick {
      */
     allowAdAttribution (tab) {
         if (tab.site.baseDomain !== this.adBaseDomain) return false
-        return this.hasNotExpired()
+        const allowed = this.hasNotExpired()
+
+        if (allowed) {
+            // If this is the first ad attribution request allowed for the tab,
+            // increment the count sent with the
+            // 'm_pageloads_with_ad_attribution' pixel.
+            if (!tab.firstAdAttributionAllowed) {
+                settings.incrementNumericSetting('m_pageloads_with_ad_attribution.count')
+                tab.firstAdAttributionAllowed = true
+            }
+
+            // If this is the first ad attribution request allowed for this
+            // AdClick, send the 'm_ad_click_active' pixel.
+            if (!this.adClickActivePixelSent) {
+                sendPixelRequest('m_ad_click_active')
+                this.adClickActivePixelSent = true
+            }
+        }
+
+        return allowed
     }
 
     getAdClickDNR (tabId) {
@@ -265,4 +362,21 @@ export class AdClick {
             chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: [this.adClickDNR.rule.id] })
         }
     }
+}
+
+/**
+ * Send the 'm_pageloads_with_ad_attribution' pixel if necessary and reset the
+ * counter. Expected to be called once every 24 hours, or more frequently during
+ * testing.
+ * @returns {Promise<void>}
+ */
+export async function sendPageloadsWithAdAttributionPixelAndResetCount () {
+    await settings.ready()
+    const count = settings.getSetting('m_pageloads_with_ad_attribution.count')
+    if (typeof count === 'number' && count > 0) {
+        await sendPixelRequest('m_pageloads_with_ad_attribution', {
+            count
+        })
+    }
+    settings.updateSetting('m_pageloads_with_ad_attribution.count', 0)
 }

--- a/shared/js/background/classes/tab-state.js
+++ b/shared/js/background/classes/tab-state.js
@@ -28,6 +28,8 @@ export class TabState {
         this.statusCode = null // statusCode is set when headers are recieved in tabManager.js
         /** @type {null | import('./ad-click-attribution-policy').AdClick} */
         this.adClick = null
+        /** @type {boolean} */
+        this.firstAdAttributionAllowed = false
         /** @type {Record<string, import('./tracker').Tracker>} */
         this.trackers = {}
         /** @type {null | import('../events/referrer-trimming').Referrer} */

--- a/shared/js/background/classes/tab.js
+++ b/shared/js/background/classes/tab.js
@@ -70,6 +70,14 @@ class Tab {
         return this._tabState.adClick
     }
 
+    set firstAdAttributionAllowed (value) {
+        this._tabState.setValue('firstAdAttributionAllowed', value)
+    }
+
+    get firstAdAttributionAllowed () {
+        return this._tabState.firstAdAttributionAllowed
+    }
+
     set disabledClickToLoadRuleActions (value) {
         this._tabState.setValue('disabledClickToLoadRuleActions', value)
     }

--- a/shared/js/background/components/email-autofill.js
+++ b/shared/js/background/components/email-autofill.js
@@ -1,4 +1,3 @@
-/* global BUILD_TARGET */
 import browser from 'webextension-polyfill'
 import { sendPixelRequest } from '../pixels'
 import { registerMessageHandler } from '../message-handlers'
@@ -16,8 +15,6 @@ import { getFromSessionStorage, setToSessionStorage, removeFromSessionStorage, c
 const MENU_ITEM_ID = 'ddg-autofill-context-menu-item'
 export const REFETCH_ALIAS_ALARM = 'refetchAlias'
 const REFETCH_ALIAS_ATTEMPT = 'refetchAliasAttempt'
-
-const pixelsEnabled = BUILD_TARGET !== 'firefox'
 
 export default class EmailAutofill {
     /**
@@ -200,7 +197,6 @@ export default class EmailAutofill {
 
     fireAutofillPixel (pixel, shouldUpdateLastUsed = false) {
         const browserName = getBrowserName() ?? 'unknown'
-        if (!pixelsEnabled) return
 
         const userData = this.settings.getSetting('userData')
         if (!userData?.userName) return
@@ -306,7 +302,6 @@ const getFullPixelName = (name, browserName) => {
 
 const fireIncontextSignupPixel = (pixel, params) => {
     const browserName = getBrowserName() ?? 'unknown'
-    if (!pixelsEnabled) return
 
     sendPixelRequest(getFullPixelName(pixel, browserName), params)
 }

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -7,6 +7,9 @@ import Companies from './companies'
 import atb from './atb'
 import tds from './storage/tds'
 import { createNewtabTrackerStatsDebugApi } from './newtab-tracker-stats-debug'
+import {
+    sendPageloadsWithAdAttributionPixelAndResetCount
+} from './classes/ad-click-attribution-policy'
 const settings = require('./settings')
 const tabManager = require('./tab-manager')
 const https = require('./https')
@@ -37,7 +40,8 @@ export default function initDebugBuild () {
         setListContents,
         getListContents,
         companies: Companies,
-        ntts: createNewtabTrackerStatsDebugApi()
+        ntts: createNewtabTrackerStatsDebugApi(),
+        sendPageloadsWithAdAttributionPixelAndResetCount
     }
 
     // mark this as a dev build

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -17,6 +17,9 @@ import {
 import httpsStorage from './storage/https'
 import ATB from './atb'
 import { clearExpiredBrokenSiteReportTimes } from './broken-site-report'
+import {
+    sendPageloadsWithAdAttributionPixelAndResetCount
+} from './classes/ad-click-attribution-policy'
 const utils = require('./utils')
 const experiment = require('./experiments')
 const settings = require('./settings')
@@ -441,6 +444,9 @@ browserWrapper.createAlarm('rotateUserAgent', { periodInMinutes: 24 * 60 })
 browserWrapper.createAlarm('rotateSessionKey', { periodInMinutes: 60 })
 // Expire site breakage reports
 browserWrapper.createAlarm('clearExpiredBrokenSiteReportTimes', { periodInMinutes: 60 })
+// Reset the ad click attribution counter and send out the corresponding pixel
+// request where necessary.
+browserWrapper.createAlarm('adClickAttributionDaily', { periodInMinutes: 60 * 24 })
 
 browser.alarms.onAlarm.addListener(async alarmEvent => {
     // Warning: Awaiting in this function doesn't actually wait for the promise to resolve before unblocking the main thread.
@@ -458,6 +464,8 @@ browser.alarms.onAlarm.addListener(async alarmEvent => {
         await utils.resetSessionKey()
     } else if (alarmEvent.name === 'clearExpiredBrokenSiteReportTimes') {
         await clearExpiredBrokenSiteReportTimes()
+    } else if (alarmEvent.name === 'adClickAttributionDaily') {
+        await sendPageloadsWithAdAttributionPixelAndResetCount()
     }
 })
 

--- a/shared/js/background/pixels.js
+++ b/shared/js/background/pixels.js
@@ -1,3 +1,4 @@
+/* global BUILD_TARGET */
 import load from './load'
 
 /**
@@ -14,8 +15,13 @@ export function getURL (pixelName) {
 }
 
 export function sendPixelRequest (pixelName, params = {}) {
+    // Pixel requests should never fire for Firefox users.
+    if (BUILD_TARGET === 'firefox') {
+        return
+    }
+
     const randomNum = Math.ceil(Math.random() * 1e7)
     const searchParams = new URLSearchParams(Object.entries(params))
     const url = getURL(pixelName) + `?${randomNum}&${searchParams.toString()}`
-    load.url(url)
+    return load.url(url)
 }

--- a/shared/js/background/settings.js
+++ b/shared/js/background/settings.js
@@ -133,6 +133,22 @@ function updateSetting (name, value) {
     })
 }
 
+function incrementNumericSetting (name, increment = 1) {
+    if (!isReady) {
+        console.warn(
+            'Settings: incrementNumericSetting() Setting not loaded:', name
+        )
+        return
+    }
+
+    let value = settings[name]
+    if (typeof value !== 'number' || isNaN(value)) {
+        value = 0
+    }
+
+    updateSetting(name, value + increment)
+}
+
 function removeSetting (name) {
     if (!isReady) {
         console.warn(`Settings: removeSetting() Setting not loaded: ${name}`)
@@ -153,6 +169,7 @@ function logSettings () {
 module.exports = {
     getSetting,
     updateSetting,
+    incrementNumericSetting,
     removeSetting,
     logSettings,
     ready,

--- a/shared/js/shared-utils/pixels.js
+++ b/shared/js/shared-utils/pixels.js
@@ -1,0 +1,45 @@
+/**
+ * Utility for tests that converts a pixel request URL into a nicely formatted
+ * Object. Returns null for invalid URLs and non-pixel URLs.
+ * @param {string|URL} url
+ * @return {{
+ *   name: string,
+ *   params: Object
+ * }?}
+ */
+export function _formatPixelRequestForTesting (url) {
+    let parsed
+    try {
+        parsed = url instanceof URL ? url : new URL(url)
+    } catch (e) {
+        return null
+    }
+
+    if (parsed.hostname !== 'improving.duckduckgo.com') {
+        return null
+    }
+
+    const name = parsed.pathname.split('/').pop()
+
+    if (!name) {
+        return null
+    }
+
+    const params = {}
+    for (const [key, value] of parsed.searchParams) {
+        // Ignore the random number prefix, that's sent to avoid caching.
+        if (value === '' && /^[0-9]+$/.test(key)) {
+            continue
+        }
+
+        // Ignore the test=1 parameter that's sent so that testing pixel
+        // requests are ignored on the server-side.
+        if (value === '1' && key === 'test') {
+            continue
+        }
+
+        params[key] = value
+    }
+
+    return { name, params }
+}

--- a/unit-test/background/ad-click-attribution-policy.js
+++ b/unit-test/background/ad-click-attribution-policy.js
@@ -1,12 +1,35 @@
-const config = require('../../shared/data/bundled/extension-config.json')
+import config from '../data/extension-config.json'
+import tdsStorageStub from '../helpers/tds'
+import {
+    _formatPixelRequestForTesting
+} from '../../shared/js/shared-utils/pixels'
+import {
+    AdClickAttributionPolicy,
+    sendPageloadsWithAdAttributionPixelAndResetCount
+} from '../../shared/js/background/classes/ad-click-attribution-policy'
+import Tab from '../../shared/js/background/classes/tab'
+import trackers from '../../shared/js/background/trackers'
+import tdsStorage from '../../shared/js/background/storage/tds'
+import load from '../../shared/js/background/load'
+
+function createAdClickAttributionPolicy (policy = {}) {
+    // This is not ideal, but it's the only way to get the policy to
+    // load the expected data. Stubs aren't working through imports.
+    const adClickAttributionPolicy = new AdClickAttributionPolicy()
+    if (!policy.allowlist) {
+        policy.allowlist = config.features.adClickAttribution.settings.allowlist
+    }
+    for (const [key, value] of Object.entries(policy)) {
+        adClickAttributionPolicy[key] = value
+    }
+
+    return adClickAttributionPolicy
+}
 
 describe('check policy', () => {
     let adClickAttributionPolicy
     beforeEach(async () => {
-        const { AdClickAttributionPolicy } = require('../../shared/js/background/classes/ad-click-attribution-policy')
-        adClickAttributionPolicy = new AdClickAttributionPolicy()
-        // This is not ideal, but it's the only way to get the policy to load the expected data. Stubs aren't working through imports.
-        adClickAttributionPolicy.allowlist = config.features.adClickAttribution.settings.allowlist
+        adClickAttributionPolicy = createAdClickAttributionPolicy()
         expect(adClickAttributionPolicy.allowlist.length).not.toEqual(0)
     })
     it('should return false if url is not expected to match', () => {
@@ -41,5 +64,360 @@ describe('check policy', () => {
                 .withContext(`Expect url: ${url} to be permitted`)
                 .toBe(true)
         }
+    })
+})
+
+describe('pixels', () => {
+    const actualSentPixels = []
+
+    const expectPixels = async ({
+        startUrl, adClickUrl, heuristicDomain = null, navigations = [], policy,
+        sendPageloadCountPixel = true, context, expectedPixels
+    }) => {
+        actualSentPixels.length = 0
+        let tab = new Tab({ tabId: 123, url: startUrl })
+
+        const adClickAttributionPolicy = createAdClickAttributionPolicy(policy)
+        const adClick = adClickAttributionPolicy.createAdClick(adClickUrl)
+        adClick.sendAdClickDetectedPixel(heuristicDomain)
+        for (const { url: navigationUrl, attributionRequestCount } of navigations) {
+            tab = new Tab({ tabId: 123, url: navigationUrl })
+
+            for (let i = 0; i < attributionRequestCount; i++) {
+                adClick.allowAdAttribution(tab)
+            }
+        }
+        if (sendPageloadCountPixel) {
+            await sendPageloadsWithAdAttributionPixelAndResetCount()
+        }
+
+        expect(actualSentPixels).withContext(context).toEqual(expectedPixels)
+    }
+
+    beforeAll(async () => {
+        tdsStorageStub.stub({ config })
+        await trackers.setLists(await tdsStorage.getLists())
+
+        spyOn(load, 'url').and.callFake(
+            url => {
+                const pixel = _formatPixelRequestForTesting(url)
+                if (pixel) {
+                    actualSentPixels.push(pixel)
+                }
+            }
+        )
+    })
+
+    beforeEach(async () => {
+        await sendPageloadsWithAdAttributionPixelAndResetCount()
+        actualSentPixels.length = 0
+    })
+
+    it('should send the correct the m_ad_click_detected pixel parameters', async () => {
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'No ad click domain available.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'none',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: {
+                domainDetectionEnabled: false
+            },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Param domain ignored, no heuristic domain.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'none',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '0'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: {
+                heuristicDetectionEnabled: false
+            },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=',
+            heuristicDomain: 'example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Heuristic domain ignored, no param domain.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'none',
+                    heuristicDetectionEnabled: '0',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: {
+                domainDetectionEnabled: false,
+                heuristicDetectionEnabled: false
+            },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            heuristicDomain: 'example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'All domains ignored.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'none',
+                    heuristicDetectionEnabled: '0',
+                    domainDetectionEnabled: '0'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Only param domain.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=',
+            heuristicDomain: 'example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Only heuristic domain.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'heuristic_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            heuristicDomain: 'example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Domains match.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'matched',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=www.example.com',
+            heuristicDomain: 'example.com',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Domains match (with www. subdomain).',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'matched',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            heuristicDomain: 'foo.example',
+            navigations: [],
+            sendPageloadCountPixel: false,
+            context: 'Domains don\'t match.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'mismatch',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+    })
+
+    it('should send the correct the m_ad_click_active pixel at the right times', async () => {
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [
+                { url: 'https://foo.example/page', attributionRequestCount: 2 }
+            ],
+            sendPageloadCountPixel: false,
+            context: 'Navigated to wrong domain, so not sent.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [
+                { url: 'https://example.com/page', attributionRequestCount: 4 }
+            ],
+            sendPageloadCountPixel: false,
+            context: 'One navigation, four allowed requests.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }, {
+                name: 'm_ad_click_active',
+                params: { }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [
+                { url: 'https://example.com/page', attributionRequestCount: 4 },
+                { url: 'https://example.com/page2', attributionRequestCount: 2 }
+            ],
+            sendPageloadCountPixel: false,
+            context: 'Two navigation, six allowed requests.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }, {
+                name: 'm_ad_click_active',
+                params: { }
+            }]
+        })
+    })
+
+    it('should send the correct the m_pageloads_with_ad_attribution pixel with correct count', async () => {
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [],
+            context: 'No navigations.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }]
+        })
+
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [
+                { url: 'https://example.com/page', attributionRequestCount: 4 },
+                { url: 'https://example.com/page2', attributionRequestCount: 2 },
+                { url: 'https://foo.example/wrong', attributionRequestCount: 3 },
+                { url: 'https://example.com/page3', attributionRequestCount: 1 }
+            ],
+            context: 'Four navigations (one wrong), seven allowed requests.',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }, {
+                name: 'm_ad_click_active',
+                params: { }
+            }, {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '3'
+                }
+            }]
+        })
+
+        // Test again, to ensure count was reset last time.
+        await expectPixels({
+            startUrl: 'https://duckduckgo.com',
+            policy: { },
+            adClickUrl: 'https://duckduckgo.com/y.js?ad_domain=example.com',
+            navigations: [
+                { url: 'https://example.com/page', attributionRequestCount: 2 }
+            ],
+            context: 'One navigation, two allowed requests',
+            expectedPixels: [{
+                name: 'm_ad_click_detected',
+                params: {
+                    domainDetection: 'serp_only',
+                    heuristicDetectionEnabled: '1',
+                    domainDetectionEnabled: '1'
+                }
+            }, {
+                name: 'm_ad_click_active',
+                params: { }
+            }, {
+                name: 'm_pageloads_with_ad_attribution',
+                params: {
+                    count: '1'
+                }
+            }]
+        })
     })
 })

--- a/unit-test/background/classes/tab.js
+++ b/unit-test/background/classes/tab.js
@@ -97,6 +97,7 @@ describe('Tab', () => {
                 surrogates: {},
                 referrer: null,
                 adClick: null,
+                firstAdAttributionAllowed: false,
                 disabledClickToLoadRuleActions: [],
                 dnrRuleIdsByDisabledClickToLoadRuleAction: {},
                 trackers: {},


### PR DESCRIPTION
This adds "pixel" requests to the mechanism we rely on to support ad
click attribution in DuckDuckGo products. These help DuckDuckGo
validate that the mechanism's logic is working correctly.

Further reading:
 - https://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/#duckduckgo-private-search-ads
 - https://improving.duckduckgo.com/

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth , @jonathanKingston 

## Steps to test this PR:
1. Ensure the ad click attribution pixels fire correctly on Chrome using [the test page](https://www.search-company.site/) .
2. Ensure the pixels _don't_ fire on Firefox.
3. Ensure the integration tests and unit tests are passing.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
