### PR TITLE
Skip some failing integration tests

### DIFF
--- a/integration-test/amp-protection.spec.js
+++ b/integration-test/amp-protection.spec.js
@@ -59,6 +59,12 @@ test.describe('Test AMP link protection', () => {
             await page.goto(
                 initialUrl, { waitUntil: 'commit' }
             )
+
+            if (page.url().startsWith('https://www.wpxi.com/unavailable-location/')) {
+                console.warn('SKIPPED:', description, '- Test page geo-blocked')
+                continue
+            }
+
             expect(page.url(), description).toEqual(expectedUrl)
         }
     })

--- a/integration-test/click-to-load-youtube.spec.js
+++ b/integration-test/click-to-load-youtube.spec.js
@@ -76,6 +76,10 @@ function overrideHandler (route) {
 
 test.describe('Test YouTube Click To Load', () => {
     test.beforeEach(async ({ context, backgroundPage, backgroundNetworkContext }) => {
+        // TODO: Remove these tests with the rest of the feature's code, or get
+        //       them passing again.
+        test.skip(true, 'YouTube Click to Load tests disabled for now.')
+
         // Overwrite the parts of the configuration needed for our tests.
         await overridePrivacyConfig(backgroundNetworkContext, 'click-to-load-youtube.json')
         await overrideTds(backgroundNetworkContext, 'click-to-load-tds.json')


### PR DESCRIPTION
The integration tests are unfortunately quite flakey. Worse still,
some tests are now failing quite consistently. Let's skip those tests
for now, so we can more easily spot future regressions:

1. The YouTube Click to Load integration tests are failing, and since
   the feature's in limbo it's probably not worth spending too much
   fixing them for now.
2. The AMP integration tests fail for some regions, since one of the
   test pages doesn't work outside of the US.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
