### PR TITLE
Adjust ad click attribution pixel logic

### DIFF
--- a/integration-test/data/click-attribution-pixels.js
+++ b/integration-test/data/click-attribution-pixels.js
@@ -24,6 +24,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'heuristic_only',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -31,7 +32,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             },
             // After 24 hours the aggregate pixel fires.
             {
@@ -53,6 +56,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'heuristic_only',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -60,7 +64,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             },
             // After 24 hours the aggregate pixel fires.
             {
@@ -83,6 +89,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'matched',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -90,7 +97,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             },
             // After 24 hours the aggregate pixel fires.
             {
@@ -113,6 +122,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'matched',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -120,7 +130,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             },
             // After 24 hours the aggregate pixel fires.
             {
@@ -142,6 +154,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'heuristic_only',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -149,7 +162,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             }
         ],
         // Navigated to another page, two more requests allowed.
@@ -174,6 +189,7 @@ exports.expectedPixels = [
             {
                 name: 'm_ad_click_detected',
                 params: {
+                    appVersion: 'EXTENSION_VERSION',
                     domainDetection: 'heuristic_only',
                     heuristicDetectionEnabled: '1',
                     domainDetectionEnabled: '1'
@@ -181,7 +197,9 @@ exports.expectedPixels = [
             },
             {
                 name: 'm_ad_click_active',
-                params: { }
+                params: {
+                    appVersion: 'EXTENSION_VERSION'
+                }
             }
         ],
         // Navigated to another page, two more requests allowed.

--- a/shared/js/background/classes/tab.js
+++ b/shared/js/background/classes/tab.js
@@ -310,7 +310,12 @@ class Tab {
     allowAdAttribution (resourcePath) {
         if (!this.site.isFeatureEnabled('adClickAttribution') || !this.adClick || !this.adClick.allowAdAttribution(this)) return false
         const policy = this.getAdClickAttributionPolicy()
-        return policy.resourcePermitted(resourcePath)
+        const permitted = policy.resourcePermitted(resourcePath)
+        if (permitted) {
+            this.adClick.requestWasAllowed(this)
+        }
+
+        return permitted
     }
 
     updateSite (url) {

--- a/shared/js/background/pixels.js
+++ b/shared/js/background/pixels.js
@@ -1,5 +1,6 @@
 /* global BUILD_TARGET */
 import load from './load'
+import { getBrowserName } from './utils'
 
 /**
  *
@@ -20,8 +21,11 @@ export function sendPixelRequest (pixelName, params = {}) {
         return
     }
 
+    const browserName = getBrowserName() || 'unknown'
+
     const randomNum = Math.ceil(Math.random() * 1e7)
     const searchParams = new URLSearchParams(Object.entries(params))
-    const url = getURL(pixelName) + `?${randomNum}&${searchParams.toString()}`
+    const url = getURL(`${pixelName}_extension_${browserName}`) +
+        `?${randomNum}&${searchParams.toString()}`
     return load.url(url)
 }


### PR DESCRIPTION
We recently added "pixel" requests to the mechanism we rely on to
support ad click attribution in DuckDuckGo products. These help
DuckDuckGo validate that the mechanism's logic is working correctly.

A few further adjustments are required:

1. The 'm_ad_click_active' pixel should only fire (and the
   'm_pageloads_with_ad_attribution' counter incremented) when a request
   is actually allowed by the mechanism.
2. The browser name (e.g. "chrome", "edge", etc.) should be appended
   to the pixel names.
3. The extension's version number (e.g. "2024.7.10") should be
   included with some of the pixels.

Further reading:
 - https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/f8755949344728145dcd9da970b7b1bfc8e7d926
 - https://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/#duckduckgo-private-search-ads
 - https://improving.duckduckgo.com/

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth, @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
