### PR TITLE
Update puppeteer dependency to 22.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
                 "karma-jasmine": "1.1.1",
                 "karma-source-map-support": "1.4.0",
                 "node-fetch": "^3.3.2",
-                "puppeteer": "^19.3.0",
+                "puppeteer": "^22.14.0",
                 "sass": "^1.77.5",
                 "standard": "17.1.0",
                 "timekeeper": "^2.3.1",
@@ -927,6 +927,57 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@puppeteer/browsers": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.3.5",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
@@ -954,6 +1005,12 @@
             "engines": {
                 "node": ">=14.16"
             }
+        },
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+            "dev": true
         },
         "node_modules/@types/chrome": {
             "version": "0.0.268",
@@ -1030,12 +1087,6 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
-        },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
         },
         "node_modules/@types/webextension-polyfill": {
             "version": "0.10.7",
@@ -1386,15 +1437,14 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -1628,6 +1678,18 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1677,10 +1739,62 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
+        "node_modules/b4a": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+            "dev": true
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/bare-events": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-fs": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^2.0.0"
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-path": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "streamx": "^2.18.0"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -1710,6 +1824,15 @@
                 "node": "^4.5.0 || >= 5.9"
             }
         },
+        "node_modules/basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1734,55 +1857,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/bl/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/bl/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/bluebird": {
@@ -2011,13 +2085,27 @@
             "dev": true
         },
         "node_modules/buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "dependencies": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4"
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-crc32": {
@@ -2254,12 +2342,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "node_modules/chrome-launcher": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
@@ -2286,6 +2368,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chromium-bidi": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.2.tgz",
+            "integrity": "sha512-4WVBa6ijmUTVr9cZD4eicQD8Mdy/HCX3bzEIYYpmk0glqYLoWH+LqQEvV9RpDRzoQSbY1KJHloYXbDMXMbDPhg==",
+            "dev": true,
+            "dependencies": {
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
+            },
+            "peerDependencies": {
+                "devtools-protocol": "*"
             }
         },
         "node_modules/ci-info": {
@@ -2550,19 +2646,29 @@
             }
         },
         "node_modules/cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/cosmiconfig/node_modules/lines-and-columns": {
@@ -2587,57 +2693,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-            "dev": true,
-            "dependencies": {
-                "node-fetch": "2.6.7"
-            }
-        },
-        "node_modules/cross-fetch/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/cross-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
-        },
-        "node_modules/cross-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "node_modules/cross-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/cross-spawn": {
@@ -2931,6 +2986,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "dev": true,
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2958,9 +3027,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1056733",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1056733.tgz",
-            "integrity": "sha512-CmTu6SQx2g3TbZzDCAV58+LTxVdKplS7xip0g5oDXpZ+isr0rv5dDP8ToyVRywzPHkCCPKgKgScEcwz4uPWDIA==",
+            "version": "0.0.1312386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
             "dev": true
         },
         "node_modules/dexie": {
@@ -3222,6 +3291,15 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3396,6 +3474,37 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dev": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/escodegen/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/eslint": {
@@ -3804,15 +3913,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eslint-plugin-react/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
             "version": "2.0.0-next.4",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -3843,14 +3943,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-scope/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "engines": {
-                "node": ">=4.0"
             }
         },
         "node_modules/eslint-utils": {
@@ -4044,14 +4136,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -4063,7 +4147,7 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/esrecurse/node_modules/estraverse": {
+        "node_modules/estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
@@ -4317,6 +4401,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true
         },
         "node_modules/fast-json-patch": {
             "version": "3.1.1",
@@ -4642,12 +4732,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
         "node_modules/fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -4811,6 +4895,44 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-uri": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "dev": true,
+            "dependencies": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/get-uri/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/getpass": {
@@ -5239,18 +5361,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/http-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5279,16 +5389,15 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -5499,6 +5608,25 @@
             "funding": {
                 "url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
             }
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -6109,31 +6237,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/jsdom/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/jsdom/node_modules/rrweb-cssom": {
@@ -6820,6 +6923,12 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/mitt": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+            "dev": true
+        },
         "node_modules/mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -6830,12 +6939,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "node_modules/mocha": {
             "version": "10.4.0",
@@ -7181,6 +7284,15 @@
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4.0"
             }
         },
         "node_modules/no-case": {
@@ -7738,6 +7850,38 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pac-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "dev": true,
+            "dependencies": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/package-json": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
@@ -7895,15 +8039,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
             "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/pend": {
             "version": "1.2.0",
@@ -8222,6 +8357,34 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -8266,55 +8429,68 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "19.3.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.3.0.tgz",
-            "integrity": "sha512-WJbi/ULaeuFOz7cfMgJlJCBAZiyqIFeQ6os4h5ex3PVTt2qosXgwI9eruFZqFAwJRv8x5pOuMhWR0aSRgyDqEg==",
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.14.0.tgz",
+            "integrity": "sha512-MGTR6/pM8zmWbTdazb6FKnwIihzsSEXBPH49mFFU96DNZpQOevCAZMnjBZGlZRGRzRK6aADCavR6SQtrbv5dQw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "cosmiconfig": "7.0.1",
-                "devtools-protocol": "0.0.1056733",
-                "https-proxy-agent": "5.0.1",
-                "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "puppeteer-core": "19.3.0"
+                "@puppeteer/browsers": "2.3.0",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1312386",
+                "puppeteer-core": "22.14.0"
+            },
+            "bin": {
+                "puppeteer": "lib/esm/puppeteer/node/cli.js"
             },
             "engines": {
-                "node": ">=14.1.0"
+                "node": ">=18"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "19.3.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.3.0.tgz",
-            "integrity": "sha512-P8VAAOBnBJo/7DKJnj1b0K9kZBF2D8lkdL94CjJ+DZKCp182LQqYemPI9omUSZkh4bgykzXjZhaVR1qtddTTQg==",
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.14.0.tgz",
+            "integrity": "sha512-rl4tOY5LcA3e374GAlsGGHc05HL3eGNf5rZ+uxkl6id9zVZKcwcp1Z+Nd6byb6WPiPeecT/dwz8f/iUm+AZQSw==",
             "dev": true,
             "dependencies": {
-                "cross-fetch": "3.1.5",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1056733",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "proxy-from-env": "1.1.0",
-                "rimraf": "3.0.2",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.10.0"
+                "@puppeteer/browsers": "2.3.0",
+                "chromium-bidi": "0.6.2",
+                "debug": "^4.3.5",
+                "devtools-protocol": "0.0.1312386",
+                "ws": "^8.18.0"
             },
             "engines": {
-                "node": ">=14.1.0"
+                "node": ">=18"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-            "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -9214,6 +9390,16 @@
                 "node": "*"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/socket.io": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.4.tgz",
@@ -9274,6 +9460,34 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "dev": true,
+            "dependencies": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/sonic-boom": {
@@ -9351,6 +9565,12 @@
             "engines": {
                 "node": ">= 10.x"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true
         },
         "node_modules/sshpk": {
             "version": "1.17.0",
@@ -9464,6 +9684,20 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/streamx": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+            "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+            "dev": true,
+            "dependencies": {
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
+            },
+            "optionalDependencies": {
+                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {
@@ -9691,45 +9925,37 @@
             "dev": true
         },
         "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dev": true,
             "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
+                "tar-stream": "^3.1.5"
+            },
+            "optionalDependencies": {
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0"
             }
         },
         "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
             "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
             }
         },
-        "node_modules/tar-stream/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+        "node_modules/text-decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
             "dev": true,
             "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
+                "b4a": "^1.6.4"
             }
         },
         "node_modules/text-table": {
@@ -10272,6 +10498,12 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "node_modules/urlpattern-polyfill": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+            "dev": true
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10419,17 +10651,6 @@
                 "npm": ">=8.0.0"
             }
         },
-        "node_modules/web-ext/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/web-ext/node_modules/array-differ": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -10474,18 +10695,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/web-ext/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/web-ext/node_modules/json-parse-even-better-errors": {
@@ -10957,15 +11166,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/yargs": {
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -11210,7 +11410,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#924a80e20e2465dcaf3dca32c9b6e9b9968222b9",
             "integrity": "sha512-jsLmuuGrWSzQwLFmenxUPGDk6QC/IkysrzKOvW85zvoY9bcdgXkKQjeJ9fAz9uEGwG7stDXk1VhCrEWKDCdcjg==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#924a80e20e2465dcaf3dca32c9b6e9b9968222b9"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#4.1.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -11632,6 +11832,39 @@
                 "config-chain": "^1.1.11"
             }
         },
+        "@puppeteer/browsers": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.3.5",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+                    "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "semver": {
+                    "version": "7.6.3",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+                    "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+                    "dev": true
+                }
+            }
+        },
         "@sindresorhus/is": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
@@ -11650,6 +11883,12 @@
             "requires": {
                 "defer-to-connect": "^2.0.1"
             }
+        },
+        "@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+            "dev": true
         },
         "@types/chrome": {
             "version": "0.0.268",
@@ -11726,12 +11965,6 @@
             "requires": {
                 "undici-types": "~5.26.4"
             }
-        },
-        "@types/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-            "dev": true
         },
         "@types/webextension-polyfill": {
             "version": "0.10.7",
@@ -11978,12 +12211,11 @@
             "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ=="
         },
         "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "requires": {
-                "debug": "4"
+                "debug": "^4.3.4"
             }
         },
         "ajv": {
@@ -12164,6 +12396,15 @@
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
         },
+        "ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.1"
+            }
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -12198,10 +12439,62 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
+        "b4a": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "bare-events": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "bare-fs": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^2.0.0"
+            }
+        },
+        "bare-os": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "dev": true,
+            "optional": true
+        },
+        "bare-path": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "bare-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "streamx": "^2.18.0"
+            }
         },
         "base64-js": {
             "version": "1.5.1",
@@ -12212,6 +12505,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "dev": true
+        },
+        "basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -12233,40 +12532,6 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
-        },
-        "bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            },
-            "dependencies": {
-                "buffer": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-                    "dev": true,
-                    "requires": {
-                        "base64-js": "^1.3.1",
-                        "ieee754": "^1.1.13"
-                    }
-                },
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                }
-            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -12434,13 +12699,13 @@
             "dev": true
         },
         "buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4"
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "buffer-crc32": {
@@ -12610,12 +12875,6 @@
                 "readdirp": "~3.6.0"
             }
         },
-        "chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "chrome-launcher": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
@@ -12632,6 +12891,17 @@
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
                     "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
                 }
+            }
+        },
+        "chromium-bidi": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.2.tgz",
+            "integrity": "sha512-4WVBa6ijmUTVr9cZD4eicQD8Mdy/HCX3bzEIYYpmk0glqYLoWH+LqQEvV9RpDRzoQSbY1KJHloYXbDMXMbDPhg==",
+            "dev": true,
+            "requires": {
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
             }
         },
         "ci-info": {
@@ -12839,16 +13109,15 @@
             }
         },
         "cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "requires": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
             },
             "dependencies": {
                 "lines-and-columns": {
@@ -12867,48 +13136,6 @@
                         "error-ex": "^1.3.1",
                         "json-parse-even-better-errors": "^2.3.0",
                         "lines-and-columns": "^1.1.6"
-                    }
-                }
-            }
-        },
-        "cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-            "dev": true,
-            "requires": {
-                "node-fetch": "2.6.7"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.7",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                },
-                "tr46": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-                    "dev": true
-                },
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-                    "dev": true
-                },
-                "whatwg-url": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "dev": true,
-                    "requires": {
-                        "tr46": "~0.0.3",
-                        "webidl-conversions": "^3.0.0"
                     }
                 }
             }
@@ -13107,6 +13334,17 @@
                 "object-keys": "^1.1.1"
             }
         },
+        "degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "dev": true,
+            "requires": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            }
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -13124,9 +13362,9 @@
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
         },
         "devtools-protocol": {
-            "version": "0.0.1056733",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1056733.tgz",
-            "integrity": "sha512-CmTu6SQx2g3TbZzDCAV58+LTxVdKplS7xip0g5oDXpZ+isr0rv5dDP8ToyVRywzPHkCCPKgKgScEcwz4uPWDIA==",
+            "version": "0.0.1312386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
             "dev": true
         },
         "dexie": {
@@ -13326,6 +13564,12 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
             "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
         },
+        "env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -13467,6 +13711,27 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "eslint": {
             "version": "8.57.0",
@@ -13809,12 +14074,6 @@
                         "esutils": "^2.0.2"
                     }
                 },
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                },
                 "resolve": {
                     "version": "2.0.0-next.4",
                     "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -13835,13 +14094,6 @@
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-                }
             }
         },
         "eslint-utils": {
@@ -13900,13 +14152,6 @@
             "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
             "requires": {
                 "estraverse": "^5.1.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-                }
             }
         },
         "esrecurse": {
@@ -13915,14 +14160,12 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "requires": {
                 "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-                }
             }
+        },
+        "estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         },
         "estree-is-member-expression": {
             "version": "1.0.0",
@@ -14107,6 +14350,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true
         },
         "fast-json-patch": {
             "version": "3.1.1",
@@ -14344,12 +14593,6 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
         "fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -14463,6 +14706,37 @@
             "requires": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
+            }
+        },
+        "get-uri": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "dev": true,
+            "requires": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
+            },
+            "dependencies": {
+                "data-uri-to-buffer": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+                    "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+                    "dev": true
+                },
+                "fs-extra": {
+                    "version": "11.2.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+                    "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                }
             }
         },
         "getpass": {
@@ -14765,17 +15039,6 @@
             "requires": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
-            },
-            "dependencies": {
-                "agent-base": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^4.3.4"
-                    }
-                }
             }
         },
         "http-signature": {
@@ -14799,12 +15062,11 @@
             }
         },
         "https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "requires": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             }
         },
@@ -14947,6 +15209,24 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
             "integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw=="
+        },
+        "ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "requires": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "dependencies": {
+                "jsbn": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+                    "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+                    "dev": true
+                }
+            }
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -15364,25 +15644,6 @@
                 "xml-name-validator": "^5.0.0"
             },
             "dependencies": {
-                "agent-base": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^4.3.4"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "7.0.4",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-                    "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "^7.0.2",
-                        "debug": "4"
-                    }
-                },
                 "rrweb-cssom": {
                     "version": "0.7.1",
                     "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -15927,16 +16188,16 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
         },
+        "mitt": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+            "dev": true
+        },
         "mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "mocha": {
             "version": "10.4.0",
@@ -16214,6 +16475,12 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+        },
+        "netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "dev": true
         },
         "no-case": {
             "version": "2.3.2",
@@ -16590,6 +16857,32 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "pac-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
+            }
+        },
+        "pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "dev": true,
+            "requires": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            }
+        },
         "package-json": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
@@ -16706,12 +16999,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
             "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-        },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
         },
         "pend": {
             "version": "1.2.0",
@@ -16940,6 +17227,30 @@
                 "ipaddr.js": "1.9.1"
             }
         },
+        "proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "7.18.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+                    "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+                    "dev": true
+                }
+            }
+        },
         "proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -16975,41 +17286,43 @@
             }
         },
         "puppeteer": {
-            "version": "19.3.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.3.0.tgz",
-            "integrity": "sha512-WJbi/ULaeuFOz7cfMgJlJCBAZiyqIFeQ6os4h5ex3PVTt2qosXgwI9eruFZqFAwJRv8x5pOuMhWR0aSRgyDqEg==",
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.14.0.tgz",
+            "integrity": "sha512-MGTR6/pM8zmWbTdazb6FKnwIihzsSEXBPH49mFFU96DNZpQOevCAZMnjBZGlZRGRzRK6aADCavR6SQtrbv5dQw==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "7.0.1",
-                "devtools-protocol": "0.0.1056733",
-                "https-proxy-agent": "5.0.1",
-                "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "puppeteer-core": "19.3.0"
+                "@puppeteer/browsers": "2.3.0",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1312386",
+                "puppeteer-core": "22.14.0"
             }
         },
         "puppeteer-core": {
-            "version": "19.3.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.3.0.tgz",
-            "integrity": "sha512-P8VAAOBnBJo/7DKJnj1b0K9kZBF2D8lkdL94CjJ+DZKCp182LQqYemPI9omUSZkh4bgykzXjZhaVR1qtddTTQg==",
+            "version": "22.14.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.14.0.tgz",
+            "integrity": "sha512-rl4tOY5LcA3e374GAlsGGHc05HL3eGNf5rZ+uxkl6id9zVZKcwcp1Z+Nd6byb6WPiPeecT/dwz8f/iUm+AZQSw==",
             "dev": true,
             "requires": {
-                "cross-fetch": "3.1.5",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1056733",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "proxy-from-env": "1.1.0",
-                "rimraf": "3.0.2",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.10.0"
+                "@puppeteer/browsers": "2.3.0",
+                "chromium-bidi": "0.6.2",
+                "debug": "^4.3.5",
+                "devtools-protocol": "0.0.1312386",
+                "ws": "^8.18.0"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.3.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+                    "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
                 "ws": {
-                    "version": "8.10.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-                    "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+                    "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
                     "dev": true,
                     "requires": {}
                 }
@@ -17673,6 +17986,12 @@
             "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
             "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
         },
+        "smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true
+        },
         "socket.io": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.4.tgz",
@@ -17715,6 +18034,27 @@
             "requires": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
+            }
+        },
+        "socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "dev": true,
+            "requires": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            }
+        },
+        "socks-proxy-agent": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
             }
         },
         "sonic-boom": {
@@ -17779,6 +18119,12 @@
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
             "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
         },
+        "sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -17840,6 +18186,18 @@
                 "date-format": "^4.0.7",
                 "debug": "^4.3.4",
                 "fs-extra": "^10.0.1"
+            }
+        },
+        "streamx": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+            "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+            "dev": true,
+            "requires": {
+                "bare-events": "^2.2.0",
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
             }
         },
         "string_decoder": {
@@ -17996,41 +18354,35 @@
             "dev": true
         },
         "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dev": true,
             "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
+                "tar-stream": "^3.1.5"
             }
         },
         "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
             "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                }
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "text-decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+            "dev": true,
+            "requires": {
+                "b4a": "^1.6.4"
             }
         },
         "text-table": {
@@ -18433,6 +18785,12 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "urlpattern-polyfill": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+            "dev": true
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18550,14 +18908,6 @@
                 "zip-dir": "2.0.0"
             },
             "dependencies": {
-                "agent-base": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-                    "requires": {
-                        "debug": "^4.3.4"
-                    }
-                },
                 "array-differ": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
@@ -18581,15 +18931,6 @@
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "7.0.4",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-                    "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-                    "requires": {
-                        "agent-base": "^7.0.2",
-                        "debug": "4"
                     }
                 },
                 "json-parse-even-better-errors": {
@@ -18917,12 +19258,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        },
-        "yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true
         },
         "yargs": {
             "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "karma-jasmine": "1.1.1",
         "karma-source-map-support": "1.4.0",
         "node-fetch": "^3.3.2",
-        "puppeteer": "^19.3.0",
+        "puppeteer": "^22.14.0",
         "sass": "^1.77.5",
         "standard": "17.1.0",
         "timekeeper": "^2.3.1",

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -293,7 +293,7 @@ describe('atb.getUninstallURL()', () => {
             expect(searchParams.get('atb')).toEqual(expectedAtb)
             expect(searchParams.get('set_atb')).toEqual(expectedSetAtb)
             expect(searchParams.get('browser')).toEqual('Chrome')
-            expect(searchParams.get('bv')).toEqual('108')
+            expect(searchParams.get('bv')).toEqual('127')
             expect(searchParams.get('v')).toEqual('1234.56')
         }
 


### PR DESCRIPTION
For some reason having a version of Puppeteer < 22 can cause
`npm install` to hang[1]. Let's update the dependency now therefore.

Note: I needed to update the dependency manually, since one of the
      unit tests needed to be tweaked.

1 - https://github.com/npm/cli/issues/4028

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
