### PR TITLE
Update typescript dependency to 5.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
                 "sass": "^1.77.5",
                 "standard": "17.1.0",
                 "timekeeper": "^2.3.1",
-                "typescript": "^5.3.3",
+                "typescript": "^5.5.4",
                 "webextension-polyfill": "^0.12.0",
                 "yargs": "^17.7.2"
             },
@@ -10284,9 +10284,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -18627,9 +18627,9 @@
             }
         },
         "typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true
         },
         "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "sass": "^1.77.5",
         "standard": "17.1.0",
         "timekeeper": "^2.3.1",
-        "typescript": "^5.3.3",
+        "typescript": "^5.5.4",
         "webextension-polyfill": "^0.12.0",
         "yargs": "^17.7.2"
     },

--- a/packages/ddg2dnr/lib/ampProtection.js
+++ b/packages/ddg2dnr/lib/ampProtection.js
@@ -8,7 +8,7 @@ const AMP_PROTECTION_PRIORITY = 40000
 
 /**
  * @typedef generateAmpProtectionRulesResult
- * @property {import('./utils').DNRRule} rule
+ * @property {Omit<chrome.declarativeNetRequest.Rule, 'id'>} rule
  * @property {object} matchDetails
  */
 

--- a/packages/ddg2dnr/lib/cookies.js
+++ b/packages/ddg2dnr/lib/cookies.js
@@ -1,4 +1,9 @@
-const { generateRequestDomainsByTrackerDomain, getTrackerEntryDomain, storeInLookup } = require('./utils')
+const {
+    castDNREnum,
+    generateRequestDomainsByTrackerDomain,
+    getTrackerEntryDomain,
+    storeInLookup
+} = require('./utils')
 
 const COOKIE_PRIORITY = 40000
 
@@ -10,7 +15,7 @@ const COOKIE_PRIORITY = 40000
  * @returns {import('./utils').RulesetResult} Cookie blocking rules
  */
 function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlist, startingRuleId = 1) {
-    /** @type {import('./utils').DNRRule[]} */
+    /** @type {chrome.declarativeNetRequest.Rule[]} */
     const rules = []
     /** @type {Map<string, { domains: Set<string>, trackerDomains: Set<string> }>} */
     const entityDomainMapping = new Map()
@@ -66,9 +71,15 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
             id: startingRuleId++,
             priority: COOKIE_PRIORITY,
             action: {
-                type: 'modifyHeaders',
-                requestHeaders: [{ header: 'cookie', operation: 'remove' }],
-                responseHeaders: [{ header: 'set-cookie', operation: 'remove' }]
+                type: castDNREnum('modifyHeaders'),
+                requestHeaders: [{
+                    header: 'cookie',
+                    operation: castDNREnum('remove')
+                }],
+                responseHeaders: [{
+                    header: 'set-cookie',
+                    operation: castDNREnum('remove')
+                }]
             },
             condition: {
                 requestDomains: Array.from(trackerDomains),
@@ -87,14 +98,20 @@ function generateCookieBlockingRuleset (tds, excludedCookieDomains, siteAllowlis
             id: ++startingRuleId,
             priority: COOKIE_PRIORITY,
             action: {
-                type: 'modifyHeaders',
-                requestHeaders: [{ header: 'cookie', operation: 'remove' }],
-                responseHeaders: [{ header: 'set-cookie', operation: 'remove' }]
+                type: castDNREnum('modifyHeaders'),
+                requestHeaders: [{
+                    header: 'cookie',
+                    operation: castDNREnum('remove')
+                }],
+                responseHeaders: [{
+                    header: 'set-cookie',
+                    operation: castDNREnum('remove')
+                }]
             },
             condition: {
                 requestDomains: singleDomainEntityDomains,
                 excludedInitiatorDomains: siteAllowlist,
-                domainType: 'thirdParty'
+                domainType: castDNREnum('thirdParty')
             }
         })
         matchDetailsByRuleId[startingRuleId] = {

--- a/packages/ddg2dnr/lib/gpc.js
+++ b/packages/ddg2dnr/lib/gpc.js
@@ -13,7 +13,7 @@ const GPC_HEADER_PRIORITY = 40000
  * @param {string[]=} allowedDomains
  *   Request domains not to add the header for. Note this also applies to
  *   initiator domains.
- * @return {import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule}
+ * @return {chrome.declarativeNetRequest.Rule}
  */
 function generateGPCheaderRule (ruleId, allowedDomains) {
     return generateDNRRule({

--- a/packages/ddg2dnr/lib/smarterEncryption.js
+++ b/packages/ddg2dnr/lib/smarterEncryption.js
@@ -131,19 +131,31 @@ function generateSmarterEncryptionRuleset (domains, startingRuleId = 1) {
 }
 
 /**
+ * @typedef {{
+ *   rule: Omit<chrome.declarativeNetRequest.Rule, 'id'>,
+ *   matchDetails: {
+ *     type: string;
+ *     possibleTrackerDomains?: string[];
+ *   };
+ * }} CreateSmarterEncryptionTemporaryRuleResult
+ */
+
+/**
  * Create a rule to disable or enable automatic HTTPS upgrades for a set of domains.
  *  - if type is 'allow' this will be an exception rule, preventing upgrades for the given domains.
  *  - if type is 'upgrade' this will be an upgradeScheme rule, causing requests for that domain to be upgraded to HTTPs.
+ *
+ * @overload
+ * @param {string[]} domains
+ * @param {'allow' | 'upgrade'} [type="allow"]
+ * @returns {CreateSmarterEncryptionTemporaryRuleResult}
+ *
+ * @overload
  * @param {string[]} domains
  * @param {'allow' | 'upgrade'} type 'allow' to create an allowlist rule, 'upgrade' to create an upgrade rule
- * @param {number} [id] (optional) rule ID
- * @returns {{
- *  rule: import('./utils.js').DNRRule;
- *  matchDetails: {
- *      type: string;
- *      possibleTrackerDomains?: string[];
- *  };
- *  }}
+ * @param {number} id (optional) rule ID
+ * @returns {Omit<CreateSmarterEncryptionTemporaryRuleResult, 'rule'> &
+              {rule: chrome.declarativeNetRequest.Rule}}
  */
 function createSmarterEncryptionTemporaryRule (domains, type = 'allow', id) {
     if (['allow', 'upgrade'].indexOf(type) === -1) {

--- a/packages/ddg2dnr/lib/tds.js
+++ b/packages/ddg2dnr/lib/tds.js
@@ -480,7 +480,7 @@ function finalizeDNRRulesAndLookup (startingRuleId, dnrRules) {
 
 /**
  * @typedef {object} generateTdsRulesetResult
- * @property {import('./utils.js').DNRRule[]} ruleset
+ * @property {chrome.declarativeNetRequest.Rule[]} ruleset
  *   The generated Tracker Blocking declarativeNetRequest ruleset.
  * @property {object} matchDetailsByRuleId
  *   Rule ID -> match details.

--- a/packages/ddg2dnr/lib/temporaryAllowlist.js
+++ b/packages/ddg2dnr/lib/temporaryAllowlist.js
@@ -11,7 +11,7 @@ const {
 
 /**
  * @typedef generateTemporaryAllowlistRulesResult
- * @property {import('./utils').DNRRule} rule
+ * @property {Omit<chrome.declarativeNetRequest.Rule, 'id'>} rule
  * @property {object} matchDetails
  */
 

--- a/packages/ddg2dnr/lib/trackerAllowlist.js
+++ b/packages/ddg2dnr/lib/trackerAllowlist.js
@@ -23,7 +23,7 @@ const MAXIMUM_RULES_PER_TRACKER_ENTRY = (CEILING_PRIORITY - BASELINE_PRIORITY) /
 
 /**
  * @typedef generateTrackerAllowlistRulesResult
- * @property {import('./utils').DNRRule} rule
+ * @property {Omit<chrome.declarativeNetRequest.Rule, 'id'>} rule
  * @property {object} matchDetails
  */
 

--- a/packages/ddg2dnr/test/referenceTests.js
+++ b/packages/ddg2dnr/test/referenceTests.js
@@ -215,8 +215,7 @@ describe('Reference Tests', /** @this {testFunction} */ () => {
             let ruleId = 10000
             blockAndAllowRules = ruleset
             for (const { rule } of generateTrackerAllowlistRules(mockConfig)) {
-                rule.id = ruleId++
-                blockAndAllowRules.push(rule)
+                blockAndAllowRules.push({ id: ruleId++, ...rule })
             }
         })
         this.beforeEach(/** @this {testFunction} */ async function () {

--- a/packages/ddg2dnr/test/utils.js
+++ b/packages/ddg2dnr/test/utils.js
@@ -103,6 +103,7 @@ describe('generateDNRRule', () => {
         {
             // generateDNRRule considers the ID optional, so that it can be
             // populated later if necessary.
+            // @ts-ignore - Deliberately accessing missing ID
             const { id } = await generateDNRRule({
                 priority: 30,
                 actionType: 'block'

--- a/packages/privacy-grade/src/classes/trackers.js
+++ b/packages/privacy-grade/src/classes/trackers.js
@@ -82,7 +82,7 @@ class Trackers {
 
     /**
      * @param {{
-     *    tldts: import('tldts'),
+     *    tldts?: import('tldts'),
      *    tldjs: import('tldts'),
      *    utils: *,
      * }} ops

--- a/shared/js/background/classes/ad-click-attribution-policy.js
+++ b/shared/js/background/classes/ad-click-attribution-policy.js
@@ -329,9 +329,15 @@ export class AdClick {
     }
 
     getAdClickDNR (tabId) {
+        const id = getNextSessionRuleId()
+        if (typeof id !== 'number') {
+            console.error('Failed to create ad click attribution rule.')
+            return
+        }
+
         const adClickDNR = {
             rule: generateDNRRule({
-                id: null,
+                id,
                 priority: AD_ATTRIBUTION_POLICY_PRIORITY,
                 actionType: 'allow',
                 requestDomains: this.allowlist.map((entry) => entry.host)
@@ -349,9 +355,13 @@ export class AdClick {
     }
 
     createDNR (tabId) {
-        this.adClickDNR = this.getAdClickDNR(tabId)
-        this.adClickDNR.rule.id = getNextSessionRuleId()
-        chrome.declarativeNetRequest.updateSessionRules({ addRules: [this.adClickDNR.rule] })
+        const adClickDNR = this.getAdClickDNR(tabId)
+        if (adClickDNR) {
+            this.adClickDNR = adClickDNR
+            chrome.declarativeNetRequest.updateSessionRules({
+                addRules: [this.adClickDNR.rule]
+            })
+        }
     }
 
     updateDNR () {

--- a/shared/js/background/dnr-click-to-load.js
+++ b/shared/js/background/dnr-click-to-load.js
@@ -11,7 +11,7 @@ import tdsStorage from './storage/tds'
  * mutated to note the new rule IDs as a side effect.
  * @param {string} ruleAction
  * @param {import('./classes/tab')} tab
- * @return {Promise<import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule[]>}
+ * @return {Promise<chrome.declarativeNetRequest.Rule[]>}
  */
 async function generateDnrAllowingRules (tab, ruleAction) {
     // The necessary declarativeNetRequest allowing rules already exist for this

--- a/shared/js/background/dnr-config-rulesets.js
+++ b/shared/js/background/dnr-config-rulesets.js
@@ -29,7 +29,7 @@ import {
  * ensured.
  * @param {number} id
  * @param {string} etag
- * @returns {import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule}
+ * @returns {chrome.declarativeNetRequest.Rule}
  */
 function generateEtagRule (id, etag) {
     return generateDNRRule({
@@ -111,7 +111,7 @@ function minimalConfig ({ unprotectedTemporary, features }) {
  * for a configuration.
  * @param {string} configName
  * @param {Object} latestState
- * @param {import('@duckduckgo/ddg2dnr/lib/utils.js').DNRRule[]} rules
+ * @param {chrome.declarativeNetRequest.Rule[]} rules
  * @param {Object} matchDetailsByRuleId
  * @returns {Promise<>}
  */


### PR DESCRIPTION
Some changes were required to get the type checking passing again:
 - Functions that return declarativeNetRequest rules with/without rule
   IDs need to be more clearly annotated, so that it's clear to
   typescript when a rule's ID is available.
 - Edge cases where getNextSessionRuleId() fails need to be handled
   properly, adding rules with an undefined/null ID won't work.
 - The DNRRule type needed to be replaced with the
   chrome.declarativeNetRequest.Rule rule type, and with that some
   string type rule properties needed to be cast to the correct enum
   types.

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#notable-behavioral-changes

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
