### PR TITLE
Update @playwright/test dependency to 1.46.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
             },
             "devDependencies": {
                 "@fingerprintjs/fingerprintjs": "^4.4.1",
-                "@playwright/test": "^1.44.1",
+                "@playwright/test": "^1.46.0",
                 "@types/chrome": "^0.0.268",
                 "@types/jasmine": "^4.3.5",
                 "@types/node": "^20.14.2",
@@ -890,18 +890,18 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-            "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
+            "integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.44.1"
+                "playwright": "1.46.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/@pnpm/network.ca-file": {
@@ -8204,33 +8204,33 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-            "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+            "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.44.1"
+                "playwright-core": "1.46.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-            "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+            "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/prelude-ls": {
@@ -11780,12 +11780,12 @@
             "optional": true
         },
         "@playwright/test": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-            "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
+            "integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
             "dev": true,
             "requires": {
-                "playwright": "1.44.1"
+                "playwright": "1.46.0"
             }
         },
         "@pnpm/network.ca-file": {
@@ -17092,19 +17092,19 @@
             }
         },
         "playwright": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-            "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+            "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2",
-                "playwright-core": "1.44.1"
+                "playwright-core": "1.46.0"
             }
         },
         "playwright-core": {
-            "version": "1.44.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-            "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+            "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
             "dev": true
         },
         "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
         "@fingerprintjs/fingerprintjs": "^4.4.1",
-        "@playwright/test": "^1.44.1",
+        "@playwright/test": "^1.46.0",
         "@types/chrome": "^0.0.268",
         "@types/jasmine": "^4.3.5",
         "@types/node": "^20.14.2",


### PR DESCRIPTION
Unfortunately it seems that we no longer get the details of
chrome-extension://* requests from Playwright. Even when for example
website scripts are redirected to shim (aka "surrogate") scripts
provided by the extension. Previously those requests included
allowed/blocked/redirected status and URLs, but now they seem to
always show up as being blocked and with the URL of
chrome-extension://invalid/. The Facebook Click to Load integration
tests need to be simplified therefore, to just check for allowed
vs blocked requests.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
