### PR TITLE
Update autofill to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,7 +176,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1f12b78d9bac4a1d9b6bad18dc2ef0593bed34a3",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11355,8 +11355,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#12.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1f12b78d9bac4a1d9b6bad18dc2ef0593bed34a3",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#13.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4689746e42b24c40c18896d697ea02b854e90d35",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/13.0.0


## Description
Updates Autofill to version [13.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/13.0.0).

### Autofill 13.0.0 release notes
## What's Changed
Minor version update, adding a new feature behind `unknown_username_categorization` featureToggle, but the toggle is optional in JS and doesn't introduce regression.
* Update password-related json files (2024-07-30) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/621
* [Form] allow reconciling full credential by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/620
* [Form] Check if form.elements is iterable before destructuring by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/629
* [Matching] Update newPassword form regex by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/628
* [Form] re-decorate input if there is 1 unknown username by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/619


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.1.0...13.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).