### PR TITLE
Update privacy-dashboard dependency to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
-                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#4.1.0",
+                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#6.0.0",
                 "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
@@ -205,8 +205,7 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#924a80e20e2465dcaf3dca32c9b6e9b9968222b9",
-            "integrity": "sha512-jsLmuuGrWSzQwLFmenxUPGDk6QC/IkysrzKOvW85zvoY9bcdgXkKQjeJ9fAz9uEGwG7stDXk1VhCrEWKDCdcjg==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#38fa9624dbb7a2f5400e64092787ccea8588ebde",
             "engines": {
                 "node": ">=18.0.0",
                 "npm": ">=9.0.0"
@@ -11372,9 +11371,8 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#924a80e20e2465dcaf3dca32c9b6e9b9968222b9",
-            "integrity": "sha512-jsLmuuGrWSzQwLFmenxUPGDk6QC/IkysrzKOvW85zvoY9bcdgXkKQjeJ9fAz9uEGwG7stDXk1VhCrEWKDCdcjg==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#4.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#38fa9624dbb7a2f5400e64092787ccea8588ebde",
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#6.0.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#4.1.0",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#6.0.0",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",

--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -1,6 +1,7 @@
 import browser from 'webextension-polyfill'
 import EventEmitter2 from 'eventemitter2'
 import ATB from './atb'
+import { postPopupMessage } from './popupMessaging'
 
 const utils = require('./utils')
 const trackers = require('./trackers')
@@ -331,7 +332,7 @@ function blockHandleResponse (thisTab, requestData) {
             }
         }
         // the tab has finished loading
-        browserWrapper.notifyPopup({ updateTabData: true })
+        postPopupMessage({ messageType: 'updateTabData' })
         // Block the request if the site is not allowlisted
         if (['block', 'redirect'].includes(tracker.action)) {
             // @ts-ignore

--- a/shared/js/background/companies.js
+++ b/shared/js/background/companies.js
@@ -1,6 +1,7 @@
 const TopBlocked = require('./classes/top-blocked')
 const Company = require('./classes/company')
 const browserWrapper = require('./wrapper')
+const { postPopupMessage } = require('./popupMessaging')
 
 const Companies = (() => {
     let companyContainer = {}
@@ -87,8 +88,7 @@ const Companies = (() => {
             totalPagesWithTrackers = 0
             lastStatsResetDate = Date.now()
             Companies.syncToStorage()
-            const resetDate = Companies.getLastResetDate()
-            browserWrapper.notifyPopup({ didResetTrackersData: resetDate })
+            postPopupMessage({ messageType: 'didResetTrackersData' })
         },
 
         getLastResetDate: () => lastStatsResetDate,

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -20,6 +20,7 @@ import { clearExpiredBrokenSiteReportTimes } from './broken-site-report'
 import {
     sendPageloadsWithAdAttributionPixelAndResetCount
 } from './classes/ad-click-attribution-policy'
+import { popupConnectionOpened, postPopupMessage } from './popupMessaging'
 const utils = require('./utils')
 const experiment = require('./experiments')
 const settings = require('./settings')
@@ -285,7 +286,7 @@ browser.webRequest.onHeadersReceived.addListener(
  */
 // message popup to close when the active tab changes.
 browser.tabs.onActivated.addListener(() => {
-    browserWrapper.notifyPopup({ closePopup: true })
+    postPopupMessage({ messageType: 'closePopup' })
 })
 
 // Include the performanceWarning flag in breakage reports.
@@ -350,6 +351,13 @@ browser.runtime.onMessage.addListener((req, sender) => {
 
     console.error('Unrecognized message to background:', req, sender)
     return false
+})
+
+// Handle popup UI (aka privacy dashboard) messaging.
+browser.runtime.onConnect.addListener(port => {
+    if (port.name === 'privacy-dashboard') {
+        popupConnectionOpened(port, messageHandlers)
+    }
 })
 
 /*

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -2,12 +2,13 @@ import browser from 'webextension-polyfill'
 import { dashboardDataFromTab } from './classes/privacy-dashboard-data'
 import { breakageReportForTab } from './broken-site-report'
 import parseUserAgentString from '../shared-utils/parse-user-agent-string'
-import { getExtensionURL, notifyPopup } from './wrapper'
+import { getExtensionURL } from './wrapper'
 import { isFeatureEnabled, reloadCurrentTab } from './utils'
 import { ensureClickToLoadRuleActionDisabled } from './dnr-click-to-load'
 import tdsStorage from './storage/tds'
 import { getArgumentsObject } from './helpers/arguments-object'
 import { isFireButtonEnabled } from './components/fire-button'
+import { postPopupMessage } from './popupMessaging'
 const utils = require('./utils')
 const settings = require('./settings')
 const tabManager = require('./tab-manager')
@@ -58,8 +59,8 @@ export async function setLists (options) {
     }
 
     try {
-        notifyPopup({ closePopup: true })
-        reloadCurrentTab()
+        postPopupMessage({ messageType: 'closePopup' })
+        await reloadCurrentTab()
     } catch (e) {
         console.error('Error trying to reload+refresh following `setLists` message', e)
     }

--- a/shared/js/background/popupMessaging.js
+++ b/shared/js/background/popupMessaging.js
@@ -1,0 +1,58 @@
+/**
+ * @typedef {import('webextension-polyfill').Runtime.Port} Port
+ * @typedef {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').IncomingExtensionMessage} OutgoingPopupMessage
+ */
+
+// Messaging connection with the popup UI (when active).
+/** @type {Port?} */
+let activePort = null
+
+/**
+ * Set up the messaging connection with the popup UI.
+ *
+ * Note: If the ServiceWorker dies while there is an open connection, the popup
+ *       will take care of re-opening the connection.
+ *
+ * @param {Port} port
+ * @param {Record<
+ *     string,
+ *     (options: any, sender: any, message: any) => any
+ * >} messageHandlers
+ */
+export function popupConnectionOpened (port, messageHandlers) {
+    activePort = port
+    port.onDisconnect.addListener(() => {
+        if (activePort === port) {
+            activePort = null
+        }
+    })
+
+    port.onMessage.addListener(async message => {
+        const messageType = message?.messageType
+
+        if (!messageType || !(messageType in messageHandlers)) {
+            console.error(
+                'Unrecognized message (privacy-dashboard -> background):', message
+            )
+            return
+        }
+
+        const response = await messageHandlers[messageType](message?.options, port, message)
+        if (typeof message?.id === 'number') {
+            port.postMessage({
+                id: message.id,
+                messageType: 'response',
+                options: response
+            })
+        }
+    })
+}
+
+/**
+ * Post a message to the popup UI, if it's open.
+ *
+ * @param {OutgoingPopupMessage} message
+ */
+export function postPopupMessage (message) {
+    activePort?.postMessage(message)
+}

--- a/shared/js/background/utils.js
+++ b/shared/js/background/utils.js
@@ -413,7 +413,7 @@ export function getURLWithoutQueryString (urlString) {
 export async function reloadCurrentTab () {
     const tab = await getCurrentTab()
     if (tab && tab.id) {
-        browser.tabs.reload(tab.id)
+        await browser.tabs.reload(tab.id)
     }
 }
 

--- a/shared/js/background/wrapper.js
+++ b/shared/js/background/wrapper.js
@@ -53,14 +53,6 @@ export function getExtensionId () {
     return browser.runtime.id
 }
 
-export async function notifyPopup (message) {
-    try {
-        await browser.runtime.sendMessage(message)
-    } catch {
-        // Ignore this as can throw an error message when the popup is not open.
-    }
-}
-
 /**
  * @param {browser.WebRequest.OnBeforeRedirectDetailsType | browser.Tabs.Tab | browser.Tabs.OnUpdatedChangeInfoType} tabData
  * @returns {{tabId: number, url: string | undefined, requestId?: string, status: string | null | undefined}}


### PR DESCRIPTION
With this update, the way privacy-dashboard communicates with the extension has
changed. Instead of sending messages using the chrome.runtime.sendMessage API,
the chrome.runtime.connect API is used instead. In the future, that will allow
us to listen for the disconnect event as a way to know when the popup UI has
been closed by the browser (e.g. the user clicked away).

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @shakyShane 
**CC:** @sammacbeth 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Check that the popup UI functions correctly, try things like allowlisting a page, or switching tabs, and make sure the popup closes itself. Ensure the website details populated in the popup UI looks right.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
