### PR TITLE
Improve the getTab, getCurrentTab, etc logic.

### DIFF
--- a/shared/js/background/tab-manager.js
+++ b/shared/js/background/tab-manager.js
@@ -11,6 +11,7 @@ const {
 const {
     clearClickToLoadDnrRulesForTab
 } = require('./dnr-click-to-load')
+const { getCurrentTab } = require('./utils')
 
 /**
  * @typedef {import('./classes/site.js').allowlistName} allowlistName
@@ -108,6 +109,19 @@ class TabManager {
             await tabManager.restore(tabId)
         }
         return tabManager.get({ tabId })
+    }
+
+    /**
+     * Return a Tab Object for the currently focused tab, if possible.
+     *
+     * @returns {Promise<import("./classes/tab")?>}
+     */
+    async getOrRestoreCurrentTab () {
+        const currentTabDetails = await getCurrentTab()
+        if (currentTabDetails?.id) {
+            return await tabManager.getOrRestoreTab(currentTabDetails.id)
+        }
+        return null
     }
 
     /**

--- a/shared/js/background/utils.js
+++ b/shared/js/background/utils.js
@@ -151,16 +151,26 @@ export function findParentDisplayName (url) {
     return 'unknown'
 }
 
-export function getCurrentURL (callback) {
-    browser.tabs.query({ active: true, lastFocusedWindow: true }).then((tabData) => {
-        if (tabData.length) {
-            callback(tabData[0].url)
-        }
-    })
-}
+/**
+ * Return the details of the currently focused tab, if available.
+ *
+ * @returns {Promise<browser.Tabs.Tab|undefined>}
+ */
+export async function getCurrentTab () {
+    // If the current tab ID is already known, fetch the details for that tab.
+    const tabId = await getFromSessionStorage('currentTabId')
 
-export async function getCurrentTab (callback) {
-    const tabData = await browser.tabs.query({ active: true, lastFocusedWindow: true })
+    if (tabId) {
+        try {
+            return await browser.tabs.get(tabId)
+        } catch (e) { }
+    }
+
+    // Otherwise, fetch the details for the currently focused tab.
+    const tabData = await browser.tabs.query({
+        active: true,
+        lastFocusedWindow: true
+    })
     if (tabData.length) {
         return tabData[0]
     }

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -117,6 +117,12 @@ const chrome = {
             addListener () { },
             removeListener () { }
         }
+    },
+    windows: {
+        onFocusChanged: {
+            addListener () { },
+            removeListener () { }
+        }
     }
 }
 export {


### PR DESCRIPTION
The getTab, getCurrentTab, etc logic was quite confused. Let's tidy that up as
best we can for now:
 - Remove the unused `getTab` and `getCurrentTab` message handlers.
 - Remove the unused and outdated `utils.getCurrentURL` function.
 - Remove the unused `callback` parameter from `utils.getCurrentTab` and add a
   JSDoc comment for the function.
 - Move the logic for getting a Tab Object for the currently focused tab into
   the TabManager class.
 - Note the current tab ID in session storage (in memory), so that the current
   tab can (usually) be determined even when the developer tools or popup UI are
   open.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
