### PR TITLE
Add support for the "toggle reports" feature

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -23,6 +23,7 @@ import EmailAutofill from './components/email-autofill'
 import OmniboxSearch from './components/omnibox-search'
 import InternalUserDetector from './components/internal-user-detector'
 import TDSStorage from './components/tds'
+import ToggleReports from './components/toggle-reports'
 import TrackersGlobal from './components/trackers'
 import DebuggerConnection from './components/debugger-connection'
 import Devtools from './components/devtools'
@@ -60,6 +61,7 @@ const components = {
     internalUser: new InternalUserDetector({ settings }),
     tabTracking: new TabTracker({ tabManager, devtools }),
     tds,
+    toggleReports: new ToggleReports(),
     trackers: new TrackersGlobal({ tds }),
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools

--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -166,7 +166,9 @@ export default class Site {
      * - User toggle on
      */
     isFeatureEnabled (featureName) {
-        const allowlistOnlyFeatures = ['autofill', 'adClickAttribution']
+        const allowlistOnlyFeatures = [
+            'autofill', 'adClickAttribution', 'toggleReports'
+        ]
         if (allowlistOnlyFeatures.includes(featureName)) {
             return this.enabledFeatures.includes(featureName)
         }

--- a/shared/js/background/components/toggle-reports.js
+++ b/shared/js/background/components/toggle-reports.js
@@ -1,0 +1,279 @@
+/**
+ * @typedef {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').ToggleReportScreen} ToggleReportOptions
+ * @typedef {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').DataItemId} ToggleReportParamId
+ */
+
+import browser from 'webextension-polyfill'
+import { registerMessageHandler } from '../message-handlers'
+import { postPopupMessage } from '../popupMessaging'
+import settings from '../settings'
+import {
+    getCurrentTab,
+    getFeatureSettings,
+    getURLWithoutQueryString,
+    reloadCurrentTab,
+    resolveAfterDelay
+} from '../utils'
+import { sendBreakageReportForCurrentTab } from '../broken-site-report'
+import { createAlarm } from '../wrapper'
+import tabManager from '../tab-manager'
+
+/**
+ * This component is for the "toggle reports" (aka the "simplified breakage
+ * report" UI flow. When the user clicks to disable protections for a website,
+ * it prompts the user to optionally submit a breakage report to us afterwards.
+ * There is some additional logic to ensure that users are not prompted to
+ * submit reports too often, to hopefully avoid annoying them.
+ *
+ * TODO: Once ToggleReports.shouldDisplay() is called from another component,
+ *       make shouldDisplay() (and the dependant methods) instance methods.
+ *       Also, then pass the tabManager and settings modules into the
+ *       ToggleReports constructor via dependency injection, instead of
+ *       importing them, to aid unit testing.
+ */
+export default class ToggleReports {
+    static ALARM_NAME = 'toggleReportsClearExpired'
+
+    /**
+     * When prompting the user to submit a breakage report, context is shown to
+     * explain what will be included in the report. This is to help the user
+     * make an informed decision. That context is based on this list of
+     * parameter IDs. The naming system is similar, but not quite the same as
+     * the breakage report parameter names themselves. See the docs[1] for a
+     * list of all the possible values. Take care to update this list as the
+     * privacy-dashboard dependency is updated, and when breakage parameters are
+     * added/removed (see '../broken-site-report.js').
+     *
+     * Note: The UI displays the parameters in the order the IDs are listed
+     *       here, so consider the ordering when adjusting the array.
+     *
+     * TODO: In the future, it would be better for the UI to accept all of the
+     *       actual parameter names instead. Needing to update the list here
+     *       manually seems error-prone. Likewise with the ordering, it would be
+     *       better for the UI to decide the display order for the parameters,
+     *       to ensure they are displayed consistently between platforms.
+     *
+     * 1 - https://duckduckgo.github.io/privacy-dashboard/modules/Toggle_Report.html
+     *
+     * @type {ToggleReportParamId[]}
+     */
+    static PARAM_IDS = [
+        'siteUrl',
+        'atb',
+        'errorDescriptions',
+        'extensionVersion',
+        'features',
+        'httpErrorCodes',
+        'jsPerformance',
+        'openerContext',
+        'requests',
+        'userRefreshCount'
+    ]
+
+    constructor () {
+        this.onDisconnect = this.toggleReportFinished.bind(this, false)
+
+        registerMessageHandler(
+            'getToggleReportOptions',
+            (_, sender) => this.toggleReportStarted(sender)
+        )
+
+        registerMessageHandler(
+            'rejectToggleReport',
+            (_, sender) => this.toggleReportFinished(false, sender)
+        )
+
+        registerMessageHandler(
+            'sendToggleReport',
+            (_, sender) => this.toggleReportFinished(true, sender)
+        )
+
+        registerMessageHandler(
+            'seeWhatIsSent',
+            () => { }
+        )
+
+        createAlarm(ToggleReports.ALARM_NAME, { periodInMinutes: 60 })
+        browser.alarms.onAlarm.addListener(async ({ name }) => {
+            if (name === ToggleReports.ALARM_NAME) {
+                await ToggleReports.clearExpiredResponses()
+            }
+        })
+    }
+
+    /**
+     * Provides details of what will be included in a breakage report, so that
+     * the user can make an informed decision. Called when the "toggle reports"
+     * UI flow begins.
+     *
+     * @param {browser.Runtime.Port} sender
+     * @returns {Promise<ToggleReportOptions>}
+     */
+    async toggleReportStarted (sender) {
+        // If the browser closes the popup UI during the "toggle reports" flow
+        // (e.g. because the user clicked away), the connection will drop and
+        // this event will fire.
+        sender?.onDisconnect?.addListener(this.onDisconnect)
+
+        let siteUrl = null
+        const currentTabUrl = (await getCurrentTab())?.url
+        if (currentTabUrl) {
+            siteUrl = getURLWithoutQueryString(currentTabUrl)
+        }
+
+        /** @type {ToggleReportOptions} */
+        const response = { data: [] }
+
+        for (const paramId of ToggleReports.PARAM_IDS) {
+            if (paramId === 'siteUrl' && siteUrl) {
+                response.data.push(
+                    { id: 'siteUrl', additional: { url: siteUrl } }
+                )
+            } else {
+                response.data.push({ id: paramId })
+            }
+        }
+
+        return response
+    }
+
+    /**
+     * Called when the "toggle reports" UI flow finishes. If the user chose to
+     * send the breakage report that will be sent now.
+     *
+     * @param {boolean} accepted
+     *   True if the user opted to send the breakage report, false otherwise.
+     * @param {browser.Runtime.Port?} sender
+     * @returns {Promise<void>}
+     */
+    async toggleReportFinished (accepted, sender) {
+        sender?.onDisconnect?.removeListener(this.onDisconnect)
+
+        // Note the response and time.
+        await settings.ready()
+        const times = settings.getSetting('toggleReportTimes') || []
+        times.push({ timestamp: Date.now(), accepted })
+        settings.updateSetting('toggleReportTimes', times)
+
+        if (accepted) {
+            try {
+                // Send the breakage report before reloading the page, to ensure
+                // the correct page details are sent with the report.
+                await sendBreakageReportForCurrentTab({
+                    pixelName: 'protection-toggled-off-breakage-report',
+                    reportFlow: 'on_protections_off_dashboard_main'
+                })
+            } catch (e) {
+                // Catch this, mostly to ensure the page is still reloaded if
+                // sending the breakage report fails.
+                console.error('Failed to send breakage report', e)
+            }
+        }
+
+        // Reload the page. If the user opted to send the breakage report, also
+        // wait five seconds before closing the popup to give them a chance to
+        // read the thank you message.
+        await Promise.all([
+            reloadCurrentTab(),
+            resolveAfterDelay(accepted ? 5000 : 0)]
+        )
+
+        postPopupMessage({ messageType: 'closePopup' })
+    }
+
+    /**
+     * Clear any old recorded response times.
+     *
+     * @returns {Promise<void>}
+     */
+    static async clearExpiredResponses () {
+        const {
+            dismissInterval,
+            promptInterval
+        } = getFeatureSettings('toggleReports')
+
+        const now = Date.now()
+        let dismissCutoff = null
+        let acceptCutoff = null
+
+        if (typeof dismissInterval === 'number') {
+            dismissCutoff = now - (dismissInterval * 1000)
+        }
+        if (typeof promptInterval === 'number') {
+            acceptCutoff = now - (promptInterval * 1000)
+        }
+
+        await settings.ready()
+        let times = settings.getSetting('toggleReportTimes') || []
+        const existingTimesLength = times.length
+        times = times.filter(
+            ({ accepted, timestamp }) =>
+                (accepted && (typeof acceptCutoff !== 'number' ||
+                              timestamp >= acceptCutoff)) ||
+                (!accepted && (typeof dismissCutoff !== 'number' ||
+                               timestamp >= dismissCutoff))
+        )
+
+        if (times.length < existingTimesLength) {
+            settings.updateSetting('toggleReportTimes', times)
+        }
+    }
+
+    /**
+     * Count the number of accepted and declined responses recorded.
+     *
+     * Note: Does not filter away expired times, take care to call
+     *       ToggleReports.clearExpiredResponses() first.
+     *
+     * @returns {Promise<{accepted: number, declined: number}>}
+     */
+    static async countResponses () {
+        await settings.ready()
+        const times = settings.getSetting('toggleReportTimes') || []
+
+        const counts = { accepted: 0, declined: 0 }
+        for (const { accepted } of times) {
+            counts[accepted ? 'accepted' : 'declined']++
+        }
+
+        return counts
+    }
+
+    /**
+     * Check if the toggle report UI flow should been displayed display for the
+     * currently focused tab.
+     *
+     * @returns {Promise<boolean>}
+     */
+    static async shouldDisplay () {
+        const currentTab = await tabManager.getOrRestoreCurrentTab()
+
+        // Feature must be enabled for the tab.
+        if (!currentTab?.site?.isFeatureEnabled('toggleReports')) {
+            return false
+        }
+
+        const {
+            dismissLogicEnabled,
+            promptLimitLogicEnabled,
+            maxPromptCount
+        } = getFeatureSettings('toggleReports')
+
+        await ToggleReports.clearExpiredResponses()
+        const counts =
+            await ToggleReports.countResponses()
+
+        // Dismissed report count must not exceed the limit.
+        if (dismissLogicEnabled && (counts.declined > 0)) {
+            return false
+        }
+
+        // Accepted report count must not exceed the limit.
+        if (promptLimitLogicEnabled && typeof maxPromptCount === 'number' &&
+            counts.accepted >= maxPromptCount) {
+            return false
+        }
+
+        return true
+    }
+}

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -41,7 +41,10 @@ export default function initDebugBuild () {
         getListContents,
         companies: Companies,
         ntts: createNewtabTrackerStatsDebugApi(),
-        sendPageloadsWithAdAttributionPixelAndResetCount
+        sendPageloadsWithAdAttributionPixelAndResetCount,
+        resetToggleReports () {
+            settings.updateSetting('toggleReportTimes', [])
+        }
     }
 
     // mark this as a dev build

--- a/shared/js/background/utils.js
+++ b/shared/js/background/utils.js
@@ -471,3 +471,18 @@ export function daysInstalled (fromDate = Date.now(), atb = settings.getSetting(
 
     return (fromDate - installTimestamp) / dayMultiplier
 }
+
+/**
+ * Returns a Promise that resolves after the given number of milliseconds.
+ * Note: The background ServiceWorker might be restarted before the returned
+ *       Promise is resolved. Consider the implications of that happening when
+ *       using this function.
+ *
+ * {number} delay (milliseconds)
+ * {returns} Promise<void>
+ */
+export function resolveAfterDelay (delay) {
+    return new Promise(resolve => {
+        setTimeout(resolve, delay)
+    })
+}

--- a/unit-test/background/classes/tab.js
+++ b/unit-test/background/classes/tab.js
@@ -125,7 +125,7 @@ describe('Tab', () => {
                 jsPerformance: [],
                 locale: 'en-US'
             }
-            expect(tabClone.site.enabledFeatures.length).toBe(14)
+            expect(tabClone.site.enabledFeatures.length).toBe(15)
             expect(JSON.stringify(tabClone, null, 4)).toEqual(JSON.stringify(tabSnapshot, null, 4))
         })
         it('should be able to get the tab from tab manager', () => {

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -70,6 +70,7 @@ async function submitAndValidateReport (report) {
     }
 
     await breakageReportForTab({
+        pixelName: 'epbf',
         tab,
         tds: report.blocklistVersion,
         remoteConfigEtag: report.remoteConfigEtag,
@@ -157,6 +158,7 @@ describe('Broken Site Reporting tests / protections state', () => {
     async function submit (tab) {
         loadPixelSpy = spyOn(loadPixel, 'url').and.returnValue(null)
         await breakageReportForTab({
+            pixelName: 'epbf',
             tab,
             tds: 'abc123',
             remoteConfigEtag: 'abd142',

--- a/unit-test/background/toggle-reports.js
+++ b/unit-test/background/toggle-reports.js
@@ -1,0 +1,328 @@
+import browser from 'webextension-polyfill'
+import load from '../../shared/js/background/load'
+import settings from '../../shared/js/background/settings'
+import ToggleReports from '../../shared/js/background/components/toggle-reports'
+import { _formatPixelRequestForTesting } from '../../shared/js/shared-utils/pixels'
+import tabManager from '../../shared/js/background/tab-manager'
+import tdsStorageStub from '../helpers/tds'
+
+describe('ToggleReports', () => {
+    const actualSentReports = []
+    let currentTabDetails = null
+    let currentTimestamp = 1
+    let settingsStorage = null
+    const toggleReports = new ToggleReports()
+    let toggleReportsConfig = null
+
+    // Dummy timestamps.
+    const oneDay = 86400000
+    const today = 1727101418823
+    const tomorrow = today + oneDay
+    const twoDaysTime = today + (oneDay * 2)
+    const threeDaysTime = today + (oneDay * 3)
+    const fourDaysTime = today + (oneDay * 4)
+    const fiveDaysTime = today + (oneDay * 5)
+    const sixDaysTime = today + (oneDay * 6)
+
+    beforeAll(async () => {
+        // Ensure the test configuration is being used, and keep a reference to
+        // the toggleReports feature configuration.
+        const { tdsData } = tdsStorageStub.stub()
+        toggleReportsConfig = tdsData.config.features.toggleReports
+
+        // Stub settings.
+        settingsStorage = new Map()
+        spyOn(settings, 'ready').and.returnValue(Promise.resolve())
+        spyOn(settings, 'getSetting').and.callFake(
+            name => settingsStorage.get(name)
+        )
+        spyOn(settings, 'updateSetting').and.callFake(
+            (name, value) => {
+                settingsStorage.set(name, value)
+            }
+        )
+
+        // Stub the necessary browser.tabs.* APIs.
+        spyOn(browser.tabs, 'query').and.callFake(() => {
+            const result = []
+
+            if (currentTabDetails) {
+                result.push(currentTabDetails)
+            }
+
+            return Promise.resolve(result)
+        })
+        spyOn(browser.tabs, 'reload').and.returnValue(Promise.resolve())
+        spyOn(browser.tabs, 'sendMessage').and.callFake((tabId, message) => {
+            if (message.getBreakagePageParams) {
+                return Promise.resolve({ })
+            }
+        })
+
+        // Stub the window.setTimeout and Date.now() APIs.
+        spyOn(window, 'setTimeout').and.callFake(callback => { callback() })
+        spyOn(Date, 'now').and.callFake(() => currentTimestamp)
+
+        // Stub the load.url function (used for pixel requests).
+        spyOn(load, 'url').and.callFake(
+            url => {
+                const pixel = _formatPixelRequestForTesting(url)
+                if (pixel?.name?.startsWith('epbf') ||
+                    pixel?.name?.startsWith('protection-toggled-off-breakage-report')) {
+                    actualSentReports.push(pixel)
+                }
+            }
+        )
+    })
+
+    beforeEach(() => {
+        actualSentReports.length = 0
+        currentTabDetails = null
+        currentTimestamp = 1
+        settingsStorage.clear()
+    })
+
+    it('toggleReportStarted()', async () => {
+        expect(await toggleReports.toggleReportStarted())
+            .toEqual({
+                data: [
+                    { id: 'siteUrl' },
+                    { id: 'atb' },
+                    { id: 'errorDescriptions' },
+                    { id: 'extensionVersion' },
+                    { id: 'features' },
+                    { id: 'httpErrorCodes' },
+                    { id: 'jsPerformance' },
+                    { id: 'openerContext' },
+                    { id: 'requests' },
+                    { id: 'userRefreshCount' }
+                ]
+            })
+
+        currentTabDetails = { url: 'https://domain.example/path?param=value' }
+
+        expect(await toggleReports.toggleReportStarted())
+            .toEqual({
+                data: [
+                    { id: 'siteUrl', additional: { url: 'https://domain.example/path' } },
+                    { id: 'atb' },
+                    { id: 'errorDescriptions' },
+                    { id: 'extensionVersion' },
+                    { id: 'features' },
+                    { id: 'httpErrorCodes' },
+                    { id: 'jsPerformance' },
+                    { id: 'openerContext' },
+                    { id: 'requests' },
+                    { id: 'userRefreshCount' }
+                ]
+            })
+    })
+
+    it('toggleReportFinished()', async () => {
+        const expectReports = async (reports, accepted, declined) => {
+            expect(await ToggleReports.countResponses())
+                .toEqual({ accepted, declined })
+            expect(actualSentReports).toEqual(reports)
+            actualSentReports.length = 0
+        }
+
+        // Set things up, so that breakage reports can be sent.
+        currentTabDetails = {
+            id: 123, url: 'https://domain.example/path?param=value'
+        }
+        tabManager.create(currentTabDetails)
+        settings.updateSetting('config-etag', 'config-etag-123')
+        settings.updateSetting('tds-etag', 'tds-etag-123')
+
+        // No reports sent initially.
+        await expectReports([], 0, 0)
+
+        // No report should be sent if user declined.
+        await toggleReports.toggleReportFinished(false)
+        await expectReports([], 0, 1)
+
+        // Disconnect counts as declined, report should not be sent.
+        await toggleReports.toggleReportStarted({
+            onDisconnect: { addListener (callback) { callback() } }
+        })
+        await expectReports([], 0, 2)
+
+        // If user accepts, report should be sent.
+        await toggleReports.toggleReportFinished(true)
+        await expectReports([{
+            name: 'protection-toggled-off-breakage-report_chrome',
+            params: {
+                siteUrl: 'https://domain.example/path',
+                tds: 'tds-etag-123',
+                remoteConfigEtag: 'config-etag-123',
+                remoteConfigVersion: '2021.6.7',
+                upgradedHttps: 'false',
+                urlParametersRemoved: 'false',
+                ctlYouTube: 'false',
+                ctlFacebookPlaceholderShown: 'false',
+                ctlFacebookLogin: 'false',
+                performanceWarning: 'false',
+                userRefreshCount: '0',
+                jsPerformance: 'undefined',
+                locale: 'en-US',
+                errorDescriptions: '[]',
+                openerContext: 'external',
+                reportFlow: 'on_protections_off_dashboard_main',
+                extensionVersion: '1234.56',
+                ignoreRequests: '',
+                blockedTrackers: '',
+                surrogates: '',
+                noActionRequests: '',
+                adAttributionRequests: '',
+                ignoredByUserRequests: ''
+            }
+        }], 1, 2)
+
+        // Tidy up.
+        tabManager.delete(currentTabDetails.id)
+    })
+
+    it('clearExpiredResponses()', async () => {
+        const expectResponseTimes = expectedTimes => {
+            expect(settings.getSetting('toggleReportTimes') || [])
+                .toEqual(expectedTimes)
+        }
+
+        // Nothing there initially.
+        expectResponseTimes([])
+
+        // Clearing doesn't do anything when there's no responses.
+        currentTimestamp = today + 1
+        await ToggleReports.clearExpiredResponses()
+        expectResponseTimes([])
+
+        // Several responses came in.
+        settings.updateSetting('toggleReportTimes', [
+            { timestamp: today, accepted: true },
+            { timestamp: today, accepted: false },
+            { timestamp: tomorrow, accepted: true },
+            { timestamp: tomorrow, accepted: false },
+            { timestamp: twoDaysTime, accepted: true },
+            { timestamp: twoDaysTime, accepted: false },
+            { timestamp: threeDaysTime, accepted: true },
+            { timestamp: threeDaysTime, accepted: false },
+            { timestamp: fourDaysTime, accepted: true },
+            { timestamp: fourDaysTime, accepted: false }
+        ])
+
+        // Responses older than the cut-off are removed.
+        currentTimestamp = fourDaysTime + 1
+        await ToggleReports.clearExpiredResponses()
+        expectResponseTimes([
+            { timestamp: threeDaysTime, accepted: true },
+            { timestamp: fourDaysTime, accepted: true },
+            { timestamp: fourDaysTime, accepted: false }
+        ])
+
+        // After some time passed, more responses should be removed.
+        currentTimestamp = fiveDaysTime + 1
+        await ToggleReports.clearExpiredResponses()
+        expectResponseTimes([
+            { timestamp: fourDaysTime, accepted: true }
+        ])
+
+        // Eventually all responses should be removed.
+        currentTimestamp = sixDaysTime + 1
+        await ToggleReports.clearExpiredResponses()
+        expectResponseTimes([])
+    })
+
+    it('countResponses()', async () => {
+        const expectResponses = async (accepted, declined) => {
+            expect(await ToggleReports.countResponses())
+                .toEqual({ accepted, declined })
+        }
+
+        // No responses recorded initially.
+        await expectResponses(0, 0)
+
+        // One declined response recorded.
+        await toggleReports.toggleReportFinished(false)
+        await expectResponses(0, 1)
+
+        // One accepted response recorded as well.
+        await toggleReports.toggleReportFinished(true)
+        await expectResponses(1, 1)
+
+        // One last accepted response.
+        await toggleReports.toggleReportFinished(true)
+        await expectResponses(2, 1)
+
+        // Responses cleared.
+        settings.updateSetting('toggleReportTimes', [])
+        await expectResponses(0, 0)
+    })
+
+    it('shouldDisplay', async () => {
+        // Set up the current tab.
+        currentTabDetails = {
+            id: 123, url: 'https://domain.example/path?param=value'
+        }
+        tabManager.create(currentTabDetails)
+
+        // Feature enabled + no responses.
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Feature disabled.
+        toggleReportsConfig.state = 'disabled'
+        expect(await ToggleReports.shouldDisplay()).toEqual(false)
+
+        // Feature enabled + no responses.
+        toggleReportsConfig.state = 'enabled'
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Feature disabled for the tab.
+        const allowedUrl = currentTabDetails.url
+        currentTabDetails.url = 'https://no-toggle-reports.example/path'
+        tabManager.create(currentTabDetails)
+        expect(await ToggleReports.shouldDisplay()).toEqual(false)
+
+        // Feature enabled + two accepted responses.
+        currentTabDetails.url = allowedUrl
+        tabManager.create(currentTabDetails)
+        currentTimestamp = today
+        settings.updateSetting('toggleReportTimes', [
+            { timestamp: today, accepted: true },
+            { timestamp: today, accepted: true }
+        ])
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Feature enabled + three accepted responses.
+        settings.updateSetting('toggleReportTimes', [
+            { timestamp: today, accepted: true },
+            { timestamp: today, accepted: true },
+            { timestamp: today, accepted: true }
+        ])
+        expect(await ToggleReports.shouldDisplay()).toEqual(false)
+
+        // Feature enabled + three accepted responses, but
+        // promptLimitLogicEnabled disabled.
+        toggleReportsConfig.settings.promptLimitLogicEnabled = false
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Feature enabled + one declined response.
+        toggleReportsConfig.settings.promptLimitLogicEnabled = true
+        settings.updateSetting('toggleReportTimes', [
+            { timestamp: today, accepted: false }
+        ])
+        expect(await ToggleReports.shouldDisplay()).toEqual(false)
+
+        // Feature enabled + one declined response, but dismissLogicEnabled
+        // disabled.
+        toggleReportsConfig.settings.dismissLogicEnabled = false
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Feature enabled + no responses.
+        toggleReportsConfig.settings.dismissLogicEnabled = true
+        settings.updateSetting('toggleReportTimes', [])
+        expect(await ToggleReports.shouldDisplay()).toEqual(true)
+
+        // Tidy up.
+        tabManager.delete(currentTabDetails.id)
+    })
+})

--- a/unit-test/data/extension-config.json
+++ b/unit-test/data/extension-config.json
@@ -208,6 +208,22 @@
                     "reason": "Breaks images on deezer"
                 }
             ]
+        },
+        "toggleReports": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "no-toggle-reports.example",
+                    "reason": "Testing"
+                }
+            ],
+            "settings": {
+                "dismissLogicEnabled": true,
+                "dismissInterval": 86400,
+                "promptLimitLogicEnabled": true,
+                "promptInterval": 172800,
+                "maxPromptCount": 3
+            }
         }
     },
     "unprotectedTemporary": [

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -78,7 +78,8 @@ const chrome = {
             removeListener () { }
         },
         sendMessage: () => {},
-        query: () => Promise.resolve([])
+        query: () => Promise.resolve([]),
+        reload: () => Promise.resolve()
     },
     webNavigation: {
         onCommitted: {


### PR DESCRIPTION
When the user clicks to disable protections for a website, the "toggle reports"
feature prompts them to also send a website breakage report to us. This helps
increase the number of user reports we receive for website breakage issues, in
turn helping us fix or mitigate them. The feature also takes care to not prompt
the user too often, at the time of writing only prompting one to three
times (depending on the user's response) every 48 hours.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 
**CC:** @shakyShane 

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
1. Try disabling protections for a website, the "simplified breakage report" (aka "toggle reports") UI should show, prompting you to send a breakage report.
2. The UI should only show after < three accepted responses, and not after any declined responses.
3. A breakage report request should be made in the extension's background when accepted.
4. Run `dbg.resetToggleReports()` in the extension's background console to reset the count.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
