### PR TITLE
Update autofill to 14.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#14.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,7 +176,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8462e3b2d03015246e06ca5b6cfe9e381f626095",
             "hasInstallScript": true
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
@@ -11345,8 +11345,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#12.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8462e3b2d03015246e06ca5b6cfe9e381f626095",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#14.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4689746e42b24c40c18896d697ea02b854e90d35",
@@ -11384,7 +11384,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#afb4f6128a3b50d53ddcb1897ea1fb4df6858aa1",
             "integrity": "sha512-n6uIvM6fZNS2tuqFlI3rF9WvZKa8AIjZ7dm4mcIst3hSU72I+9eJMPgOTOhbZT2ufo04buaLHj6NYtYV5M1xbg==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#afb4f6128a3b50d53ddcb1897ea1fb4df6858aa1"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#14.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/14.0.0


## Description
Updates Autofill to version [14.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/14.0.0).

### Autofill 14.0.0 release notes
## What's Changed
Re-introducing autofill.js in android iframes. `emailProtectionGetAlias` must be handled on android.

* Avoid double settings.refresh on all pages by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/65
* [GH Actions] upgrade checkout/action to v4 by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/653
* [Android] Re-introduce autofill in iframe by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/652


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/13.1.0...14.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).