### PR TITLE
Bump CI to node 20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - run: npm run install-ci
       - run: npm run lint
@@ -20,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [18]
+        version: [20]
         os: [ubuntu-latest, macos-latest]
         target: ['release-firefox', 'release-chrome']
     runs-on: ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - run: npm run install-ci
       - run: npm test
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - run: npm run install-ci
       - name: Install Playwright Browsers

--- a/.github/workflows/ddg2dnr.yml
+++ b/.github/workflows/ddg2dnr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        node: [18.x]
+        node: [20.x]
         os: [ubuntu-latest] # FIXME - macos-latest runner keeps failing
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        node: [18.x]
+        node: [20.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/privacy-grade.yml
+++ b/.github/workflows/privacy-grade.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - name: Lint
         run: |
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - name: Test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
 
       - name: Bump version and config


### PR DESCRIPTION

## Description:
Some of our dependencies are [dropping support for Node 18](https://github.com/duckduckgo/duckduckgo-privacy-extension/actions/runs/11214035345/job/31168291389?pr=2742). Node 20 is the current LTS, let's use that.