### PR TITLE
Fix SASS deprecation warnings

### DIFF
--- a/shared/scss/_mixins.scss
+++ b/shared/scss/_mixins.scss
@@ -2,13 +2,13 @@
 
 /* Logo */
 @mixin ddg_logo () {
-    @include cross_platform_bg_image("logo-horizontal@2x.png");
     background-size: contain;
+    @include cross_platform_bg_image("logo-horizontal@2x.png");
 }
 
 @mixin ddg_logo--small () {
-    @include cross_platform_bg_image("logo-small.svg");
     background-size: contain;
+    @include cross_platform_bg_image("logo-small.svg");
 }
 
 

--- a/shared/scss/views/_extension-page.scss
+++ b/shared/scss/views/_extension-page.scss
@@ -9,10 +9,10 @@
 }
 
 .ddg-logo {
-    @include ddg_logo();
     width: 158px;
     height: 44px;
     margin-bottom: 23px;
+    @include ddg_logo();
 
     span {
         display: none;
@@ -26,7 +26,7 @@
         font-weight: normal;
         line-height: 1.4;
         color: #666666;
-        
+
         a {
             font-weight: bold;
         }
@@ -67,7 +67,7 @@
         left: 0;
         top: -8px;
     }
-    
+
     a {
         font-weight: bold;
     }


### PR DESCRIPTION

## Description:
We started getting warnings when building our SASS stylesheets:

> Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
> More info: https://sass-lang.com/d/mixed-decls

This PR fixes those warnings by reordering `@include` statements.