### PR TITLE
Reorganize dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,22 @@ updates:
     labels:
       - "dependencies"
     groups:
-      external-dependencies:
+      types:
         patterns:
-          - "*"
-        exclude-patterns:
-          - "puppeteer"
-          - "@duckduckgo/*"
-          - "privacy-test-pages"
+          - "@types/*"
+      test:
+        patterns:
+          - "karma*"
+          - "@playwright/*"
+          - "timekeeper"
+      build:
+        patterns:
+          - "eslint*"
+          - "sass"
+          - "standard"
+          - "esbuild"
+          - "yargs"
+          - "web-ext"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description:
The current grouping is too large, making it difficult to figure out which dependency is causing failures. This PR creates 3 logical groups (types, test and build) to split up dependabot PRs into logical units.