### PR TITLE
Move DNR module side-effects into a component.

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -27,6 +27,7 @@ import ToggleReports from './components/toggle-reports'
 import TrackersGlobal from './components/trackers'
 import DebuggerConnection from './components/debugger-connection'
 import Devtools from './components/devtools'
+import DNR from './components/dnr'
 import initDebugBuild from './devbuild'
 import initReloader from './devbuild-reloader'
 import tabManager from './tab-manager'
@@ -74,6 +75,7 @@ if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
 // MV3-only components
 if (BUILD_TARGET === 'chrome') {
     components.scriptInjection = new MV3ContentScriptInjection()
+    components.dnr = new DNR({ settings, tds })
 }
 console.log(new Date(), 'Loaded components:', components)
 // @ts-ignore

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -27,7 +27,7 @@ import ToggleReports from './components/toggle-reports'
 import TrackersGlobal from './components/trackers'
 import DebuggerConnection from './components/debugger-connection'
 import Devtools from './components/devtools'
-import DNR from './components/dnr'
+import DNRListeners from './components/dnr-listeners'
 import initDebugBuild from './devbuild'
 import initReloader from './devbuild-reloader'
 import tabManager from './tab-manager'
@@ -75,7 +75,7 @@ if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
 // MV3-only components
 if (BUILD_TARGET === 'chrome') {
     components.scriptInjection = new MV3ContentScriptInjection()
-    components.dnr = new DNR({ settings, tds })
+    components.dnrListeners = new DNRListeners({ settings, tds })
 }
 console.log(new Date(), 'Loaded components:', components)
 // @ts-ignore

--- a/shared/js/background/components/dnr-listeners.js
+++ b/shared/js/background/components/dnr-listeners.js
@@ -1,10 +1,10 @@
 import browser from 'webextension-polyfill'
-import ATB from '../atb'
-import { flushSessionRules } from '../dnr-session-rule-id'
-import { clearInvalidDynamicRules } from '../dnr-utils'
-import { refreshUserAllowlistRules } from '../dnr-user-allowlist'
-import { ensureGPCHeaderRule } from '../dnr-gpc'
-import { onConfigUpdate } from '../dnr-config-rulesets'
+import ATB from '../atb.js'
+import { flushSessionRules } from '../dnr-session-rule-id.js'
+import { clearInvalidDynamicRules } from '../dnr-utils.js'
+import { refreshUserAllowlistRules } from '../dnr-user-allowlist.js'
+import { ensureGPCHeaderRule } from '../dnr-gpc.js'
+import { onConfigUpdate } from '../dnr-config-rulesets.js'
 
 /**
  * @typedef {import('./tds.js').default} TDS
@@ -12,8 +12,15 @@ import { onConfigUpdate } from '../dnr-config-rulesets'
  * @typedef {import('./trackers.js').default} Trackers
  */
 
-export default class DNR {
+export default class DNRListeners {
     /**
+     * This component hooks up DNR library functions to various listeners so they can react to
+     * resource state and set DNR rules accordingly. Currently listens for:
+     *  - Config loading and updates.
+     *  - Blocklist loading and updates.
+     *  - Settings changes (for the GPC setting).
+     *  - Extension install and update events.
+     *
      * @param {{
     *  settings: Settings;
     *  tds: TDS;

--- a/shared/js/background/components/dnr.js
+++ b/shared/js/background/components/dnr.js
@@ -1,0 +1,56 @@
+import browser from 'webextension-polyfill'
+import ATB from '../atb'
+import { flushSessionRules } from '../dnr-session-rule-id'
+import { clearInvalidDynamicRules } from '../dnr-utils'
+import { refreshUserAllowlistRules } from '../dnr-user-allowlist'
+import { ensureGPCHeaderRule } from '../dnr-gpc'
+import { onConfigUpdate } from '../dnr-config-rulesets'
+
+/**
+ * @typedef {import('./tds.js').default} TDS
+ * @typedef {import('../settings.js')} Settings
+ * @typedef {import('./trackers.js').default} Trackers
+ */
+
+export default class DNR {
+    /**
+     * @param {{
+    *  settings: Settings;
+    *  tds: TDS;
+    * }} options
+    */
+    constructor ({ settings, tds }) {
+        this.featureName = 'DNR'
+        this.settings = settings
+        this.tds = tds
+        browser.runtime.onInstalled.addListener(this.postInstall.bind(this))
+        tds.config.onUpdate(onConfigUpdate)
+        tds.tds.onUpdate(onConfigUpdate)
+        this.settings.onSettingUpdate.addEventListener(
+            'GPC', () => { ensureGPCHeaderRule(this.tds.config.data) }
+        )
+    }
+
+    async postInstall () {
+        await this.settings.ready()
+        // remove any orphaned session rules (can happen on extension update/restart)
+        await flushSessionRules()
+        // check that the dynamic rule state is consistent with the rule ranges we expect
+        clearInvalidDynamicRules()
+        // create ATB rule if there is a stored value in settings
+        ATB.setOrUpdateATBdnrRule(this.settings.getSetting('atb'))
+
+        // Refresh the user allowlisting declarativeNetRequest rule, only
+        // necessary to handle the upgrade between MV2 and MV3 extensions.
+        // TODO: Remove this a while after users have all been migrated to
+        //       the MV3 build.
+        const allowlist = this.settings.getSetting('allowlisted') || {}
+        const allowlistedDomains = []
+        for (const [domain, enabled] of Object.entries(allowlist)) {
+            if (enabled) {
+                allowlistedDomains.push(domain)
+            }
+        }
+        await refreshUserAllowlistRules(allowlistedDomains)
+    }
+}

--- a/shared/js/background/components/dnr.js
+++ b/shared/js/background/components/dnr.js
@@ -27,7 +27,10 @@ export default class DNR {
         tds.config.onUpdate(onConfigUpdate)
         tds.tds.onUpdate(onConfigUpdate)
         this.settings.onSettingUpdate.addEventListener(
-            'GPC', () => { ensureGPCHeaderRule(this.tds.config.data) }
+            'GPC', async () => {
+                await this.tds.config.ready
+                ensureGPCHeaderRule(this.tds.config.data)
+            }
         )
     }
 

--- a/shared/js/background/dnr-config-rulesets.js
+++ b/shared/js/background/dnr-config-rulesets.js
@@ -1,4 +1,4 @@
-import { getExtensionVersion, getManifestVersion } from './wrapper'
+import { getExtensionVersion } from './wrapper'
 import settings from './settings'
 import tdsStorage from './storage/tds'
 import trackers from './trackers'

--- a/shared/js/background/dnr-config-rulesets.js
+++ b/shared/js/background/dnr-config-rulesets.js
@@ -299,8 +299,3 @@ export async function onConfigUpdate (configName, etag, configValue) {
     })
     await ruleUpdateLock
 }
-
-if (getManifestVersion() === 3) {
-    tdsStorage.onUpdate('config', onConfigUpdate)
-    tdsStorage.onUpdate('tds', onConfigUpdate)
-}

--- a/shared/js/background/dnr-config-rulesets.js
+++ b/shared/js/background/dnr-config-rulesets.js
@@ -50,7 +50,6 @@ function generateEtagRule (id, etag) {
  */
 async function configRulesNeedUpdate (configName, expectedState) {
     const settingName = SETTING_PREFIX + configName
-    await settings.ready()
     const settingValue = settings.getSetting(settingName)
 
     // No setting saved for the configuration yet, this is likely the first time
@@ -164,7 +163,6 @@ async function updateConfigRules (
         settingValue[key] = latestState[key]
     }
 
-    await settings.ready()
     if (Object.keys(allowingRulesByClickToLoadAction).length) {
         settings.updateSetting('allowingDnrRulesByClickToLoadRuleAction', allowingRulesByClickToLoadAction)
     }
@@ -182,7 +180,7 @@ async function updateConfigRules (
  */
 export async function updateExtensionConfigRules (etag = null, configValue = null) {
     const extensionVersion = getExtensionVersion()
-    const denylistedDomains = await getDenylistedDomains()
+    const denylistedDomains = getDenylistedDomains()
 
     const latestState = {
         extensionVersion,
@@ -191,14 +189,11 @@ export async function updateExtensionConfigRules (etag = null, configValue = nul
     }
 
     if (!configValue) {
-        await tdsStorage.ready('config')
         configValue = tdsStorage.config
     }
 
     if (!etag) {
         const settingName = SETTING_PREFIX + 'config'
-        await settings.ready()
-        await tdsStorage.ready('config')
         const settingValue = settings.getSetting(settingName)
         if (!settingValue?.etag) {
             // Should not be possible, but if the etag is unknown at this point
@@ -229,7 +224,7 @@ export async function updateExtensionConfigRules (etag = null, configValue = nul
 
 export async function updateCombinedConfigBlocklistRules () {
     const extensionVersion = getExtensionVersion()
-    const denylistedDomains = await getDenylistedDomains()
+    const denylistedDomains = getDenylistedDomains()
     const tdsEtag = settings.getSetting('tds-etag')
     const combinedState = {
         etag: `${settings.getSetting('config-etag')}-${tdsEtag}`,

--- a/shared/js/background/dnr-gpc.js
+++ b/shared/js/background/dnr-gpc.js
@@ -15,7 +15,6 @@ export async function ensureGPCHeaderRule (config = null) {
     const addRules = []
 
     if (!config) {
-        await tdsStorage.ready('config')
         config = tdsStorage.config
     }
 

--- a/shared/js/background/dnr-gpc.js
+++ b/shared/js/background/dnr-gpc.js
@@ -35,7 +35,3 @@ export async function ensureGPCHeaderRule (config = null) {
         removeRuleIds, addRules
     })
 }
-
-settings.onSettingUpdate.addEventListener(
-    'GPC', () => { ensureGPCHeaderRule() }
-)

--- a/shared/js/background/dnr-user-allowlist.js
+++ b/shared/js/background/dnr-user-allowlist.js
@@ -103,10 +103,9 @@ export async function refreshUserAllowlistRules (allowlistedDomains) {
 
 /**
  * Retrieve a normalized and sorted list of user denylisted domains.
- * @returns {Promise<string[]>}
+ * @returns {string[]}
  */
-export async function getDenylistedDomains () {
-    await settings.ready()
+export function getDenylistedDomains () {
     const denylist = settings.getSetting('denylisted') || {}
 
     const denylistedDomains = []

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -7,13 +7,6 @@
 import browser from 'webextension-polyfill'
 import messageHandlers from './message-handlers'
 import { updateActionIcon } from './events/privacy-icon-indicator'
-import { flushSessionRules } from './dnr-session-rule-id'
-import {
-    clearInvalidDynamicRules
-} from './dnr-utils'
-import {
-    refreshUserAllowlistRules
-} from './dnr-user-allowlist'
 import httpsStorage from './storage/https'
 import ATB from './atb'
 import { clearExpiredBrokenSiteReportTimes } from './broken-site-report'

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -54,32 +54,6 @@ async function onInstalled (details) {
         experiment.setActiveExperiment()
     }
 
-    if (manifestVersion === 3) {
-        await settings.ready()
-
-        // remove any orphaned session rules (can happen on extension update/restart)
-        await flushSessionRules()
-
-        // check that the dynamic rule state is consistent with the rule ranges we expect
-        clearInvalidDynamicRules()
-
-        // create ATB rule if there is a stored value in settings
-        ATB.setOrUpdateATBdnrRule(settings.getSetting('atb'))
-
-        // Refresh the user allowlisting declarativeNetRequest rule, only
-        // necessary to handle the upgrade between MV2 and MV3 extensions.
-        // TODO: Remove this a while after users have all been migrated to
-        //       the MV3 build.
-        const allowlist = settings.getSetting('allowlisted') || {}
-        const allowlistedDomains = []
-        for (const [domain, enabled] of Object.entries(allowlist)) {
-            if (enabled) {
-                allowlistedDomains.push(domain)
-            }
-        }
-        await refreshUserAllowlistRules(allowlistedDomains)
-    }
-
     // Inject the email content script on all tabs upon installation (not needed on Firefox)
     // FIXME the below code throws an unhandled exception in MV3
     try {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kzar 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
A couple of the DNR modules were registering listeners on import. This PR moves that sites into a component, so we have control over when those listeners get registered, and to what objects.
