### PR TITLE
[Autofill] Bump autofill to 15.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -11728,7 +11728,7 @@
         },
         "@duckduckgo/autofill": {
             "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#12.0.1"
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed569676555d493c9c5575eaed22aa02569aac9",
@@ -11755,7 +11755,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#acb35e41952e1f6062aca4732d1f7ea3bd134f2e",
             "integrity": "sha512-k0l3M4szEa0omhD3rGvlzkWH4Oxp4uTs8GvukIjZdVuqKu0PlQMYiVAtrGxv0ykgIks7efWbbDb8StmuRC25cQ==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#acb35e41952e1f6062aca4732d1f7ea3bd134f2e"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#7.0.4"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
The last 15.0.0 automation broke, so we missed out on creating a bump task for extensions. I am going to do it manually for now, the automation should be fixed for the next one.

**Release notes**
(Since 14.0.0 was not merged yet, we can jump straight to 15.0.0. There are not many changes in between 14 and 15 anyway, except android autofill support.)

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.0.1...15.0.0

## Steps to test this PR:
Smoke tests were performed as a part of the autofill release process for all platforms.