### PR TITLE
Update autofill to 15.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.0.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -176,8 +176,9 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-            "hasInstallScript": true
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
+            "hasInstallScript": true,
+            "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/content-scope-scripts": {
             "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed569676555d493c9c5575eaed22aa02569aac9",
@@ -11727,8 +11728,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.0.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed569676555d493c9c5575eaed22aa02569aac9",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/15.1.0


## Description
Updates Autofill to version [15.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/15.1.0).

### Autofill 15.1.0 release notes
## What's Changed
* [Form] expand username re-categorization to phone by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/691
* [Matching] Add 'search' for forceUnknown by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/692
* [Release automation] Update asana usage by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/693


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/15.0.0...15.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).