### PR TITLE
Update autofill to 16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -174,7 +174,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#88982a3802ac504e2f1a118a73bfdf2d8f4a7735",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11454,8 +11454,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#88982a3802ac504e2f1a118a73bfdf2d8f4a7735",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#695412097915d14e0d977f7c11f979af6448bd8c",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0


## Description
Updates Autofill to version [16.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0).

### Autofill 16.0.0 release notes
## What's Changed
This PR introduces breaking changes for Android/Windows causing save autofill prompt to get triggered in username only fields.
* Upgrade to shared eslint config + Adopt Prettier by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/695
* Ignore lint PR in git blame by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/699
* Update password-related json files (2024-11-18) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/706
* [Form] Always scan shadow elements when categorizing the form inputs by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/703
* Bump ts-to-zod from 3.1.3 to 3.14.0 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/710
* [FormAnalyzer] Fix paperlesspost.com login form by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/711
* [FormAnalyzer] Tweak regex to match forgot password attribute by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/712
* [Form] Trigger partialSave on username/email only form submit by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/702


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/15.1.0...16.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).