### PR TITLE
Disable AMP tests

### DIFF
--- a/integration-test/amp-protection.spec.js
+++ b/integration-test/amp-protection.spec.js
@@ -6,7 +6,7 @@ import { overridePrivacyConfig } from './helpers/testConfig';
 const testSite = 'https://privacy-test-pages.site/privacy-protections/amp/';
 
 test.describe('Test AMP link protection', () => {
-    test('Redirects AMP URLs correctly', async ({ context, backgroundPage, page, backgroundNetworkContext }) => {
+    test.skip('Redirects AMP URLs correctly', async ({ context, backgroundPage, page, backgroundNetworkContext }) => {
         await overridePrivacyConfig(backgroundNetworkContext, 'amp-protection.json');
         await backgroundWait.forExtensionLoaded(context);
         await backgroundWait.forAllConfiguration(backgroundPage);


### PR DESCRIPTION

## Description:
Sets AMP tests to be skipped.

 - These tests are regularly flakey because they depend on external sites.
 - They occasionally perma-fail when a site changes its paths.
 - This protection is not particularly relevant now that AMP is mostly dead.
 
