### PR TITLE
Update autofill to 16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -174,7 +174,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#47c26dc32b94cdbcef3e6157497147917678c25c",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11454,8 +11454,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#47c26dc32b94cdbcef3e6157497147917678c25c",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#695412097915d14e0d977f7c11f979af6448bd8c",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0


## Description
Updates Autofill to version [16.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0).

### Autofill 16.1.0 release notes
## What's Changed
* [DeviceInterface] Call closeautofillparent only after openManage calls by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/718
* [CredentialsImport] Call credentials flow call first, and then close parent by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/723
* [FeatureToggle] Add new autofill config for partial save trigger by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/724


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/16.0.0...16.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).