### PR TITLE
New message breakageFormOptionsRequested for Privacy Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -218,7 +218,7 @@
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
             "version": "7.3.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#177625e1c289ba6d37bffcd546db3451bb967cb9",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#fb6e2a33e74571059fed8a1b991077625a623005",
             "engines": {
                 "node": ">=22.0.0",
                 "npm": ">=9.0.0"
@@ -11488,7 +11488,7 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#177625e1c289ba6d37bffcd546db3451bb967cb9",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#fb6e2a33e74571059fed8a1b991077625a623005",
             "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#pr-releases/pr-196"
         },
         "@duckduckgo/privacy-grade": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
-                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.4.0",
+                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#pr-releases/pr-196",
                 "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
@@ -217,8 +217,7 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
-            "version": "7.3.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#022c845b06ace6a4aa712a4fa3e79da32193d5c6",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#0e4f5e874fce58ce648edc102bb386b94648231d",
             "engines": {
                 "node": ">=22.0.0",
                 "npm": ">=9.0.0"
@@ -11488,8 +11487,13 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
+<<<<<<< HEAD
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#022c845b06ace6a4aa712a4fa3e79da32193d5c6",
             "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#7.4.0"
+=======
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#0e4f5e874fce58ce648edc102bb386b94648231d",
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#pr-releases/pr-196"
+>>>>>>> f7549e421 (Dashboard updated)
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,7 +217,8 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#0e4f5e874fce58ce648edc102bb386b94648231d",
+            "version": "7.3.2",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#d23ffd8a76cc69810dc77e87c721a73ac0bd47fe",
             "engines": {
                 "node": ">=22.0.0",
                 "npm": ">=9.0.0"
@@ -11487,13 +11488,8 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
-<<<<<<< HEAD
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#022c845b06ace6a4aa712a4fa3e79da32193d5c6",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#7.4.0"
-=======
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#0e4f5e874fce58ce648edc102bb386b94648231d",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#d23ffd8a76cc69810dc77e87c721a73ac0bd47fe",
             "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#pr-releases/pr-196"
->>>>>>> f7549e421 (Dashboard updated)
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,7 +218,7 @@
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
             "version": "7.3.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#d23ffd8a76cc69810dc77e87c721a73ac0bd47fe",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#177625e1c289ba6d37bffcd546db3451bb967cb9",
             "engines": {
                 "node": ">=22.0.0",
                 "npm": ">=9.0.0"
@@ -11488,7 +11488,7 @@
             "integrity": "sha512-cJvuLGRnREddo20OCk4qiFUVxS1xA6Y5MRpaDFuzdNkdrs1tF5F52EbfBSGFEbP6i+xUcoVYeqQ7DxT1MPa+jA=="
         },
         "@duckduckgo/privacy-dashboard": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#d23ffd8a76cc69810dc77e87c721a73ac0bd47fe",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#177625e1c289ba6d37bffcd546db3451bb967cb9",
             "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#pr-releases/pr-196"
         },
         "@duckduckgo/privacy-grade": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.4.0",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#pr-releases/pr-196",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",

--- a/shared/js/background/components/toggle-reports.js
+++ b/shared/js/background/components/toggle-reports.js
@@ -70,6 +70,8 @@ export default class ToggleReports {
 
         registerMessageHandler('getToggleReportOptions', (_, sender) => this.toggleReportStarted(sender));
 
+        registerMessageHandler('getBreakageFormOptions', (_, sender) => this.breakageFormOptionsRequested());
+
         registerMessageHandler('rejectToggleReport', (_, sender) => this.toggleReportFinished(false, sender));
 
         registerMessageHandler('sendToggleReport', (_, sender) => this.toggleReportFinished(true, sender));
@@ -98,6 +100,34 @@ export default class ToggleReports {
         // this event will fire.
         sender?.onDisconnect?.addListener(this.onDisconnect);
 
+        let siteUrl = null;
+        const currentTabUrl = (await getCurrentTab())?.url;
+        if (currentTabUrl) {
+            siteUrl = getURLWithoutQueryString(currentTabUrl);
+        }
+
+        /** @type {ToggleReportOptions} */
+        const response = { data: [] };
+
+        for (const paramId of ToggleReports.PARAM_IDS) {
+            if (paramId === 'siteUrl' && siteUrl) {
+                response.data.push({ id: 'siteUrl', additional: { url: siteUrl } });
+            } else {
+                response.data.push({ id: paramId });
+            }
+        }
+
+        return response;
+    }
+
+    /**
+     * Provides details of what will be included in a breakage report, so that
+     * the user can make an informed decision. Called when the "breakage form"
+     * UI flow begins.
+     *
+     * @returns {Promise<ToggleReportOptions>}
+     */
+    async breakageFormOptionsRequested() {
         let siteUrl = null;
         const currentTabUrl = (await getCurrentTab())?.url;
         if (currentTabUrl) {


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1209010699733787/f

**Reviewer:** @kzar 

## Description:

In order to have separate page-reload behavior on the Toggle Report and Breakage Form screens, the `getToggleReportOptions` message has been split. The new `breakageFormOptionsRequested` message, which is only called from the Breakage Form, does not trigger a page reload on disconnect.

Note: The Privacy Dashboard is currently pointing to a development branch and should be updated to its latest release before merging this PR.

## Steps to test this PR:
1. Load extension on any web page
2. Click on “Report a problem with this site"
3. Follow breakage report steps until you reach the submission form
4. Click on “See What’s Sent” and confirm that a list of data disclosure items appears
5. Submit the report and close the extension
6. Confirm that the page is not reloaded

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
