### PR TITLE
Add getBreakageFormOptions message handler

### DIFF
--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -1,6 +1,6 @@
 import browser from 'webextension-polyfill';
 import { dashboardDataFromTab } from './classes/privacy-dashboard-data';
-import { sendBreakageReportForCurrentTab } from './broken-site-report';
+import { getDisclosureDetails, sendBreakageReportForCurrentTab } from './broken-site-report';
 import parseUserAgentString from '../shared-utils/parse-user-agent-string';
 import { getExtensionURL } from './wrapper';
 import { isFeatureEnabled, reloadCurrentTab } from './utils';
@@ -345,6 +345,7 @@ const messageHandlers = {
     getBrowser,
     openOptions,
     submitBrokenSiteReport,
+    getBreakageFormOptions: getDisclosureDetails,
     getPrivacyDashboardData,
     getTopBlockedByPages,
     getClickToLoadState,

--- a/unit-test/background/broken-site-report.js
+++ b/unit-test/background/broken-site-report.js
@@ -1,0 +1,59 @@
+import browser from 'webextension-polyfill';
+import { getDisclosureDetails } from '../../shared/js/background/broken-site-report';
+
+describe('broke-site-report', () => {
+    let currentTabDetails = null;
+
+    beforeAll(async () => {
+        // Stub the necessary browser.tabs.* APIs.
+        spyOn(browser.tabs, 'query').and.callFake(() => {
+            const result = [];
+
+            if (currentTabDetails) {
+                result.push(currentTabDetails);
+            }
+
+            return Promise.resolve(result);
+        });
+    });
+
+    beforeEach(() => {
+        currentTabDetails = null;
+    });
+
+    it('getDisclosureDetails()', async () => {
+        expect(await getDisclosureDetails()).toEqual({
+            data: [
+                { id: 'siteUrl' },
+                { id: 'atb' },
+                { id: 'errorDescriptions' },
+                { id: 'extensionVersion' },
+                { id: 'features' },
+                { id: 'httpErrorCodes' },
+                { id: 'jsPerformance' },
+                { id: 'locale' },
+                { id: 'openerContext' },
+                { id: 'requests' },
+                { id: 'userRefreshCount' },
+            ],
+        });
+
+        currentTabDetails = { url: 'https://domain.example/path?param=value' };
+
+        expect(await getDisclosureDetails()).toEqual({
+            data: [
+                { id: 'siteUrl', additional: { url: 'https://domain.example/path' } },
+                { id: 'atb' },
+                { id: 'errorDescriptions' },
+                { id: 'extensionVersion' },
+                { id: 'features' },
+                { id: 'httpErrorCodes' },
+                { id: 'jsPerformance' },
+                { id: 'locale' },
+                { id: 'openerContext' },
+                { id: 'requests' },
+                { id: 'userRefreshCount' },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
The privacy-dashboard is going to be sending a new message
"getBreakageFormOptions", which is very similar to "getToggleReportOptions"
except for use by the standard breakage report UI flow. Let's add that now,
taking care to share the logic between those message handlers.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jdorweiler, @mgurgel 

## Steps to test this PR:
1. Disable protections for a website, then click to see report details.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
