### PR TITLE
Implement the 'rollout' config option for percentage rollouts of sub-features

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -28,6 +28,7 @@ import TrackersGlobal from './components/trackers';
 import DebuggerConnection from './components/debugger-connection';
 import Devtools from './components/devtools';
 import DNRListeners from './components/dnr-listeners';
+import RemoteConfig from './components/remote-config';
 import initDebugBuild from './devbuild';
 import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
@@ -66,6 +67,7 @@ const components = {
     trackers: new TrackersGlobal({ tds }),
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools,
+    config: new RemoteConfig({ tds, settings })
 };
 
 // Chrome-only components

--- a/shared/js/background/components/remote-config.js
+++ b/shared/js/background/components/remote-config.js
@@ -1,0 +1,87 @@
+
+/**
+ * @typedef {import('../settings.js')} Settings
+ * @typedef {import('./tds').default} TDSStorage
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/config.js').GenericV4Config} Config
+ */
+
+import { getFeatureSettings, isFeatureEnabled, satisfiesMinVersion } from '../utils'
+import { getExtensionVersion } from '../wrapper'
+
+export default class RemoteConfig {
+    /**
+     * @param {{
+     * tds: TDSStorage
+     *  settings: Settings
+     * }} opts
+     */
+    constructor({ tds, settings }) {
+        /** @type {Config?} */
+        this.config = null
+        this.settings = settings
+        this.ready = new Promise((resolve) => {
+            tds.config.onUpdate(async (_, etag, v) => {
+                await this.settings.ready()
+                this.config = processRawConfig(v)
+                resolve(null)
+            })
+        })
+    }
+
+    /**
+     * 
+     * @param {string} featureName 
+     * @returns {boolean}
+     */
+    isFeatureEnabled(featureName) {
+        return isFeatureEnabled(featureName, this.config || undefined)
+    }
+
+    /**
+     * 
+     * @param {string} featureName 
+     * @returns {object}
+     */
+    getFeatureSettings(featureName) {
+        return getFeatureSettings(featureName, this.config || undefined)
+    }
+
+    isSubFeatureEnabled(featureName, subFeatureName) {
+        if (this.config) {
+            return isSubFeatureEnabled(featureName, subFeatureName, this.config)
+        } else {
+            return false
+        }
+    }
+}
+
+/**
+ * 
+ * @param {Config} configValue 
+ * @returns {Config}
+ */
+function processRawConfig(configValue) {
+    return configValue
+}
+
+/**
+ * 
+ * @param {string} featureName 
+ * @param {string} subFeatureName 
+ * @param {Config} config
+ * @returns {boolean}
+ */
+function isSubFeatureEnabled(featureName, subFeatureName, config) {
+    const feature = config.features[featureName];
+    const subFeature = (feature?.features || {})[subFeatureName];
+    if (!feature || !subFeature) {
+        return false
+    }
+    if (subFeature?.minSupportedVersion) {
+        const extensionVersionString = getExtensionVersion();
+        if (!satisfiesMinVersion(subFeature.minSupportedVersion, extensionVersionString)) {
+            return false;
+        }
+    }
+    return subFeature?.state === 'enabled';
+}

--- a/shared/js/background/components/remote-config.js
+++ b/shared/js/background/components/remote-config.js
@@ -32,7 +32,9 @@ export default class RemoteConfig {
      * @param {Config} configValue 
      */
     updateConfig(configValue) {
-        this.config = processRawConfig(configValue, this.settings)
+        // copy config value before modification
+        const configCopy = structuredClone(configValue)
+        this.config = processRawConfig(configCopy, this.settings)
     }
 
     /**

--- a/shared/js/background/storage/tds.js
+++ b/shared/js/background/storage/tds.js
@@ -16,7 +16,7 @@ export default {
     _tds: { entities: {}, trackers: {}, domains: {}, cnames: {} },
     _surrogates: '',
     get config() {
-        return globalThis.components?.tds.config.data || this._config;
+        return globalThis.components?.config.config || this._config;
     },
     get tds() {
         return globalThis.components?.tds.tds.data || this._tds;

--- a/shared/js/background/utils.js
+++ b/shared/js/background/utils.js
@@ -8,6 +8,10 @@ import sha1 from '../shared-utils/sha1';
 const browserInfo = parseUserAgentString();
 
 /**
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/config.js').GenericV4Config} Config
+ */
+
+/**
  * Produce a random float, matches the output of Math.random() but much more cryptographically psudo-random.
  * @returns {number}
  */
@@ -376,10 +380,11 @@ export function satisfiesMinVersion(minVersionString, extensionVersionString) {
  * parameter to check if the state is equeal to other states (i.e. state === 'beta').
  *
  * @param {String} featureName - the name of the feature
+ * @param {Config} config
  * @returns {boolean} - if feature is enabled
  */
-export function isFeatureEnabled(featureName) {
-    const feature = tdsStorage.config.features[featureName];
+export function isFeatureEnabled(featureName, config = tdsStorage.config) {
+    const feature = config.features[featureName];
     if (!feature) {
         return false;
     }
@@ -399,10 +404,11 @@ export function isFeatureEnabled(featureName) {
  * Returns the settings object associated with featureName in the config
  *
  * @param {String} featureName - the name of the feature
+ * @param {Config} config
  * @returns {Object} - Settings associated in the config with featureName
  */
-export function getFeatureSettings(featureName) {
-    const feature = tdsStorage.config.features[featureName];
+export function getFeatureSettings(featureName, config = tdsStorage.config) {
+    const feature = config.features[featureName];
     if (typeof feature !== 'object' || feature === null || !feature.settings) {
         return {};
     }

--- a/unit-test/background/remote-config.js
+++ b/unit-test/background/remote-config.js
@@ -1,0 +1,286 @@
+const { default: RemoteConfig } = require('../../shared/js/background/components/remote-config');
+
+class MockSettings {
+    constructor() {
+        this.mockSettingData = new Map();
+        this.ready = () => Promise.resolve();
+    }
+
+    getSetting(key) {
+        return this.mockSettingData.get(key);
+    }
+    updateSetting(key, value) {
+        this.mockSettingData.set(key, value);
+    }
+}
+
+fdescribe('rollouts', () => {
+    function constructMockRemoteConfig() {
+        return new RemoteConfig({ settings: new MockSettings() });
+    }
+
+    it('test staged rollout for default-enabled feature flag', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        defaultTrue: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 0.1,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'defaultTrue')).toBeFalse();
+    });
+
+    it('the disable state of the feature always wins', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'disabled',
+                    features: {
+                        fooFeature: {
+                            state: 'disabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 0,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeFalse();
+        expect(config.isSubFeatureEnabled('testFeature', 'defaultTrue')).toBeFalse();
+
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'disabled',
+                    features: {
+                        fooFeature: {
+                            state: 'disabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeFalse();
+        expect(config.isSubFeatureEnabled('testFeature', 'defaultTrue')).toBeFalse();
+    });
+
+    it('the rollout step set to 0 disables the feature', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 0,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeFalse();
+    });
+
+    it("the parent feature disabled doesn't interfer with the sub-feature state", () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'disabled',
+                    features: {
+                        fooFeature: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeFalse();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeTrue();
+    });
+
+    it('the feature incremental steps are ignored when feature disabled', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'disabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 1,
+                                    },
+                                    {
+                                        percent: 2,
+                                    },
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeFalse();
+    });
+
+    it('the feature incremental steps are executed when feature is enabled', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 0.5,
+                                    },
+                                    {
+                                        percent: 1.5,
+                                    },
+                                    {
+                                        percent: 2,
+                                    },
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeTrue();
+    });
+
+    it('the invalid rollout steps are ignored and not executed', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: -1,
+                                    },
+                                    {
+                                        percent: 100,
+                                    },
+                                    {
+                                        percent: 200,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeTrue();
+    });
+
+    it('disable a previously enabled incremental rollout', () => {
+        const config = constructMockRemoteConfig();
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'enabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeTrue();
+
+        config.updateConfig({
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    features: {
+                        fooFeature: {
+                            state: 'disabled',
+                            rollout: {
+                                steps: [
+                                    {
+                                        percent: 100,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(config.isFeatureEnabled('testFeature')).toBeTrue();
+        expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeFalse();
+    });
+});

--- a/unit-test/background/remote-config.js
+++ b/unit-test/background/remote-config.js
@@ -385,6 +385,10 @@ describe('rollouts', () => {
 
     it('full feature lifecycle', () => {
         const config = constructMockRemoteConfig();
+        let mockExtensionVersion = '2024.10.12';
+        spyOn(chrome.runtime, 'getManifest').and.callFake(() => ({
+            version: mockExtensionVersion,
+        }));
         // all disabled
         config.updateConfig({
             features: {
@@ -591,7 +595,7 @@ describe('rollouts', () => {
                     features: {
                         fooFeature: {
                             state: 'enabled',
-                            minSupportedVersion: '2030.12.25',
+                            minSupportedVersion: '2024.12.25',
                             rollout: {
                                 steps: [
                                     {
@@ -608,6 +612,7 @@ describe('rollouts', () => {
         expect(config.isSubFeatureEnabled('testFeature', 'fooFeature')).toBeFalse();
 
         // resume rollout and update app version
+        mockExtensionVersion = '2024.12.25';
         config.updateConfig({
             features: {
                 testFeature: {
@@ -615,7 +620,7 @@ describe('rollouts', () => {
                     features: {
                         fooFeature: {
                             state: 'enabled',
-                            minSupportedVersion: '2024.1.1',
+                            minSupportedVersion: '2024.12.25',
                             rollout: {
                                 steps: [
                                     {
@@ -639,7 +644,7 @@ describe('rollouts', () => {
                     features: {
                         fooFeature: {
                             state: 'enabled',
-                            minSupportedVersion: '2024.1.1',
+                            minSupportedVersion: '2024.12.25',
                             rollout: {
                                 steps: [
                                     {
@@ -666,7 +671,7 @@ describe('rollouts', () => {
                     features: {
                         fooFeature: {
                             state: 'enabled',
-                            minSupportedVersion: '2024.1.1',
+                            minSupportedVersion: '2024.12.25',
                         },
                     },
                 },

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -29,7 +29,7 @@ const chrome = {
         id: '577dc9b9-c381-115a-2246-3f95fe0e6ffe',
         sendMessage: () => {},
         getManifest: () => {
-            return { version: '2025.1.1' };
+            return { version: '1234.56' };
         },
         setUninstallURL: () => {},
         getURL: (path) => path,

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -29,7 +29,7 @@ const chrome = {
         id: '577dc9b9-c381-115a-2246-3f95fe0e6ffe',
         sendMessage: () => {},
         getManifest: () => {
-            return { version: '1234.56' };
+            return { version: '2025.1.1' };
         },
         setUninstallURL: () => {},
         getURL: (path) => path,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
- Adds support for the `rollout` sub-feature config option.
- On-device dice roll when we see a new rollout. If this is within the rollout threshold, the sub-feature is marked as enabled. Otherwise it is disabled.
- Includes unit-tests moved over from the Android test suite for the same feature.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
