### PR TITLE
Implement target conditions on rollouts.

### DIFF
--- a/shared/js/background/i18n.js
+++ b/shared/js/background/i18n.js
@@ -20,3 +20,11 @@ export function getFullUserLocale() {
 
     return browser.i18n.getUILanguage();
 }
+
+export function getUserLocaleCountry() {
+    try {
+        return getFullUserLocale().split('-')[1];
+    } catch (e) {
+        return '';
+    }
+}

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -25,6 +25,11 @@ const chrome = {
         updateDynamicRules() {},
         updateSessionRules() {},
     },
+    i18n: {
+        getUILanguage() {
+            return 'en-US';
+        },
+    },
     runtime: {
         id: '577dc9b9-c381-115a-2246-3f95fe0e6ffe',
         sendMessage: () => {},


### PR DESCRIPTION
## Description:
- Allows the `target` condition on a sub-feature to be used to only enable it for a subset of users who match a given locale or locale-country.
- Includes more tests imported from Android.