### PR TITLE
GH Actions: Rollback to ubuntu 22.04 for puppeteer-based actions.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
             - run: npm run ${{ matrix.target }}
 
     unit-tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4

--- a/.github/workflows/ddg2dnr.yml
+++ b/.github/workflows/ddg2dnr.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 node: [22.x]
-                os: [ubuntu-latest] # FIXME - macos-latest runner keeps failing
+                os: [ubuntu-22.04] # FIXME - macos-latest runner keeps failing
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node }}
@@ -23,7 +23,7 @@ jobs:
         strategy:
             matrix:
                 node: [22.x]
-                os: [ubuntu-latest]
+                os: [ubuntu-22.04]
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node }}


### PR DESCRIPTION
Fixes no-sandbox error as seen in https://github.com/duckduckgo/duckduckgo-privacy-extension/actions/runs/12767773293 and https://github.com/duckduckgo/duckduckgo-privacy-extension/actions/runs/12767773307
