### PR TITLE
A/B/N Experiment metrics

### DIFF
--- a/pixel-definitions/pixels/experiments.json
+++ b/pixel-definitions/pixels/experiments.json
@@ -26,5 +26,48 @@
                 "format": "date"
             }
         ]
+    },
+    "experiment.metrics": {
+        "description": "Triggered when user converted on a given metric in the scope of an A/B/N experiment.",
+        "owners": [
+            "smacbeth"
+        ],
+        "triggers": [
+            "startup",
+            "user_submitted",
+            "search_ddg"
+        ],
+        "suffixes": [
+            {
+                "description": "Experiment user is being enrolled in: equal to the sub feature name",
+                "type": "string"
+            },
+            {
+                "description": "Cohort the user has chosen",
+                "type": "string"
+            },
+            "extension",
+            "browser"
+        ],
+        "parameters": [
+            {
+                "key": "enrollmentDate",
+                "description": "Date the enrollment happened.",
+                "format": "date"
+            },
+            {
+                "key": "metric",
+                "description": "Name of the metric triggered (e.g. 'search')"
+            },
+            {
+                "key": "conversionWindowDays",
+                "description": "Conversion window the metric triggered in.",
+                "pattern": "[0-9]+(-[0-9]+)?"
+            },
+            {
+                "key": "value",
+                "description": "Value associated with the metric, e.g. number of times it triggered within the period."
+            }
+        ]
     }
 }

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -32,6 +32,7 @@ import RemoteConfig from './components/remote-config';
 import initDebugBuild from './devbuild';
 import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
+import AbnExperimentMetrics from './components/abn-experiments';
 // NOTE: this needs to be the first thing that's require()d when the extension loads.
 // otherwise FF might miss the onInstalled event
 require('./events');
@@ -47,6 +48,7 @@ settings.ready().then(() => {
 const remoteConfig = new RemoteConfig({ settings });
 const tds = new TDSStorage({ settings, remoteConfig });
 const devtools = new Devtools({ tds });
+const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
 /**
  * @type {{
  *  autofill: EmailAutofill;
@@ -57,6 +59,7 @@ const devtools = new Devtools({ tds });
  *  tabTracking: TabTracker;
  *  trackers: TrackersGlobal;
  *  remoteConfig: RemoteConfig;
+ *  abnMetrics: AbnExperimentMetrics;
  * }}
  */
 const components = {
@@ -70,6 +73,7 @@ const components = {
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools,
     remoteConfig,
+    abnMetrics,
 };
 
 // Chrome-only components

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -32,7 +32,7 @@ import RemoteConfig from './components/remote-config';
 import initDebugBuild from './devbuild';
 import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
-import AbnExperimentMetrics from './components/abn-experiments';
+import AbnExperimentMetrics, { AppUseMetric, SearchMetric } from './components/abn-experiments';
 // NOTE: this needs to be the first thing that's require()d when the extension loads.
 // otherwise FF might miss the onInstalled event
 require('./events');
@@ -48,7 +48,6 @@ settings.ready().then(() => {
 const remoteConfig = new RemoteConfig({ settings });
 const tds = new TDSStorage({ settings, remoteConfig });
 const devtools = new Devtools({ tds });
-const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
 /**
  * @type {{
  *  autofill: EmailAutofill;
@@ -59,7 +58,7 @@ const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
  *  tabTracking: TabTracker;
  *  trackers: TrackersGlobal;
  *  remoteConfig: RemoteConfig;
- *  abnMetrics: AbnExperimentMetrics;
+ *  abnMetrics: AbnExperimentMetrics?;
  * }}
  */
 const components = {
@@ -73,11 +72,13 @@ const components = {
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools,
     remoteConfig,
-    abnMetrics,
 };
 
 // Chrome-only components
 if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
+    const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
+    components.abnMetrics = abnMetrics;
+    components.metrics = [new AppUseMetric({ abnMetrics }), new SearchMetric({ abnMetrics })];
     components.fireButton = new FireButton({ settings, tabManager });
 }
 // MV3-only components

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -32,7 +32,7 @@ import RemoteConfig from './components/remote-config';
 import initDebugBuild from './devbuild';
 import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
-import AbnExperimentMetrics, { AppUseMetric, SearchMetric } from './components/abn-experiments';
+import AbnExperimentMetrics, { AppUseMetric, PixelMetric, SearchMetric } from './components/abn-experiments';
 // NOTE: this needs to be the first thing that's require()d when the extension loads.
 // otherwise FF might miss the onInstalled event
 require('./events');
@@ -78,7 +78,7 @@ const components = {
 if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
     const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
     components.abnMetrics = abnMetrics;
-    components.metrics = [new AppUseMetric({ abnMetrics }), new SearchMetric({ abnMetrics })];
+    components.metrics = [new AppUseMetric({ abnMetrics }), new SearchMetric({ abnMetrics }), new PixelMetric({ abnMetrics })];
     components.fireButton = new FireButton({ settings, tabManager });
 }
 // MV3-only components

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -17,7 +17,7 @@ import { sendPixelRequest } from '../pixels';
 /**
  * @returns {ExperimentMetric[]}
  */
-export function generateBuildRetentionMetrics() {
+export function generateRetentionMetrics() {
     return ['app_use', 'search'].flatMap((metric) => {
         const metrics = [0, 1, 2, 3, 4, 5, 6, 7].map((conversionWindowStart) => ({
             metric,
@@ -133,7 +133,7 @@ export default class AbnExperimentMetrics {
         const cohort = this.remoteConfig.getCohort(featureName, subFeatureName);
         if (cohort && !cohort.enrolledAt) {
             cohort.enrolledAt = Date.now();
-            cohort.metrics = (metrics || generateBuildRetentionMetrics()).map((m) => ({ ...m, counter: 0, sent: false }));
+            cohort.metrics = (metrics || generateRetentionMetrics()).map((m) => ({ ...m, counter: 0, sent: false }));
             sendPixelRequest(`experiment_enroll_${subFeatureName}_${cohort.name}`, {
                 enrollmentDate: new Date(cohort.enrolledAt).toISOString().slice(0, 10),
             });

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -71,7 +71,7 @@ export class SearchMetric {
         browser.webRequest.onCompleted.addListener(
             async (details) => {
                 const params = new URL(details.url).searchParams;
-                if (params.has('q') && (params.get('q')?.length || 0) > 0) {
+                if (params.get('q')?.length) {
                     await abnMetrics.remoteConfig.ready;
                     abnMetrics.onMetricTriggered('search');
                 }

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -143,9 +143,16 @@ export default class AbnExperimentMetrics {
     }
 
     /**
-     *
+     * Triggered when a given metric is triggered.
+     * 
+     * Checks all active, enrolled subfeature experiments to find matching metrics that should be 
+     * sent for them. With those that match, their counter is incremented by `value`, and if they
+     * exceed the threshold, a pixel is sent.
+     * 
+     * After incrementing counters and potentially sending pixels, the updated cohort state is 
+     * written back to settings.
      * @param {string} metric
-     * @param {number} value
+     * @param {number} [value]
      * @param {number} [timestamp]
      */
     async onMetricTriggered(metric, value = 1, timestamp) {
@@ -159,6 +166,8 @@ export default class AbnExperimentMetrics {
                 }
                 const enrollmentDate = new Date(cohort.enrolledAt).toISOString().slice(0, 10);
                 const daysSinceEnrollment = Math.floor(((timestamp || Date.now()) - cohort.enrolledAt) / (1000 * 60 * 60 * 24));
+                // Find metrics for this experiment that match at this point in time.
+                // i.e. we are within the conversion window, and haven't sent the pixel yet.
                 const matchingPixels = cohort.metrics.filter(
                     (m) =>
                         m.metric === metric &&

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -1,0 +1,129 @@
+/**
+ * @typedef {{
+ *  metric: string;
+ *  value: number;
+ *  conversionWindowStart: number;
+ *  conversionWindowEnd: number;
+ * }} ExperimentMetric
+ *
+ * @typedef {{
+ *  counter: number;
+ *  sent: boolean;
+ * } & ExperimentMetric} ExperimentMetricCounter
+ */
+
+import { sendPixelRequest } from '../pixels';
+
+/**
+ * @returns {ExperimentMetric[]}
+ */
+function generateBuildRetentionMetrics() {
+    return ['app_use', 'search'].flatMap((metric) => {
+        const metrics = [0, 1, 2, 3, 4, 5, 6, 7].map((conversionWindowStart) => ({
+            metric,
+            value: 1,
+            conversionWindowStart,
+            conversionWindowEnd: conversionWindowStart,
+        }));
+        metrics.push({
+            metric,
+            value: 1,
+            conversionWindowStart: 5,
+            conversionWindowEnd: 7,
+        });
+        return metrics.concat(
+            [4, 6, 11, 21, 30].flatMap((value) => {
+                return [
+                    [5, 7],
+                    [8, 15],
+                ].map(([conversionWindowStart, conversionWindowEnd]) => ({
+                    metric,
+                    value,
+                    conversionWindowStart,
+                    conversionWindowEnd,
+                }));
+            }),
+        );
+    });
+}
+
+export default class AbnExperimentMetrics {
+    /**
+     *
+     * @param {{
+     *  remoteConfig: import('./remote-config').default
+     * }} opts
+     */
+    constructor({ remoteConfig }) {
+        this.remoteConfig = remoteConfig;
+    }
+
+    /**
+     * Mark that the user should be enrolled in the experiment for the given feature and sub feature.
+     *
+     * This will send the enrollment
+     * @param {string} featureName
+     * @param {string} subFeatureName
+     * @param {ExperimentMetric[]} [metrics]
+     */
+    markExperimentEnrolled(featureName, subFeatureName, metrics) {
+        const cohort = this.remoteConfig.getCohort(featureName, subFeatureName);
+        if (cohort && !cohort.enrolledAt) {
+            cohort.enrolledAt = Date.now();
+            cohort.metrics = (metrics || generateBuildRetentionMetrics()).map((m) => ({ ...m, counter: 0, sent: false }));
+            sendPixelRequest(`experiment_enroll_${subFeatureName}_${cohort.name}`, {
+                enrollmentDate: new Date(cohort.enrolledAt).toISOString().slice(0, 10),
+            });
+            // updated stored cohort metadata
+            this.remoteConfig.setCohort(featureName, subFeatureName, cohort);
+        }
+    }
+
+    /**
+     *
+     * @param {string} metric
+     * @param {number} value
+     * @param {number} [timestamp]
+     */
+    onMetricTriggered(metric, value = 1, timestamp) {
+        this.remoteConfig
+            .getSubFeatureStatuses()
+            .filter((status) => status.hasCohorts && status.cohort && status.cohort.enrolledAt)
+            .forEach((status) => {
+                const cohort = status.cohort;
+                if (!cohort?.metrics || !cohort?.enrolledAt) {
+                    return;
+                }
+                const enrollmentDate = new Date(cohort.enrolledAt).toISOString().slice(0, 10);
+                const daysSinceEnrollment = Math.floor(((timestamp || Date.now()) - cohort.enrolledAt) / (1000 * 60 * 60 * 24));
+                const matchingPixels = cohort.metrics.filter(
+                    (m) =>
+                        m.metric === metric &&
+                        !m.sent &&
+                        m.conversionWindowStart <= daysSinceEnrollment &&
+                        m.conversionWindowEnd >= daysSinceEnrollment,
+                );
+                if (matchingPixels.length > 0) {
+                    matchingPixels
+                        .filter((m) => {
+                            // increment counter value and check it exceeds the threshold
+                            m.counter += value;
+                            return m.counter >= m.value;
+                        })
+                        .forEach((m) => {
+                            m.sent = true;
+                            sendPixelRequest(`experiment_metrics_${status.subFeature}_${cohort.name}`, {
+                                metric: m.metric,
+                                conversionWindowDays:
+                                    m.conversionWindowStart === m.conversionWindowEnd
+                                        ? `${m.conversionWindowStart}`
+                                        : `${m.conversionWindowStart}-${m.conversionWindowEnd}`,
+                                value: m.value,
+                                enrollmentDate,
+                            });
+                        });
+                    this.remoteConfig.setCohort(status.feature, status.subFeature, cohort);
+                }
+            });
+    }
+}

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -110,6 +110,26 @@ export class PixelMetric {
     }
 }
 
+/**
+ * A/B/N testing framework: metrics.
+ *
+ * This component handles metrics needed for A/B testing. It handles the rate-limiting required
+ * to define and send metrics as per the documentation in Asana (https://app.asana.com/0/1208889145294658/1208747415972722/f)
+ *
+ * Usage:
+ *  - The main entry point is `markExperimentEnrolled`. This should be used to move an assigned experiment to
+ * 'enrolled' state when the user first sees the treatment behavior. You can call this multiple times, as
+ * subsequent calls will be a no-op if the user is already enrolled.
+ *  - When enrolling, you can pass a list of 'metrics' that should be sent for the experiment. Each metric defines an
+ * event, value count and conversion window. e.g. metric: 'search', value: 4, conversionWindow 1-7: triggered
+ * once 4 searches have been done within 1-7 days (inclusive) of enrollment.
+ *  - `generateRetentionMetrics` can be used to create a default list of retention metrics (search and app_use).
+ *
+ * Example:
+ *  - Check if user has been assigned a cohort for the subfeature: `remoteConfig.getCohortName(feature, subFeature) !== null`
+ *  - Check if user is in the 'treatment' group: `remoteConfig.isSubFeatureEnabled(feature, subFeature, 'treatment')`
+ *  - Enroll the user in the experiment (with default retention metrics.): `abnMetrics.markExperimentEnrolled(feature, subFeature)`
+ */
 export default class AbnExperimentMetrics {
     /**
      *

--- a/shared/js/background/components/abn-experiments.js
+++ b/shared/js/background/components/abn-experiments.js
@@ -90,7 +90,7 @@ export class PixelMetric {
      * Currently intercepts `epbf` pixels and triggers a `brokenSiteReport` metric.
      * @param {{
      * abnMetrics: AbnExperimentMetrics
-    * }} opts
+     * }} opts
      */
     constructor({ abnMetrics }) {
         browser.webRequest.onCompleted.addListener(
@@ -144,12 +144,12 @@ export default class AbnExperimentMetrics {
 
     /**
      * Triggered when a given metric is triggered.
-     * 
-     * Checks all active, enrolled subfeature experiments to find matching metrics that should be 
+     *
+     * Checks all active, enrolled subfeature experiments to find matching metrics that should be
      * sent for them. With those that match, their counter is incremented by `value`, and if they
      * exceed the threshold, a pixel is sent.
-     * 
-     * After incrementing counters and potentially sending pixels, the updated cohort state is 
+     *
+     * After incrementing counters and potentially sending pixels, the updated cohort state is
      * written back to settings.
      * @param {string} metric
      * @param {number} [value]

--- a/unit-test/background/abn-framework.js
+++ b/unit-test/background/abn-framework.js
@@ -1,4 +1,39 @@
-import { choseCohort } from '../../shared/js/background/components/remote-config';
+import { ParamsValidator } from '@duckduckgo/pixel-schema/src/params_validator.mjs';
+
+import messageHandlers from '../../shared/js/background/message-handlers';
+import RemoteConfig, { choseCohort } from '../../shared/js/background/components/remote-config';
+import AbnExperimentMetrics from '../../shared/js/background/components/abn-experiments';
+import load from '../../shared/js/background/load';
+import commonParams from '../../pixel-definitions/common_params.json';
+import commonSuffixes from '../../pixel-definitions/common_suffixes.json';
+import experimentPixels from '../../pixel-definitions/pixels/experiments.json';
+
+class MockSettings {
+    constructor() {
+        this.mockSettingData = new Map();
+        this.ready = () => Promise.resolve();
+    }
+
+    getSetting(key) {
+        return structuredClone(this.mockSettingData.get(key));
+    }
+    updateSetting(key, value) {
+        this.mockSettingData.set(key, value);
+    }
+}
+
+function constructMockComponents() {
+    // clear message handlers to prevent conflict when registering
+    Object.keys(messageHandlers).forEach((k) => delete messageHandlers[k]);
+    const remoteConfig = new RemoteConfig({ settings: new MockSettings() });
+    const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
+    return {
+        remoteConfig,
+        abnMetrics,
+    };
+}
+
+const pixelValidator = new ParamsValidator(commonParams, commonSuffixes);
 
 describe('choseCohort', () => {
     it('picks the only cohort if there is only one available', () => {
@@ -123,5 +158,176 @@ describe('choseCohort', () => {
             b: 25,
             c: 25,
         });
+    });
+});
+
+fdescribe('ABN pixels', () => {
+    const feature = 'testFeature';
+    const subFeature = 'fooFeature';
+    const mockExperimentConfig = {
+        features: {
+            testFeature: {
+                state: 'disabled',
+                features: {
+                    fooFeature: {
+                        state: 'enabled',
+                        rollout: {
+                            steps: [
+                                {
+                                    percent: 100,
+                                },
+                            ],
+                        },
+                        cohorts: [
+                            {
+                                name: 'control',
+                                weight: 1,
+                            },
+                            {
+                                name: 'blue',
+                                weight: 0,
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    };
+    let pixelRequests = [];
+    let pixelIntercept = null;
+
+    beforeEach(() => {
+        pixelRequests = [];
+        pixelIntercept = spyOn(load, 'url').and.callFake((url) => {
+            const parsed = new URL(url);
+            pixelRequests.push(parsed.pathname + parsed.search);
+        });
+    });
+
+    it('markExperimentEnrolled sends a correct pixel only once', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+        expect(pixelValidator.validateLivePixels(experimentPixels['experiment.enroll'], 'experiment.enroll', pixelRequests[0])).toEqual([]);
+
+        // call a second time: pixel shouldn't be triggered again
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+    });
+
+    it('markExperimentEnrolled with no metrics creates the default set', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        expect(remoteConfig.getCohort(feature, subFeature).metrics.length).toEqual(38);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+    });
+
+    it('markExperimentEnrolled sends no pixel if experiment does not exist', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, 'fooFeature2');
+        expect(pixelIntercept).toHaveBeenCalledTimes(0);
+    });
+
+    it('onMetricTriggered triggers a metric pixel exactly once for an experiment', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        abnMetrics.onMetricTriggered('search');
+        abnMetrics.onMetricTriggered('search');
+        // enrollment + metric pixels
+        expect(pixelIntercept).toHaveBeenCalledTimes(2);
+        expect(pixelRequests[1]).toContain('conversionWindowDays=0&');
+        expect(pixelRequests[1]).toContain('value=1&');
+        // TODO: pixel validation
+    });
+
+    it('onMetricTriggered can trigger multiple matching metrics', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        // modify enrollment to be 6 days ago
+        const cohort = remoteConfig.getCohort(feature, subFeature);
+        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 6;
+        remoteConfig.setCohort(feature, subFeature, cohort);
+        abnMetrics.onMetricTriggered('search');
+        expect(pixelIntercept).toHaveBeenCalledTimes(3);
+        const sentConversionWindows = pixelRequests
+            .filter((u) => u.startsWith('/t/experiment_metrics_'))
+            .map((u) => new URLSearchParams(u.split('?')[1]).get('conversionWindowDays'));
+        expect(sentConversionWindows).toEqual(['6', '5-7']);
+    });
+
+    it('metric conversion window is inclusive of first and last days', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature);
+        // modify enrollment to be 7 days ago
+        const cohort = remoteConfig.getCohort(feature, subFeature);
+        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 7;
+        remoteConfig.setCohort(feature, subFeature, cohort);
+        // trigger on day 5
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 2);
+        // trigger on day 7
+        abnMetrics.onMetricTriggered('app_use', 1, Date.now());
+        expect(pixelIntercept).toHaveBeenCalledTimes(5);
+        const sentConversionWindows = pixelRequests
+            .filter((u) => u.startsWith('/t/experiment_metrics_'))
+            .map((u) => new URLSearchParams(u.split('?')[1]).get('conversionWindowDays'));
+        expect(sentConversionWindows).toEqual(['5', '5-7', '7', '5-7']);
+    });
+
+    it('metric value count applies to conversion window only', () => {
+        const { remoteConfig, abnMetrics } = constructMockComponents();
+        remoteConfig.updateConfig(mockExperimentConfig);
+        abnMetrics.markExperimentEnrolled(feature, subFeature, [{
+            metric: 'search',
+            conversionWindowStart: 5,
+            conversionWindowEnd: 7,
+            value: 4
+        }, {
+            metric: 'search',
+            conversionWindowStart: 5,
+            conversionWindowEnd: 5,
+            value: 1
+        }, {
+            metric: 'search',
+            conversionWindowStart: 5,
+            conversionWindowEnd: 5,
+            value: 2
+        }]);
+        // modify enrollment to be 7 days ago
+        const cohort = remoteConfig.getCohort(feature, subFeature);
+        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 7;
+        remoteConfig.setCohort(feature, subFeature, cohort);
+        pixelRequests.pop()
+        // day 1 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 6);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+        // day 2 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 5);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+        // day 3 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 4);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+        // day 4 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 3);
+        expect(pixelIntercept).toHaveBeenCalledTimes(1);
+        // day 5 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 2);
+        // value=1 metric was triggered on day 5
+        expect(pixelIntercept).toHaveBeenCalledTimes(2);
+        expect(pixelRequests.pop()).toContain('conversionWindowDays=5&value=1')
+        // day 6 search x2
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 1);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 1);
+        expect(pixelIntercept).toHaveBeenCalledTimes(2);
+        // day 7 search
+        abnMetrics.onMetricTriggered('search', 1, Date.now());
+        // value=4 metric triggers now
+        expect(pixelIntercept).toHaveBeenCalledTimes(3);
+        expect(pixelRequests.pop()).toContain('conversionWindowDays=5-7&value=4')
     });
 });

--- a/unit-test/background/abn-framework.js
+++ b/unit-test/background/abn-framework.js
@@ -8,6 +8,8 @@ import commonParams from '../../pixel-definitions/common_params.json';
 import commonSuffixes from '../../pixel-definitions/common_suffixes.json';
 import experimentPixels from '../../pixel-definitions/pixels/experiments.json';
 
+const ONE_HOUR_MS = 1000 * 60 * 60;
+
 class MockSettings {
     constructor() {
         this.mockSettingData = new Map();
@@ -252,7 +254,8 @@ describe('ABN pixels', () => {
         abnMetrics.markExperimentEnrolled(feature, subFeature);
         // modify enrollment to be 6 days ago
         const cohort = remoteConfig.getCohort(feature, subFeature);
-        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 6;
+        // note use 25 hours so this does fall exactly on a day boundry (which could make the test non-deterministic)
+        cohort.enrolledAt = Date.now() - ONE_HOUR_MS * 25 * 6;
         remoteConfig.setCohort(feature, subFeature, cohort);
         abnMetrics.onMetricTriggered('search');
         expect(pixelIntercept).toHaveBeenCalledTimes(3);
@@ -274,10 +277,10 @@ describe('ABN pixels', () => {
         abnMetrics.markExperimentEnrolled(feature, subFeature);
         // modify enrollment to be 7 days ago
         const cohort = remoteConfig.getCohort(feature, subFeature);
-        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 7;
+        cohort.enrolledAt = Date.now() - ONE_HOUR_MS * 25 * 7;
         remoteConfig.setCohort(feature, subFeature, cohort);
         // trigger on day 5
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 2);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 2);
         // trigger on day 7
         abnMetrics.onMetricTriggered('app_use', 1, Date.now());
         expect(pixelIntercept).toHaveBeenCalledTimes(5);
@@ -317,29 +320,29 @@ describe('ABN pixels', () => {
         ]);
         // modify enrollment to be 7 days ago
         const cohort = remoteConfig.getCohort(feature, subFeature);
-        cohort.enrolledAt = Date.now() - 1000 * 60 * 60 * 25 * 7;
+        cohort.enrolledAt = Date.now() - ONE_HOUR_MS * 25 * 7;
         remoteConfig.setCohort(feature, subFeature, cohort);
         pixelRequests.pop();
         // day 1 search
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 6);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 6);
         expect(pixelIntercept).toHaveBeenCalledTimes(1);
         // day 2 search
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 5);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 5);
         expect(pixelIntercept).toHaveBeenCalledTimes(1);
         // day 3 search
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 4);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 4);
         expect(pixelIntercept).toHaveBeenCalledTimes(1);
         // day 4 search
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 3);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 3);
         expect(pixelIntercept).toHaveBeenCalledTimes(1);
         // day 5 search
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 2);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 2);
         // value=1 metric was triggered on day 5
         expect(pixelIntercept).toHaveBeenCalledTimes(2);
         expect(pixelRequests.pop()).toContain('conversionWindowDays=5&value=1');
         // day 6 search x2
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 1);
-        abnMetrics.onMetricTriggered('search', 1, Date.now() - 1000 * 60 * 60 * 25 * 1);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 1);
+        abnMetrics.onMetricTriggered('search', 1, Date.now() - ONE_HOUR_MS * 25 * 1);
         expect(pixelIntercept).toHaveBeenCalledTimes(2);
         // day 7 search
         abnMetrics.onMetricTriggered('search', 1, Date.now());

--- a/unit-test/background/abn-framework.js
+++ b/unit-test/background/abn-framework.js
@@ -161,7 +161,7 @@ describe('choseCohort', () => {
     });
 });
 
-fdescribe('ABN pixels', () => {
+describe('ABN pixels', () => {
     const feature = 'testFeature';
     const subFeature = 'fooFeature';
     const mockExperimentConfig = {
@@ -241,7 +241,7 @@ fdescribe('ABN pixels', () => {
         expect(pixelIntercept).toHaveBeenCalledTimes(2);
         expect(pixelRequests[1]).toContain('conversionWindowDays=0&');
         expect(pixelRequests[1]).toContain('value=1&');
-        // TODO: pixel validation
+        expect(pixelValidator.validateLivePixels(experimentPixels['experiment.metrics'], 'experiment.metrics', pixelRequests[1])).toEqual([]);
     });
 
     it('onMetricTriggered can trigger multiple matching metrics', () => {
@@ -258,6 +258,8 @@ fdescribe('ABN pixels', () => {
             .filter((u) => u.startsWith('/t/experiment_metrics_'))
             .map((u) => new URLSearchParams(u.split('?')[1]).get('conversionWindowDays'));
         expect(sentConversionWindows).toEqual(['6', '5-7']);
+        expect(pixelValidator.validateLivePixels(experimentPixels['experiment.metrics'], 'experiment.metrics', pixelRequests[1])).toEqual([]);
+        expect(pixelValidator.validateLivePixels(experimentPixels['experiment.metrics'], 'experiment.metrics', pixelRequests[2])).toEqual([]);
     });
 
     it('metric conversion window is inclusive of first and last days', () => {
@@ -277,6 +279,11 @@ fdescribe('ABN pixels', () => {
             .filter((u) => u.startsWith('/t/experiment_metrics_'))
             .map((u) => new URLSearchParams(u.split('?')[1]).get('conversionWindowDays'));
         expect(sentConversionWindows).toEqual(['5', '5-7', '7', '5-7']);
+        pixelRequests.forEach((u) => {
+            if (u.startsWith('/t/experiment_metrics_')) {
+                expect(pixelValidator.validateLivePixels(experimentPixels['experiment.metrics'], 'experiment.metrics', u)).toEqual([]);
+            }
+        })
     });
 
     it('metric value count applies to conversion window only', () => {

--- a/unit-test/background/remote-config.js
+++ b/unit-test/background/remote-config.js
@@ -3,7 +3,6 @@ import browser from 'webextension-polyfill';
 import RemoteConfig from '../../shared/js/background/components/remote-config';
 import messageHandlers from '../../shared/js/background/message-handlers';
 
-
 class MockSettings {
     constructor() {
         this.mockSettingData = new Map();


### PR DESCRIPTION
Implements metrics for A/B/N experiments, as per https://app.asana.com/0/1208889145294658/1208747415972722

Metrics implemented:
- `app_use` (triggered when the background service worker starts up).
- `search` (on SERP landing).
- `brokenSiteReport` (when the user has sent a broken site report).

Note, metrics are not active in Firefox.
