### PR TITLE
TDS (blocklist) override via A/B test

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -46,7 +46,8 @@ settings.ready().then(() => {
 });
 
 const remoteConfig = new RemoteConfig({ settings });
-const tds = new TDSStorage({ settings, remoteConfig });
+const abnMetrics = BUILD_TARGET !== 'firefox' ? new AbnExperimentMetrics({ remoteConfig }) : null;
+const tds = new TDSStorage({ settings, remoteConfig, abnMetrics });
 const devtools = new Devtools({ tds });
 /**
  * @type {{
@@ -72,12 +73,11 @@ const components = {
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools,
     remoteConfig,
+    abnMetrics,
 };
 
 // Chrome-only components
 if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
-    const abnMetrics = new AbnExperimentMetrics({ remoteConfig });
-    components.abnMetrics = abnMetrics;
     components.metrics = [new AppUseMetric({ abnMetrics }), new SearchMetric({ abnMetrics }), new PixelMetric({ abnMetrics })];
     components.fireButton = new FireButton({ settings, tabManager });
 }

--- a/shared/js/background/components/tds.js
+++ b/shared/js/background/components/tds.js
@@ -1,9 +1,11 @@
 import ResourceLoader from './resource-loader.js';
 import constants from '../../../data/constants';
+import { generateRetentionMetrics } from './abn-experiments.js';
 
 /**
  * @typedef {import('../settings.js')} Settings
  * @typedef {import('./remote-config.js').default} RemoteConfig
+ * @typedef {import('./abn-experiments.js').default} AbnExperimentMetrics
  */
 
 const TDS_OVERRIDE_SETTINGS_KEY = 'tdsOverride';
@@ -13,12 +15,14 @@ export default class TDSStorage {
     /**
      * @param {{
      *  settings: Settings,
-     *  remoteConfig: RemoteConfig
+     *  remoteConfig: RemoteConfig,
+     *  abnMetrics: AbnExperimentMetrics?
      * }} opts
      */
-    constructor({ settings, remoteConfig }) {
+    constructor({ settings, remoteConfig, abnMetrics }) {
         this.settings = settings;
         this.remoteConfig = remoteConfig;
+        this.abnMetrics = abnMetrics;
         /** @deprecated config is an alias of remoteConfig */
         this.config = this.remoteConfig;
         this.surrogates = new ResourceLoader(
@@ -58,25 +62,33 @@ export default class TDSStorage {
         const enabledBlocklistOverrides = Object.keys(contentBlockingSubFeatures).filter(
             (k) => k.startsWith('TDS') && this.config.isSubFeatureEnabled(CONTENT_BLOCKING, k),
         );
-        if (enabledBlocklistOverrides.length > 0) {
-            const subFeatureName = enabledBlocklistOverrides[0]
-            const overrideSubFeature = contentBlockingSubFeatures[subFeatureName]
+        if (enabledBlocklistOverrides.length > 0 && this.abnMetrics) {
+            const subFeatureName = enabledBlocklistOverrides[0];
+            const overrideSubFeature = contentBlockingSubFeatures[subFeatureName];
             // If this is enabled via an experiment, the override URL is defined as `${cohortName}Url`, otherwise, for a normal rollout use `nextUrl`.
-            const settingsKey = `${this.remoteConfig.getCohortName(CONTENT_BLOCKING, subFeatureName) || 'next'}Url`
-            const overridePath = overrideSubFeature.settings && overrideSubFeature.settings[settingsKey]
+            const settingsKey = `${this.remoteConfig.getCohortName(CONTENT_BLOCKING, subFeatureName) || 'next'}Url`;
+            const overridePath = overrideSubFeature.settings && overrideSubFeature.settings[settingsKey];
             if (!overridePath) {
-                console.warn(`Couldn't find TDS override path in subfeature settings.`)
-                return
+                console.warn(`Couldn't find TDS override path in subfeature settings.`);
+                return;
             }
             if (overridePath !== this.settings.getSetting(TDS_OVERRIDE_SETTINGS_KEY)) {
                 console.log('TDS URL override changed to ', overridePath);
                 this.settings.updateSetting(TDS_OVERRIDE_SETTINGS_KEY, overridePath);
                 this.tds.checkForUpdates(true);
             }
-            this.remoteConfig.markExperimentEnrolled(CONTENT_BLOCKING, subFeatureName)
+            this.abnMetrics.markExperimentEnrolled(CONTENT_BLOCKING, subFeatureName, [
+                ...generateRetentionMetrics(),
+                {
+                    metric: 'brokenSiteReport',
+                    conversionWindowStart: 0,
+                    conversionWindowEnd: 14,
+                    value: 1,
+                },
+            ]);
         } else if (this.settings.getSetting(TDS_OVERRIDE_SETTINGS_KEY)) {
             // User removed from experiment/rollout, reset TDS override and fetch default list
-            this.settings.removeSetting(TDS_OVERRIDE_SETTINGS_KEY)
+            this.settings.removeSetting(TDS_OVERRIDE_SETTINGS_KEY);
             this.tds.checkForUpdates(true);
         }
     }

--- a/shared/js/background/components/tds.js
+++ b/shared/js/background/components/tds.js
@@ -6,6 +6,9 @@ import constants from '../../../data/constants';
  * @typedef {import('./remote-config.js').default} RemoteConfig
  */
 
+const TDS_OVERRIDE_SETTINGS_KEY = 'tdsOverride';
+const CONTENT_BLOCKING = 'contentBlocking';
+
 export default class TDSStorage {
     /**
      * @param {{
@@ -14,6 +17,7 @@ export default class TDSStorage {
      * }} opts
      */
     constructor({ settings, remoteConfig }) {
+        this.settings = settings;
         this.remoteConfig = remoteConfig;
         /** @deprecated config is an alias of remoteConfig */
         this.config = this.remoteConfig;
@@ -28,14 +32,52 @@ export default class TDSStorage {
         this.tds = new ResourceLoader(
             {
                 name: 'tds',
-                remoteUrl: constants.tdsLists[1].url,
+                remoteUrl: this.getTDSUrl.bind(this),
                 updateIntervalMinutes: 15,
             },
             { settings },
         );
+        this.remoteConfig.onUpdate(this.checkShouldOverrideTDS.bind(this));
     }
 
     ready() {
         return Promise.all([this.tds.ready, this.surrogates.ready, this.remoteConfig.ready]);
+    }
+
+    async getTDSUrl() {
+        await this.config.ready;
+        const overridePath = this.settings.getSetting(TDS_OVERRIDE_SETTINGS_KEY);
+        if (overridePath) {
+            return `https://staticcdn.duckduckgo.com/trackerblocking/${overridePath}`;
+        }
+        return constants.tdsLists[1].url;
+    }
+
+    checkShouldOverrideTDS() {
+        const contentBlockingSubFeatures = this.config.config?.features[CONTENT_BLOCKING].features || {};
+        const enabledBlocklistOverrides = Object.keys(contentBlockingSubFeatures).filter(
+            (k) => k.startsWith('TDS') && this.config.isSubFeatureEnabled(CONTENT_BLOCKING, k),
+        );
+        if (enabledBlocklistOverrides.length > 0) {
+            const subFeatureName = enabledBlocklistOverrides[0]
+            const overrideSubFeature = contentBlockingSubFeatures[subFeatureName]
+            // If this is enabled via an experiment, the override URL is defined as `${cohortName}Url`, otherwise, for a normal rollout use `nextUrl`.
+            const settingsKey = `${this.remoteConfig.getCohortName(CONTENT_BLOCKING, subFeatureName) || 'next'}Url`
+            const overridePath = overrideSubFeature.settings && overrideSubFeature.settings[settingsKey]
+            if (!overridePath) {
+                console.warn(`Couldn't find TDS override path in subfeature settings.`)
+                return
+            }
+            if (overridePath !== this.settings.getSetting(TDS_OVERRIDE_SETTINGS_KEY)) {
+                console.log('TDS URL override changed to ', overridePath);
+                this.settings.updateSetting(TDS_OVERRIDE_SETTINGS_KEY, overridePath);
+                this.tds.checkForUpdates(true);
+            }
+            this.remoteConfig.markExperimentEnrolled(CONTENT_BLOCKING, subFeatureName)
+        } else if (this.settings.getSetting(TDS_OVERRIDE_SETTINGS_KEY)) {
+            // User removed from experiment/rollout, reset TDS override and fetch default list
+            this.settings.removeSetting(TDS_OVERRIDE_SETTINGS_KEY)
+            this.tds.checkForUpdates(true);
+        }
     }
 }


### PR DESCRIPTION
(This PR is stacked on top of #2905).

Allow A/B tests to override the blocklist URL, so we can test blocklist changes side-by-side.