### PR TITLE
Update autofill to 16.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.3.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -175,7 +175,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11668,8 +11668,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#15.1.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#cc7b6b92b6a9af30c2753c144304dd59f70f0bbe",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.3.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.2.0


## Description
Updates Autofill to version [16.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.2.0).

### Autofill 16.2.0 release notes
## What's Changed
* [Matching] Update regex to match for 'confirm password' by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/719
* Update password-related json files (2025-01-06) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/730
* [FormAnalyzer] Use conservative regex for attributes by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/735
* [FormAnalyzer] Don't flip scores on buttons with specific text by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/725
* [FormAnalyzer] add external link check for submit buttons by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/736
* [FormAnalyzer] scoring password hints by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/720
* [Matching] only allow matching on password types by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/740
* [Autofill utils] Form wrapper failsafe documentation by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/741
* [Form] phone and credit card for recategorization by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/733


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/15.1.0...16.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).