### PR TITLE
Refactor broken site report message handlers

### DIFF
--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -29,6 +29,7 @@ import DebuggerConnection from './components/debugger-connection';
 import Devtools from './components/devtools';
 import DNRListeners from './components/dnr-listeners';
 import RemoteConfig from './components/remote-config';
+import DashboardMessaging from './components/dashboard-messaging';
 import initDebugBuild from './devbuild';
 import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
@@ -51,14 +52,17 @@ const remoteConfig = new RemoteConfig({ settings });
 const abnMetrics = BUILD_TARGET !== 'firefox' ? new AbnExperimentMetrics({ remoteConfig }) : null;
 const tds = new TDSStorage({ settings, remoteConfig, abnMetrics });
 const devtools = new Devtools({ tds });
+const dashboardMessaging = new DashboardMessaging({ settings, tds, tabManager })
 /**
  * @type {{
  *  autofill: EmailAutofill;
+ *  dashboardMessaging: DashboardMessaging
  *  omnibox: OmniboxSearch;
  *  fireButton?: FireButton;
  *  internalUser: InternalUserDetector;
  *  tds: TDSStorage;
  *  tabTracking: TabTracker;
+ *  toggleReports: ToggleReports;
  *  trackers: TrackersGlobal;
  *  remoteConfig: RemoteConfig;
  *  abnMetrics: AbnExperimentMetrics?;
@@ -67,11 +71,12 @@ const devtools = new Devtools({ tds });
  */
 const components = {
     autofill: new EmailAutofill({ settings }),
+    dashboardMessaging,
     omnibox: new OmniboxSearch(),
     internalUser: new InternalUserDetector({ settings }),
     tabTracking: new TabTracker({ tabManager, devtools }),
     tds,
-    toggleReports: new ToggleReports(),
+    toggleReports: new ToggleReports({ dashboardMessaging }),
     trackers: new TrackersGlobal({ tds }),
     debugger: new DebuggerConnection({ tds, devtools }),
     devtools,

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -52,7 +52,7 @@ const remoteConfig = new RemoteConfig({ settings });
 const abnMetrics = BUILD_TARGET !== 'firefox' ? new AbnExperimentMetrics({ remoteConfig }) : null;
 const tds = new TDSStorage({ settings, remoteConfig, abnMetrics });
 const devtools = new Devtools({ tds });
-const dashboardMessaging = new DashboardMessaging({ settings, tds, tabManager })
+const dashboardMessaging = new DashboardMessaging({ settings, tds, tabManager });
 /**
  * @type {{
  *  autofill: EmailAutofill;

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -321,6 +321,8 @@ export async function breakageReportForTab({
 export async function sendBreakageReportForCurrentTab({ pixelName, currentTab, category, description, reportFlow }) {
     await settings.ready();
     await tdsStorage.ready('config');
+    // wait for onload callbacks (to ensure that config has been correctly processed)
+    await tdsStorage.config.allLoadingFinished
 
     const tab = currentTab || (await tabManager.getOrRestoreCurrentTab());
     if (!tab) {

--- a/shared/js/background/broken-site-report.js
+++ b/shared/js/background/broken-site-report.js
@@ -10,15 +10,12 @@
  * @typedef {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').DataItemId} DisclosureParamId
  */
 
-const browser = require('webextension-polyfill');
 const load = require('./load');
 const browserWrapper = require('./wrapper');
 const settings = require('./settings');
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string');
 const { getCurrentTab, getURLWithoutQueryString } = require('./utils');
 const { getURL } = require('./pixels');
-const tdsStorage = require('./storage/tds').default;
-const tabManager = require('./tab-manager');
 const maxPixelLength = 7000;
 
 /**
@@ -305,47 +302,6 @@ export async function breakageReportForTab({
     if (reportFlow) brokenSiteParams.set('reportFlow', reportFlow);
 
     return fire(pixelName, brokenSiteParams.toString());
-}
-
-/**
- * Attempt to send a breakage report for the currently focused tab.
- *
- * @param {Object} arg
- * @prop {string} pixelName
- * @prop {import("./classes/tab") | undefined} arg.currentTab
- * @prop {string | undefined} arg.category
- * @prop {string | undefined} arg.description
- * @prop {string | undefined} arg.reportFlow
- *   String detailing the UI flow that this breakage report came from.
- */
-export async function sendBreakageReportForCurrentTab({ pixelName, currentTab, category, description, reportFlow }) {
-    await settings.ready();
-    await tdsStorage.ready('config');
-    // wait for onload callbacks (to ensure that config has been correctly processed)
-    await tdsStorage.config.allLoadingFinished
-
-    const tab = currentTab || (await tabManager.getOrRestoreCurrentTab());
-    if (!tab) {
-        return;
-    }
-
-    const pageParams = (await browser.tabs.sendMessage(tab.id, { getBreakagePageParams: true })) || {};
-
-    const tds = settings.getSetting('tds-etag');
-    const remoteConfigEtag = settings.getSetting('config-etag');
-    const remoteConfigVersion = tdsStorage.config.version;
-
-    return await breakageReportForTab({
-        pixelName,
-        tab,
-        tds,
-        remoteConfigEtag,
-        remoteConfigVersion,
-        category,
-        description,
-        pageParams,
-        reportFlow,
-    });
 }
 
 /**

--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -8,7 +8,7 @@ import { isFireButtonEnabled } from './fire-button';
 /**
  * Message handlers for communication from the dashboard to the extension background.
  *
- * Note, additional message handles for toggle reports is in the separate ToggleReports component.
+ * Note, additional message handlers for toggle reports is in the separate ToggleReports component.
  */
 export default class DashboardMessaging {
     /**

--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -1,0 +1,92 @@
+import browser from 'webextension-polyfill';
+import { breakageReportForTab, getDisclosureDetails } from '../broken-site-report';
+import { dashboardDataFromTab } from '../classes/privacy-dashboard-data';
+import { registerMessageHandler } from '../message-handlers';
+import { getCurrentTab } from '../utils';
+import { isFireButtonEnabled } from './fire-button';
+
+/**
+ * Message handlers for communication from the dashboard to the extension background.
+ *
+ * Note, additional message handles for toggle reports is in the separate ToggleReports component.
+ */
+export default class DashboardMessaging {
+    /**
+     * @param {{
+     *  settings: import('../settings.js');
+     *  tds: import('./tds').default;
+     *  tabManager: import('../tab-manager.js');
+     * }} args
+     */
+    constructor({ settings, tds, tabManager }) {
+        this.settings = settings;
+        this.tds = tds;
+        this.tabManager = tabManager;
+
+        registerMessageHandler('submitBrokenSiteReport', (report) => this.submitBrokenSiteReport(report));
+        registerMessageHandler('getPrivacyDashboardData', this.getPrivacyDashboardData.bind(this));
+        registerMessageHandler('getBreakageFormOptions', getDisclosureDetails);
+    }
+
+    /**
+     * Only the dashboard sends this message, so we import the types from there.
+     * @param {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').BreakageReportRequest} breakageReport
+     * @param {string} [pixelName]
+     * @param {string} [reportFlow]
+     * @returns {Promise<void>}
+     */
+    async submitBrokenSiteReport(breakageReport, pixelName = 'epbf', reportFlow = undefined) {
+        // wait for config and TDS so we can get etags and config version
+        await Promise.all([this.tds.remoteConfig.allLoadingFinished, this.tds.tds.ready]);
+        const { category, description } = breakageReport;
+        const tab = await this.tabManager.getOrRestoreCurrentTab();
+        if (!tab) {
+            return;
+        }
+        const pageParams = (await browser.tabs.sendMessage(tab.id, { getBreakagePageParams: true })) || {};
+        const tds = this.tds.tds.etag;
+        const remoteConfigEtag = this.tds.remoteConfig.etag;
+        const remoteConfigVersion = this.tds.remoteConfig.config?.version;
+        return breakageReportForTab({
+            pixelName,
+            tab,
+            tds,
+            remoteConfigEtag,
+            remoteConfigVersion,
+            category,
+            description,
+            pageParams,
+            reportFlow,
+        });
+    }
+
+    /**
+     * This message is here to ensure the privacy dashboard can render
+     * from a single call to the extension.
+     *
+     * Currently, it will collect data for the current tab and email protection
+     * user data.
+     */
+    async getPrivacyDashboardData(options) {
+        let { tabId } = options;
+        if (tabId === null) {
+            const currentTab = await getCurrentTab();
+            if (!currentTab?.id) {
+                throw new Error('could not get the current tab...');
+            }
+            tabId = currentTab?.id;
+        }
+
+        // Await for storage to be ready; this happens on service worker closing mostly.
+        await this.settings.ready();
+        await this.tds.config.ready;
+
+        const tab = await this.tabManager.getOrRestoreTab(tabId);
+        if (!tab) throw new Error('unreachable - cannot access current tab with ID ' + tabId);
+        const userData = this.settings.getSetting('userData');
+        const fireButtonData = {
+            enabled: isFireButtonEnabled,
+        };
+        return dashboardDataFromTab(tab, userData, fireButtonData);
+    }
+}

--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -8,7 +8,31 @@ import { isFireButtonEnabled } from './fire-button';
 /**
  * Message handlers for communication from the dashboard to the extension background.
  *
- * Note, additional message handlers for toggle reports is in the separate ToggleReports component.
+ * Note, handlers are split over multiple components, and some are not yet encapsulated in a component.
+ *
+ * Implemented in this component:
+ *  - getBreakageFormOptions
+ *  - getPrivacyDashboardData
+ *  - submitBrokenSiteReport
+ *
+ * FireButton component:
+ *  - doBurn
+ *  - getBurnOptions
+ *  - setBurnDefaultOption
+ *
+ * EmailAutofill component:
+ *  - refreshAlias
+ *
+ * ToggleReports component:
+ *  - getToggleReportOptions
+ *  - rejectToggleReport
+ *  - sendToggleReport
+ *  - seeWhatIsSent
+ *
+ * Static message handlers:
+ *  - openOptions
+ *  - search
+ *  - setLists
  */
 export default class DashboardMessaging {
     /**

--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -33,6 +33,8 @@ import { isFireButtonEnabled } from './fire-button';
  *  - openOptions
  *  - search
  *  - setLists
+ *
+ * See https://duckduckgo.github.io/privacy-dashboard/modules/Browser_Extensions_integration.html
  */
 export default class DashboardMessaging {
     /**

--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -37,7 +37,7 @@ export default class DashboardMessaging {
      */
     async submitBrokenSiteReport(breakageReport, pixelName = 'epbf', reportFlow = undefined) {
         // wait for config and TDS so we can get etags and config version
-        await Promise.all([this.tds.remoteConfig.allLoadingFinished, this.tds.tds.ready]);
+        await Promise.all([this.tds.remoteConfig.ready, this.tds.tds.ready]);
         const { category, description } = breakageReport;
         const tab = await this.tabManager.getOrRestoreCurrentTab();
         if (!tab) {

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -1,13 +1,10 @@
 import browser from 'webextension-polyfill';
-import { dashboardDataFromTab } from './classes/privacy-dashboard-data';
-import { getDisclosureDetails, sendBreakageReportForCurrentTab } from './broken-site-report';
 import parseUserAgentString from '../shared-utils/parse-user-agent-string';
 import { getExtensionURL } from './wrapper';
 import { isFeatureEnabled, reloadCurrentTab } from './utils';
 import { ensureClickToLoadRuleActionDisabled } from './dnr-click-to-load';
 import tdsStorage from './storage/tds';
 import { getArgumentsObject } from './helpers/arguments-object';
-import { isFireButtonEnabled } from './components/fire-button';
 import { postPopupMessage } from './popup-messaging';
 import ToggleReports from './components/toggle-reports';
 const utils = require('./utils');
@@ -97,47 +94,6 @@ export function openOptions() {
     } else {
         browser.runtime.openOptionsPage();
     }
-}
-
-/**
- * Only the dashboard sends this message, so we import the types from there.
- * @param {import('@duckduckgo/privacy-dashboard/schema/__generated__/schema.types').BreakageReportRequest} breakageReport
- * @returns {Promise<void>}
- */
-export function submitBrokenSiteReport(breakageReport) {
-    const pixelName = 'epbf';
-    const { category, description } = breakageReport;
-    return sendBreakageReportForCurrentTab({ pixelName, category, description });
-}
-
-/**
- * This message is here to ensure the privacy dashboard can render
- * from a single call to the extension.
- *
- * Currently, it will collect data for the current tab and email protection
- * user data.
- */
-export async function getPrivacyDashboardData(options) {
-    let { tabId } = options;
-    if (tabId === null) {
-        const currentTab = await utils.getCurrentTab();
-        if (!currentTab?.id) {
-            throw new Error('could not get the current tab...');
-        }
-        tabId = currentTab?.id;
-    }
-
-    // Await for storage to be ready; this happens on service worker closing mostly.
-    await settings.ready();
-    await tdsStorage.ready('config');
-
-    const tab = await tabManager.getOrRestoreTab(tabId);
-    if (!tab) throw new Error('unreachable - cannot access current tab with ID ' + tabId);
-    const userData = settings.getSetting('userData');
-    const fireButtonData = {
-        enabled: isFireButtonEnabled,
-    };
-    return dashboardDataFromTab(tab, userData, fireButtonData);
 }
 
 export function getTopBlockedByPages(options) {
@@ -344,9 +300,6 @@ const messageHandlers = {
     allowlistOptIn,
     getBrowser,
     openOptions,
-    submitBrokenSiteReport,
-    getBreakageFormOptions: getDisclosureDetails,
-    getPrivacyDashboardData,
     getTopBlockedByPages,
     getClickToLoadState,
     getYouTubeVideoDetails,

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -279,9 +279,6 @@ export function addDebugFlag(message, sender, req) {
  * @param {(options: any, sender: any, req: any) => any} func
  */
 export function registerMessageHandler(name, func) {
-    if (messageHandlers[name]) {
-        throw new Error(`Attempt to re-register existing message handler ${name}`);
-    }
     messageHandlers[name] = func;
 }
 

--- a/shared/js/background/storage/tds.js
+++ b/shared/js/background/storage/tds.js
@@ -15,6 +15,7 @@ export default {
     _config: { features: {} },
     _tds: { entities: {}, trackers: {}, domains: {}, cnames: {} },
     _surrogates: '',
+    /** @type {import('@duckduckgo/privacy-configuration/schema/config').GenericV4Config} */
     get config() {
         return globalThis.components?.remoteConfig.config || this._config;
     },
@@ -60,7 +61,7 @@ export default {
             return Promise.resolve();
         }
         if (configName && listNames.includes(configName)) {
-            return tdsStorage[configName].ready;
+            return tdsStorage[configName].allLoadingFinished;
         }
         return Promise.all(listNames.map((n) => tdsStorage[n].ready));
     },

--- a/unit-test/background/abn-framework.js
+++ b/unit-test/background/abn-framework.js
@@ -7,22 +7,9 @@ import load from '../../shared/js/background/load';
 import commonParams from '../../pixel-definitions/common_params.json';
 import commonSuffixes from '../../pixel-definitions/common_suffixes.json';
 import experimentPixels from '../../pixel-definitions/pixels/experiments.json';
+import { MockSettings } from '../helpers/mocks';
 
 const ONE_HOUR_MS = 1000 * 60 * 60;
-
-class MockSettings {
-    constructor() {
-        this.mockSettingData = new Map();
-        this.ready = () => Promise.resolve();
-    }
-
-    getSetting(key) {
-        return structuredClone(this.mockSettingData.get(key));
-    }
-    updateSetting(key, value) {
-        this.mockSettingData.set(key, value);
-    }
-}
 
 function constructMockComponents() {
     // clear message handlers to prevent conflict when registering

--- a/unit-test/background/dashboard-messaging.js
+++ b/unit-test/background/dashboard-messaging.js
@@ -83,7 +83,7 @@ describe('DashboardMessaging component', () => {
                     siteUrl: 'https://domain.example/path',
                     tds: tds.tds.etag,
                     remoteConfigEtag: tds.remoteConfig.etag,
-                    remoteConfigVersion: tds.remoteConfig.config.version,
+                    remoteConfigVersion: `${tds.remoteConfig.config.version}`,
                     protectionsState: 'false',
                     ...defaultBrokenSitePixelParams,
                 },
@@ -113,7 +113,7 @@ describe('DashboardMessaging component', () => {
                     siteUrl: 'https://domain2.example/path',
                     tds: tds.tds.etag,
                     remoteConfigEtag: tds.remoteConfig.etag,
-                    remoteConfigVersion: tds.remoteConfig.config.version,
+                    remoteConfigVersion: `${tds.remoteConfig.config.version}`,
                     reportFlow: 'on_protections_off_dashboard_main',
                     // protectionsState is removed from these reports
                     ...defaultBrokenSitePixelParams,

--- a/unit-test/background/dashboard-messaging.js
+++ b/unit-test/background/dashboard-messaging.js
@@ -1,0 +1,120 @@
+import browser from 'webextension-polyfill';
+import load from '../../shared/js/background/load';
+import tabManager from '../../shared/js/background/tab-manager';
+import DashboardMessaging from '../../shared/js/background/components/dashboard-messaging';
+import { MockSettings, mockTdsStorage } from '../helpers/mocks';
+import { _formatPixelRequestForTesting } from '../../shared/js/shared-utils/pixels';
+
+const defaultBrokenSitePixelParams = {
+    upgradedHttps: 'false',
+    urlParametersRemoved: 'false',
+    ctlYouTube: 'false',
+    ctlFacebookPlaceholderShown: 'false',
+    ctlFacebookLogin: 'false',
+    performanceWarning: 'false',
+    userRefreshCount: '0',
+    jsPerformance: 'undefined',
+    locale: 'en-US',
+    errorDescriptions: '[]',
+    openerContext: 'external',
+    extensionVersion: '1234.56',
+    ignoreRequests: '',
+    blockedTrackers: '',
+    surrogates: '',
+    noActionRequests: '',
+    adAttributionRequests: '',
+    ignoredByUserRequests: '',
+};
+
+describe('DashboardMessaging component', () => {
+    describe('submitBrokenSiteReport', () => {
+        let currentTabDetails = null;
+        const actualSentReports = [];
+        /** @type {DashboardMessaging} */
+        let dashboardMessaging = null;
+        /** @type {import('../../shared/js/background/components/tds').default} */
+        let tds = null;
+
+        beforeEach(() => {
+            currentTabDetails = null;
+            actualSentReports.length = 0;
+            spyOn(browser.tabs, 'sendMessage').and.callFake((tabId, message) => {
+                if (message.getBreakagePageParams) {
+                    return Promise.resolve({});
+                }
+            });
+            spyOn(load, 'url').and.callFake((url) => {
+                const pixel = _formatPixelRequestForTesting(url);
+                if (pixel?.name?.startsWith('epbf') || pixel?.name?.startsWith('protection-toggled-off-breakage-report')) {
+                    actualSentReports.push(pixel);
+                }
+            });
+            spyOn(browser.tabs, 'query').and.callFake(() => {
+                const result = [];
+
+                if (currentTabDetails) {
+                    result.push(currentTabDetails);
+                }
+
+                return Promise.resolve(result);
+            });
+            const settings = new MockSettings();
+            tds = mockTdsStorage(settings);
+            dashboardMessaging = new DashboardMessaging({
+                settings,
+                tds,
+                tabManager,
+            });
+        });
+
+        it('sends a broken site report pixel with provide category and description', async () => {
+            currentTabDetails = {
+                id: 123,
+                url: 'https://domain.example/path?param=value',
+            };
+            tabManager.create(currentTabDetails);
+            await dashboardMessaging.submitBrokenSiteReport({ category: 'foo', description: 'ben' });
+            expect(actualSentReports).toHaveSize(1);
+            expect(actualSentReports[0]).toEqual({
+                name: 'epbf_chrome',
+                params: {
+                    category: 'foo',
+                    description: 'ben',
+                    siteUrl: 'https://domain.example/path',
+                    tds: tds.tds.etag,
+                    remoteConfigEtag: tds.remoteConfig.etag,
+                    remoteConfigVersion: tds.remoteConfig.config.version,
+                    protectionsState: 'false',
+                    ...defaultBrokenSitePixelParams,
+                },
+            });
+        });
+
+        it('does not send a pixel if there is no active tab', async () => {
+            await dashboardMessaging.submitBrokenSiteReport({ category: 'foo', description: 'ben' });
+            expect(actualSentReports).toHaveSize(0);
+        });
+
+        it('can send toggle reports', async () => {
+            currentTabDetails = {
+                id: 123,
+                url: 'https://domain.example/path?param=value',
+            };
+            tabManager.create(currentTabDetails);
+            await dashboardMessaging.submitBrokenSiteReport({}, 'protection-toggled-off-breakage-report', 'on_protections_off_dashboard_main');
+            expect(actualSentReports).toHaveSize(1);
+            expect(actualSentReports[0]).toEqual({
+                name: 'protection-toggled-off-breakage-report_chrome',
+                params: {
+                    siteUrl: 'https://domain.example/path',
+                    tds: tds.tds.etag,
+                    remoteConfigEtag: tds.remoteConfig.etag,
+                    remoteConfigVersion: tds.remoteConfig.config.version,
+                    reportFlow: 'on_protections_off_dashboard_main',
+                    // protectionsState is removed from these reports
+                    ...defaultBrokenSitePixelParams,
+                },
+            });
+        });
+    });
+});

--- a/unit-test/background/dashboard-messaging.js
+++ b/unit-test/background/dashboard-messaging.js
@@ -98,15 +98,19 @@ describe('DashboardMessaging component', () => {
         it('can send toggle reports', async () => {
             currentTabDetails = {
                 id: 123,
-                url: 'https://domain.example/path?param=value',
+                url: 'https://domain2.example/path?param=value',
             };
             tabManager.create(currentTabDetails);
-            await dashboardMessaging.submitBrokenSiteReport({}, 'protection-toggled-off-breakage-report', 'on_protections_off_dashboard_main');
+            await dashboardMessaging.submitBrokenSiteReport(
+                {},
+                'protection-toggled-off-breakage-report',
+                'on_protections_off_dashboard_main',
+            );
             expect(actualSentReports).toHaveSize(1);
             expect(actualSentReports[0]).toEqual({
                 name: 'protection-toggled-off-breakage-report_chrome',
                 params: {
-                    siteUrl: 'https://domain.example/path',
+                    siteUrl: 'https://domain2.example/path',
                     tds: tds.tds.etag,
                     remoteConfigEtag: tds.remoteConfig.etag,
                     remoteConfigVersion: tds.remoteConfig.config.version,

--- a/unit-test/background/toggle-reports.js
+++ b/unit-test/background/toggle-reports.js
@@ -8,11 +8,8 @@ describe('ToggleReports', () => {
     let currentTabDetails = null;
     let currentTimestamp = 1;
     let settingsStorage = null;
-    const toggleReports = new ToggleReports({
-        dashboardMessaging: {
-            submitBrokenSiteReport: () => {},
-        },
-    });
+    /** @type {ToggleReports} */
+    let toggleReports = null;
     /** @type {jasmine.Spy} */
     let submittedReports;
     let toggleReportsConfig = null;
@@ -63,14 +60,19 @@ describe('ToggleReports', () => {
             callback();
         });
         spyOn(Date, 'now').and.callFake(() => currentTimestamp);
-
-        submittedReports = spyOn(toggleReports.dashboardMessaging, 'submitBrokenSiteReport');
     });
 
     beforeEach(() => {
         currentTabDetails = null;
         currentTimestamp = 1;
         settingsStorage.clear();
+
+        toggleReports = new ToggleReports({
+            dashboardMessaging: {
+                submitBrokenSiteReport: () => {},
+            },
+        });
+        submittedReports = spyOn(toggleReports.dashboardMessaging, 'submitBrokenSiteReport');
     });
 
     it('toggleReportStarted()', async () => {

--- a/unit-test/data/extension-config.json
+++ b/unit-test/data/extension-config.json
@@ -1,5 +1,5 @@
 {
-    "version": "2021.6.7",
+    "version": 1738568676812,
     "readme": "https://github.com/duckduckgo/privacy-configuration",
     "features": {
         "adClickAttribution": {

--- a/unit-test/helpers/mocks.js
+++ b/unit-test/helpers/mocks.js
@@ -27,7 +27,7 @@ export function mockTdsStorage(settings) {
     const settingsReadyPromise = new Promise((resolve) => {
         settingsResolve = resolve;
     });
-    settings.ready = () => settingsReadyPromise
+    settings.ready = () => settingsReadyPromise;
     const etags = require('../../shared/data/etags.json');
     const remoteConfig = new RemoteConfig({ settings });
     remoteConfig._loadFromURL = () =>
@@ -44,7 +44,7 @@ export function mockTdsStorage(settings) {
     tds.surrogates._loadFromURL = () =>
         Promise.resolve({
             contents: require('./../data/surrogates.js').surrogates,
-            etag: 'surrogates'
+            etag: 'surrogates',
         });
     settingsResolve();
     return tds;

--- a/unit-test/helpers/mocks.js
+++ b/unit-test/helpers/mocks.js
@@ -1,0 +1,51 @@
+import RemoteConfig from '../../shared/js/background/components/remote-config';
+import TDSStorage from '../../shared/js/background/components/tds';
+
+export class MockSettings {
+    constructor() {
+        this.mockSettingData = new Map();
+        this.ready = () => Promise.resolve();
+    }
+
+    getSetting(key) {
+        return structuredClone(this.mockSettingData.get(key));
+    }
+    updateSetting(key, value) {
+        this.mockSettingData.set(key, value);
+    }
+    removeSetting(name) {
+        this.mockSettingData.delete(name);
+    }
+    clearSettings() {
+        this.mockSettingData.clear();
+    }
+}
+
+export function mockTdsStorage(settings) {
+    // delay settings ready until we have fetch mocking in place
+    let settingsResolve = null;
+    const settingsReadyPromise = new Promise((resolve) => {
+        settingsResolve = resolve;
+    });
+    settings.ready = () => settingsReadyPromise
+    const etags = require('../../shared/data/etags.json');
+    const remoteConfig = new RemoteConfig({ settings });
+    remoteConfig._loadFromURL = () =>
+        Promise.resolve({
+            contents: require('./../data/extension-config.json'),
+            etag: etags['config-etag'],
+        });
+    const tds = new TDSStorage({ settings, remoteConfig });
+    tds.tds._loadFromURL = () =>
+        Promise.resolve({
+            contents: require('./../data/tds.json'),
+            etag: etags['current-mv3-tds-etag'],
+        });
+    tds.surrogates._loadFromURL = () =>
+        Promise.resolve({
+            contents: require('./../data/surrogates.js').surrogates,
+            etag: 'surrogates'
+        });
+    settingsResolve();
+    return tds;
+}


### PR DESCRIPTION

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Some breakage reports were coming through with config version `undefined` on Firefox (https://app.asana.com/0/0/1209244730607066/f). This is likely caused by a race condition in the breakage report flow if the background is not fully loaded yet.

To fix this, this PR:
- Moves the sendBreakageReport function to a component.
- Removes static access to page context information, using components instead.
- Allows us to wait for the correct config lifecycle event before getting config version.
- Updates the toggle reports component to use this new entrypoint for sending reports.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
