### PR TITLE
Update autofill to 16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.3.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -311,7 +311,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#47c26dc32b94cdbcef3e6157497147917678c25c",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11880,8 +11880,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.2.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#47c26dc32b94cdbcef3e6157497147917678c25c",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#cc7b6b92b6a9af30c2753c144304dd59f70f0bbe",
@@ -11964,7 +11964,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#5683679b32808fe3320c2f80573578830158a6d3",
             "integrity": "sha512-AVYAHcaTctYdBfRi1Io5pJ0jjSDXKMLVNvCfPNDtP2dNcKEcf0wa8oQ+gGIQMZHvTxUH3eFOLqMRxv79vDiNgA==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#5683679b32808fe3320c2f80573578830158a6d3"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#8.2.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -11976,7 +11976,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#2a34ad71ceac331459793188a95398492bef99d9",
             "integrity": "sha512-EcLBmT7baXVA0HIzWvzIWPVxlplwZwKRrAG1flt1JXnTjByuzDc3PLFrXnHPL9oDd3vH6Llvxb020MyNImKfzQ==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#2a34ad71ceac331459793188a95398492bef99d9"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.3.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0


## Description
Updates Autofill to version [16.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0).

### Autofill 16.1.0 release notes
Test release for the Apple monorepo

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).