### PR TITLE
Update autofill to 17.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.18.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -311,7 +311,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11883,13 +11883,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#676d42679296a175169e433f2332e55644151edd",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#16.2.0"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#874b27ad51d1784c934760c85493f78e609c4409",
             "integrity": "sha512-EeumZzb+LoTbsudKM9M3DJO+DMLSTntW0cwrGuFqDdzZ92W5hfrbLiCh7vMjtmfMY8sWDYiVh0cOwdsuAub2PA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#874b27ad51d1784c934760c85493f78e609c4409",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#7.18.0",
             "requires": {
                 "immutable-json-patch": "^6.0.1"
             }
@@ -11967,7 +11967,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#c05d7ce7debe45593bfd9759d6bcae0cd740c52f",
             "integrity": "sha512-jptp3u0i8GOVHo/2AHDA3+NqHzDFso2/7Knb8kFM0Q29pglU14Ns/x9Z+l/5K9mPEsIs0pcEFWjvxuahRnJv5A==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#c05d7ce7debe45593bfd9759d6bcae0cd740c52f"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#8.4.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -11979,7 +11979,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#658c8a694724c01fee523c9f586a5e5a56637d6f",
             "integrity": "sha512-uWX9xitvQ+xGDoUfggog5endAWG2ro3IsMurd6KAd1YFvVBu+tX8VQp7rawidJZpbtBySIUPeolkSAUkQ3mHCw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#658c8a694724c01fee523c9f586a5e5a56637d6f"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.18.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.0


## Description
Updates Autofill to version [17.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.0).

### Autofill 17.0.0 release notes
## What's Changed
* [Workflow] Upgrade ubunutu in workflows by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/767
* Update password-related json files (2025-03-05) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/768
* Update password-related json files (2025-03-07) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/771
* build: drop apple-specific assets by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/772
* build: migrate to esbuild by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/327


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/16.2.2...17.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).