### PR TITLE
chrome mv3: translate extension name in French

### DIFF
--- a/browsers/chrome/_locales/fr/messages.json
+++ b/browsers/chrome/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Search & Tracker Protection",
+    "message" : "DuckDuckGo Recherche & Protection contre les Traqueurs",
     "description" : "Le titre de l'extension, affiché dans la boutique en ligne"
   },
   "appDesc" : {


### PR DESCRIPTION
## Description:

`appName` is not translated in French, it's a copy from `en` value. So I brought a translation.

## Steps to test this PR:

No need, only translation is touched.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
