### PR TITLE
Update autofill to 17.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.13.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -316,7 +316,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -11836,8 +11836,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d26d4a628cbd50dd765984de6feab44cff66f85f",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^17.7.2"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.13.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.2.0


## Description
Updates Autofill to version [17.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.2.0).

### Autofill 17.2.0 release notes
## What's Changed
* Update password-related json files (2025-04-15) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/797
* [SiteSpecificFixes] Add support for input types by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/795
* [SiteSpecificFeature] Add readme for site-specific-feature by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/799
* build: add missing precompile-regexes step by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/807
* build: exclude generated regex folder from watch by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/808
* Update password-related json files (2025-05-05) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/806
* Update password-related json files (2025-05-06) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/810
* Add credit card and identity for Windows by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/796
* Ema/cc forms fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/809
* Recategorize password variant by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/818
* Update password-related json files (2025-05-16) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/822


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/17.1.0...17.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).