### PR TITLE
Update autofill to 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -313,7 +313,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7532135989abb6ddbde48632b7222e0abed7d253",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12321,13 +12321,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#7532135989abb6ddbde48632b7222e0abed7d253",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#18.1.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2e1d9f562e98d4a6caf8eaedf80e168eadf297da",
             "integrity": "sha512-7GiE94Ri65Nw/hgrP+2waR3T1BqtFdKLf8fFqGDNpw1lvBanMM1T6WK4B0yYuZOX6kRprlhUFmu2Ud7FQxxFtA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#2e1d9f562e98d4a6caf8eaedf80e168eadf297da",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#10.1.0",
             "requires": {
                 "immutable-json-patch": "^6.0.1",
                 "urlpattern-polyfill": "^10.1.0"
@@ -12452,7 +12452,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#fd3b7e2d8194e265c537f227c706de7db3085da5",
             "integrity": "sha512-ioMXEiMtdurk4nDrANxe9mLqVfu4FYjPSIQlkjzIsSncAnqAPpc2J6cyOoOYcg/NA448ByoYLEm6stLuKorvHg==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#fd3b7e2d8194e265c537f227c706de7db3085da5"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#9.4.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -12464,7 +12464,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
             "integrity": "sha512-IrVXzW1Gyilt4Rqy77j7hcMPS8/ldFvsnqFMnQpqGP5MaQXpzOQN+thLUcxgMU/AJL6u3TO/GIxYdTgS9YQMPw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#47a71fcdbd1277bc2020d1239945ca6bdb22c74d"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",
@@ -18249,7 +18249,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#74d9a2a3e931adf782b444ce07b0030a6663baad",
             "integrity": "sha512-F4qjK0GBlRu1hrhizEKBkt3hqSQciaQTl/dR7i3+5ybGwR728c/C2GteYSabto+XPEte65hxLp7FiOqt+ynxjg==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#74d9a2a3e931adf782b444ce07b0030a6663baad",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.3.5",
             "requires": {
                 "@duckduckgo/content-scope-scripts": "git+https://git@github.com/duckduckgo/content-scope-scripts#9.8.0",
                 "body-parser": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.1.0


## Description
Updates Autofill to version [18.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.1.0).

### Autofill 18.1.0 release notes
## What's Changed
* Feat: enable iOS QuickType by toggling autocomplete on input focus/blur by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/860
* Fix: add "date" to Skip and add immitracker form to the tests by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/866
* Chore: Update node and dependencies by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/850
* Chore: Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/863
* Chore: Speed up playwright in CI by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/854

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.0.0...18.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).