### PR TITLE
Update autofill to 18.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -313,7 +313,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21abb6f36a0cefc238c7366c50144ca792ada305",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12321,13 +12321,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#21abb6f36a0cefc238c7366c50144ca792ada305",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#18.2.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a382fa493c5309a5399b35ef5c49cf2895dcf367",
             "integrity": "sha512-VsPRWh+jQMJIZ/r235d/OQ6AFJqmtPAQUbS+XzDyqNEnZoS4NGEfRlFT1zLKkwH2lhY54dqPitjaf1CNKWkvQQ==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#a382fa493c5309a5399b35ef5c49cf2895dcf367",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#10.6.0",
             "requires": {
                 "immutable-json-patch": "^6.0.1",
                 "urlpattern-polyfill": "^10.1.0"
@@ -12452,7 +12452,7 @@
         "@duckduckgo/privacy-dashboard": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#fd3b7e2d8194e265c537f227c706de7db3085da5",
             "integrity": "sha512-ioMXEiMtdurk4nDrANxe9mLqVfu4FYjPSIQlkjzIsSncAnqAPpc2J6cyOoOYcg/NA448ByoYLEm6stLuKorvHg==",
-            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#fd3b7e2d8194e265c537f227c706de7db3085da5"
+            "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#9.4.0"
         },
         "@duckduckgo/privacy-grade": {
             "version": "file:packages/privacy-grade",
@@ -12464,7 +12464,7 @@
         "@duckduckgo/privacy-reference-tests": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
             "integrity": "sha512-IrVXzW1Gyilt4Rqy77j7hcMPS8/ldFvsnqFMnQpqGP5MaQXpzOQN+thLUcxgMU/AJL6u3TO/GIxYdTgS9YQMPw==",
-            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#47a71fcdbd1277bc2020d1239945ca6bdb22c74d"
+            "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {
             "version": "git+ssh://git@github.com/duckduckgo/tracker-surrogates.git#0528e3226df15b1a3e319ad68ef76612a8f26623",
@@ -18249,7 +18249,7 @@
         "privacy-test-pages": {
             "version": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#74d9a2a3e931adf782b444ce07b0030a6663baad",
             "integrity": "sha512-F4qjK0GBlRu1hrhizEKBkt3hqSQciaQTl/dR7i3+5ybGwR728c/C2GteYSabto+XPEte65hxLp7FiOqt+ynxjg==",
-            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#74d9a2a3e931adf782b444ce07b0030a6663baad",
+            "from": "privacy-test-pages@github:duckduckgo/privacy-test-pages#1.3.5",
             "requires": {
                 "@duckduckgo/content-scope-scripts": "git+https://git@github.com/duckduckgo/content-scope-scripts#9.8.0",
                 "body-parser": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.2.0


## Description
Updates Autofill to version [18.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.2.0).

### Autofill 18.2.0 release notes
## What's Changed
* fix scanner debugging by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/611
* [GH Action] Reduce dependabot frequency by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/871
* Fix: acehardware.com - update submitButtonSelector ignoring aria-label="clear" by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/877
* build(deps-dev): bump eslint from 9.28.0 to 9.30.1 by @dependabot[bot] in https://github.com/duckduckgo/duckduckgo-autofill/pull/873
* [CredentialsImport] Credentials import support for iOS and Android by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/823
* [site-specific-fixes] Move thresholds to site-specific-fixes by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/832
* Chore: UI refresh — Update Icons by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/876
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/879
* [CredentialsImport] Only show prompts on empty input by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/878
* [Windows] Call setSize after font load finishes by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/864
* [HTMLTooltip] type htmltooltipoptions by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/880


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.1.0...18.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).