### PR TITLE
Update autofill to 18.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -314,7 +314,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#252082be808ece0ab91d60a27e18bfcf10dcec1b",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12322,8 +12322,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#252082be808ece0ab91d60a27e18bfcf10dcec1b",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#18.3.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a382fa493c5309a5399b35ef5c49cf2895dcf367",

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
+        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.4.0",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
-        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
         "deep-freeze": "0.0.1",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.0


## Description
Updates Autofill to version [18.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.0).

### Autofill 18.3.0 release notes
## What's Changed
* [Form] Don't reset value, if the target input is non-ddg or unknown by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/748
* add qobuz.com example and fix it's cardName skip issue by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/882
* [Matching] Tweak regex to match "access settings" string to login by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/883
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/886
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/888
* [Scanner] Check if target is in shadow root for forced form by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/885
* [Windows prompt] set auto height on windows by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/893
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/894
* [Bundle size] GH Action for reporting bundle size by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/896


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.2.0...18.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).