### PR TITLE
Update autofill to 18.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.7.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -314,7 +314,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#123b64c7c78f492a1a3e6f60a8f891557a23a2eb",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12088,13 +12088,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#123b64c7c78f492a1a3e6f60a8f891557a23a2eb",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#18.3.1"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#21f48aee920f05e158615e5d09941bdbf0277287",
             "integrity": "sha512-t65+WmJlYuxhxfkZEoRgzr+P5u4EFKkogH/7jofpJOmUmJmyYUl2vFydKseWEIkQGspVpP7KwO9FU4awMCabKg==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#21f48aee920f05e158615e5d09941bdbf0277287",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#11.7.0",
             "requires": {
                 "immutable-json-patch": "^6.0.2",
                 "urlpattern-polyfill": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.7.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
+        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.4.0",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
-        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
         "deep-freeze": "0.0.1",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1


## Description
Updates Autofill to version [18.3.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1).

### Autofill 18.3.1 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/899
* [Autosubmit/Autoprompt] Force autoprompt and submit on accounts.google.com by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/901


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.3.0...18.3.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).