### PR TITLE
Remove failing ATB majorVersion < 500 test

### DIFF
--- a/unit-test/background/atb-utils.js
+++ b/unit-test/background/atb-utils.js
@@ -7,12 +7,8 @@ describe('utils.getCurrentATB', () => {
         expect(result.majorVersion % 1).toEqual(0);
     });
 
-    it('should return a majorVersion greater than 25', function () {
-        expect(result.majorVersion).toBeGreaterThan(25);
-    });
-
-    it('should return a majorVersion less than 500', function () {
-        expect(result.majorVersion).toBeLessThan(500);
+    it('should return a majorVersion greater than 500', function () {
+        expect(result.majorVersion).toBeGreaterThan(500);
     });
 
     it('should return a minorVersion from 1-7', function () {


### PR DESCRIPTION
This test was first added around five years ago[1], and since the majorVersion
seems to be generated based on the current date relative to the test date, it
has started exceeding 500. Let's just remove it.

While we're at it, let's bump the floor check since we know majorVersion is now
above 500.

1 - https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/9a43e2da975c83c2aecabff3f9c14b4a2b9d540e

**Reviewer:** @moollaza 