### PR TITLE
Get declarativeNetRequest reference tests running reliably

### DIFF
--- a/packages/ddg2dnr/puppeteerInterface.js
+++ b/packages/ddg2dnr/puppeteerInterface.js
@@ -14,7 +14,8 @@ class PuppeteerInterface {
         // Open the browser, installing the test extension.
         this.browser = await puppeteer.launch({
             headless: 'chrome',
-            args: ['--disable-extensions-except=' + testExtensionPath, '--load-extension=' + testExtensionPath],
+            pipe: true,
+            enableExtensions: [testExtensionPath],
         });
 
         // Find the background ServiceWorker for the extension.


### PR DESCRIPTION
The declarativeNetRequest reference tests were timing out sometimes, waiting for
Puppeteer to find the test extension's background ServiceWorker. It seems we can
improve that by making use of the `pipe` and `enableExtensions` options[1].

1 - https://pptr.dev/guides/chrome-extensions#service-worker-mv3

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 