### PR TITLE
Fix case sensitive matching of declarativeNetRequest rules

### DIFF
--- a/packages/ddg2dnr/lib/utils.js
+++ b/packages/ddg2dnr/lib/utils.js
@@ -237,14 +237,19 @@ function generateDNRRule({
             delete dnrRule.condition.requestDomains;
         }
 
-        if (!matchCase) {
-            dnrRule.condition.isUrlFilterCaseSensitive = false;
+        // urlFilter rules default to case insensitive matching.
+        if (matchCase) {
+            dnrRule.condition.isUrlFilterCaseSensitive = true;
         }
     } else if (regexFilter) {
         dnrRule.condition.regexFilter = regexFilter;
 
-        if (!matchCase) {
-            dnrRule.condition.isUrlFilterCaseSensitive = false;
+        // regexFilter rules also default to case insensitive matching, despite
+        // the API docs implying otherwise. Also note that
+        // isUrlFilterCaseSensitive applies to both urlFilter and regexFilter
+        // conditions.
+        if (matchCase) {
+            dnrRule.condition.isUrlFilterCaseSensitive = true;
         }
     }
 

--- a/packages/ddg2dnr/test/ampProtection.js
+++ b/packages/ddg2dnr/test/ampProtection.js
@@ -86,7 +86,6 @@ describe('AMP link protection', () => {
                         redirect: { regexSubstitution: 'https://\\1' },
                     },
                     condition: {
-                        isUrlFilterCaseSensitive: false,
                         regexFilter: '^https?:\\/\\/(?:w{3}\\.)?google\\..{2,}\\/amp\\/s\\/(.+)$',
                         resourceTypes: ['main_frame'],
                         excludedInitiatorDomains: ['exception1.example', 'exception2.example'],
@@ -101,7 +100,6 @@ describe('AMP link protection', () => {
                         redirect: { regexSubstitution: 'https://\\1' },
                     },
                     condition: {
-                        isUrlFilterCaseSensitive: false,
                         regexFilter: '^https?:\\/\\/.+ampproject\\.org\\/.\\/s\\/(.+)$',
                         resourceTypes: ['main_frame'],
                         excludedInitiatorDomains: ['exception1.example', 'exception2.example'],

--- a/packages/ddg2dnr/test/matchCase.js
+++ b/packages/ddg2dnr/test/matchCase.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+const { actualMatchOutcome } = require('./utils/helpers');
+const { generateDNRRule } = require('../lib/utils');
+
+/**
+ * @typedef {import('./utils/helpers').testFunction} testFunction
+ */
+
+describe('Case sensitive matching', /** @this {testFunction} */ async function () {
+    it('Enforces matchCase correctly', /** @this {testFunction} */ async function () {
+        const ruleset = [
+            generateDNRRule({
+                id: 1001,
+                priority: 1,
+                actionType: 'block',
+                urlFilter: '||domain.example/ignorecase1BLOCK',
+                matchCase: false,
+            }),
+            generateDNRRule({
+                id: 1002,
+                priority: 1,
+                actionType: 'block',
+                urlFilter: '||domain.example/matchcase2BLOCK',
+                matchCase: true,
+            }),
+            generateDNRRule({
+                id: 1003,
+                priority: 1,
+                actionType: 'block',
+                regexFilter: 'https://domain.example/[i]gnorecase3BLOCK',
+                matchCase: false,
+            }),
+            generateDNRRule({
+                id: 1004,
+                priority: 1,
+                actionType: 'block',
+                regexFilter: 'https://domain.example/m[a]tchcase4BLOCK',
+                matchCase: true,
+            }),
+        ];
+        await this.browser.addRules(ruleset);
+
+        const tests = [
+            { requestUrl: 'https://domain.example/ignorecase1block', expectedAction: 'block' },
+            { requestUrl: 'https://domain.example/ignorecase1BLOCK', expectedAction: 'block' },
+            { requestUrl: 'https://domain.example/matchcase2block', expectedAction: 'ignore' },
+            { requestUrl: 'https://domain.example/matchcase2BLOCK', expectedAction: 'block' },
+            { requestUrl: 'https://domain.example/ignorecase3block', expectedAction: 'block' },
+            { requestUrl: 'https://domain.example/ignorecase3BLOCK', expectedAction: 'block' },
+            { requestUrl: 'https://domain.example/matchcase4block', expectedAction: 'ignore' },
+            { requestUrl: 'https://domain.example/matchcase4BLOCK', expectedAction: 'block' },
+        ];
+
+        for (const { requestUrl, expectedAction } of tests) {
+            const { actualAction } = await actualMatchOutcome(this.browser, { requestUrl, websiteUrl: 'https://website.example' });
+            assert.equal(actualAction, expectedAction, requestUrl);
+        }
+    });
+});

--- a/packages/ddg2dnr/test/referenceTests.js
+++ b/packages/ddg2dnr/test/referenceTests.js
@@ -8,6 +8,10 @@ const { generateTdsRuleset } = require('../lib/tds');
 const { generateCookieBlockingRuleset } = require('../lib/cookies');
 const { generateTrackerAllowlistRules } = require('../lib/trackerAllowlist');
 
+/**
+ * @typedef {import('./utils/helpers').testFunction} testFunction
+ */
+
 function referenceTestPath(...args) {
     return require.resolve(path.join('@duckduckgo/privacy-reference-tests', ...args));
 }
@@ -28,14 +32,6 @@ function* testCases(referenceTests) {
         }
     }
 }
-
-/**
- * @typedef {{
- *  beforeAll: (fn: () => Promise<any>) => Void;
- *  beforeEach: (fn: () => Promise<any>) => Void;
- *  browser: import('../puppeteerInterface').PuppeteerInterface;
- * }} testFunction
- */
 
 describe('Reference Tests', /** @this {testFunction} */ () => {
     it('TR-domain-matching', /** @this {testFunction} */ async function () {

--- a/packages/ddg2dnr/test/trackerAllowlist.js
+++ b/packages/ddg2dnr/test/trackerAllowlist.js
@@ -170,7 +170,6 @@ describe('Tracker Allowlist', () => {
                     },
                     condition: {
                         urlFilter: '||domain.invalid/path',
-                        isUrlFilterCaseSensitive: false,
                         excludedRequestDomains: ['subdomain.domain.invalid', 'another.subdomain.domain.invalid'],
                     },
                 },
@@ -182,10 +181,6 @@ describe('Tracker Allowlist', () => {
                     },
                     condition: {
                         urlFilter: '||subdomain.domain.invalid',
-                        // Note: Case-insensitive matching isn't required
-                        //       here. It would be nice to improve this case
-                        //       in the future.
-                        isUrlFilterCaseSensitive: false,
                         excludedRequestDomains: ['another.subdomain.domain.invalid'],
                     },
                 },
@@ -197,10 +192,6 @@ describe('Tracker Allowlist', () => {
                     },
                     condition: {
                         urlFilter: '12345',
-                        // Note: Case-insensitive matching isn't required
-                        //       here. It would be nice to improve this case
-                        //       in the future.
-                        isUrlFilterCaseSensitive: false,
                         requestDomains: ['another.subdomain.domain.invalid'],
                         initiatorDomains: ['different-initiator.invalid'],
                     },
@@ -213,7 +204,6 @@ describe('Tracker Allowlist', () => {
                     },
                     condition: {
                         urlFilter: '||another.subdomain.domain.invalid',
-                        isUrlFilterCaseSensitive: false,
                         initiatorDomains: ['initiator1.invalid', 'initiator2.invalid'],
                     },
                 },
@@ -225,7 +215,6 @@ describe('Tracker Allowlist', () => {
                     },
                     condition: {
                         urlFilter: 'subdomain.different-tracker.invalid/path',
-                        isUrlFilterCaseSensitive: false,
                         requestDomains: ['different-tracker.invalid'],
                     },
                 },

--- a/packages/ddg2dnr/test/utils.js
+++ b/packages/ddg2dnr/test/utils.js
@@ -265,12 +265,9 @@ describe('generateDNRRule', () => {
                 urlFilter: 'abc',
             });
 
-            // By default, Tracker Blocking rules are case insensitive, and by
-            // default declarativeNetRequest rules are case sensitive. So,
-            // unless specified the `isUrlFilterCaseSensitive: false` option
-            // must be included.
+            // By default, Tracker Blocking rules match case insensitively, and
+            // so do declarativeNetRequest urlFilter rule conditions.
             await assert.deepEqual(condition, {
-                isUrlFilterCaseSensitive: false,
                 urlFilter: 'abc',
             });
         }
@@ -285,6 +282,7 @@ describe('generateDNRRule', () => {
 
             await assert.deepEqual(condition, {
                 urlFilter: 'abc',
+                isUrlFilterCaseSensitive: true,
             });
         }
 
@@ -297,7 +295,6 @@ describe('generateDNRRule', () => {
             });
 
             await assert.deepEqual(condition, {
-                isUrlFilterCaseSensitive: false,
                 urlFilter: 'abc',
                 requestDomains: ['example.invalid'],
             });
@@ -317,7 +314,6 @@ describe('generateDNRRule', () => {
             //       logic was designed for a specific use-case (tds.json) and
             //       will likely need to be expanded in the future.
             await assert.deepEqual(condition, {
-                isUrlFilterCaseSensitive: false,
                 urlFilter: '||example.invalid/abc',
             });
         }
@@ -338,12 +334,12 @@ describe('generateDNRRule', () => {
                 priority: 10,
                 actionType: 'block',
                 regexFilter: 'abc',
+                matchCase: false,
             });
 
-            // Like urlFilter above, the `isUrlFilterCaseSensitive: false`
-            // option is necessary unless case sensitive matching is requested.
+            // As with urlFilter above, `isUrlFilterCaseSensitive: false` is the
+            // the default and can be omitted for regexFilter rules.
             await assert.deepEqual(condition, {
-                isUrlFilterCaseSensitive: false,
                 regexFilter: 'abc',
             });
         }
@@ -358,6 +354,7 @@ describe('generateDNRRule', () => {
 
             await assert.deepEqual(condition, {
                 regexFilter: 'abc',
+                isUrlFilterCaseSensitive: true,
             });
         }
     });

--- a/packages/ddg2dnr/test/utils/helpers.js
+++ b/packages/ddg2dnr/test/utils/helpers.js
@@ -1,4 +1,12 @@
 /**
+ * @typedef {{
+ *  beforeAll: (fn: () => Promise<any>) => Void;
+ *  beforeEach: (fn: () => Promise<any>) => Void;
+ *  browser: import('../../puppeteerInterface').PuppeteerInterface;
+ * }} testFunction
+ */
+
+/**
  * Helper for checking request matching outcomes.
  * Note: The logic around determining action is simplistic, but good enough for
  *       now.


### PR DESCRIPTION
The isUrlFilterCaseSensitive rule condition was being set incorrectly when
generating declarativeNetRequest rules, resulting in case sensitive matching to
never apply:
 - The isUrlFilterCaseSensitive rule condition defaults to false[1], not true
   as we previously understood.
 - The same applies for regexFilter rules in practive, despite the API docs
   implying the opposite[2].

Let's correct that logic, update the corresponding tests, and add some
testMatchOutcome tests to verify that case sensitivity is working correctly.

1 - https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#property-RuleCondition-isUrlFilterCaseSensitive
2 - https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#property-RegexOptions-isCaseSensitive

**Reviewer:** @sammacbeth 

## Automated tests:
- [x] Unit tests
- [ ] Integration tests
