### PR TITLE
Add support for RequestBlocklist feature

### DIFF
--- a/integration-test/data/configs/request-blocklist.json
+++ b/integration-test/data/configs/request-blocklist.json
@@ -1,0 +1,19 @@
+{
+    "globalThis.dbg.tds.config.features.requestBlocklist": {
+        "state": "enabled",
+        "settings": {
+            "blockedRequests": {
+                "third-party.site": {
+                    "rules": [
+                        {
+                            "rule": "bad.third-party.site/*.jpg",
+                            "domains": ["<all>"],
+                            "reason": "Test rule"
+                        }
+                    ]
+                }
+            }
+        },
+        "exceptions":[]
+    }
+}

--- a/integration-test/data/empty-tds.json
+++ b/integration-test/data/empty-tds.json
@@ -1,0 +1,6 @@
+{
+    "trackers": {},
+    "entities": {},
+    "cnames": [],
+    "domains": {}
+}

--- a/integration-test/request-blocklist.spec.js
+++ b/integration-test/request-blocklist.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from './helpers/playwrightHarness';
+import { forAllConfiguration, forExtensionLoaded, forDynamicDNRRulesLoaded } from './helpers/backgroundWait';
+import { overridePrivacyConfig, overrideTds } from './helpers/testConfig';
+import { runRequestBlockingTest } from './helpers/requests';
+
+const testHost = 'privacy-test-pages.site';
+const testSite = `https://${testHost}/privacy-protections/request-blocking/`;
+
+function expectBlocked(protectionsEnabled, url) {
+    return protectionsEnabled && new URL(url).pathname.endsWith('.jpg');
+}
+
+test.describe('Test Request Blocklist feature', () => {
+    test('Should block the .jpg requests', async ({ page, backgroundPage, context, backgroundNetworkContext, manifestVersion }) => {
+        await overrideTds(backgroundNetworkContext, 'empty-tds.json');
+        await overridePrivacyConfig(backgroundNetworkContext, 'request-blocklist.json');
+        await forExtensionLoaded(context);
+        await forAllConfiguration(backgroundPage);
+        if (manifestVersion === 3) {
+            await forDynamicDNRRulesLoaded(backgroundPage);
+        }
+
+        for (const protectionsEnabled of [true, false]) {
+            // Disable protections after the first time.
+            if (!protectionsEnabled) {
+                await backgroundPage.evaluate(async (domain) => {
+                    /* global dbg */
+                    dbg.tabManager.setList({ list: 'allowlisted', domain, value: true });
+                }, testHost);
+            }
+
+            // Load and run the request blocking test page.
+            const { testCount, pageRequests } = await runRequestBlockingTest(page, testSite);
+            expect(testCount).toBeGreaterThan(0);
+
+            // Verify that the .jpg image requests were blocked as expected.
+            for (const { url, status } of pageRequests) {
+                // TODO: Figure out why the video.mp4 request is reported as
+                //       blocked regardless.
+                if (new URL(url).pathname.endsWith('video.mp4')) {
+                    continue;
+                }
+
+                expect(status, `URL: ${url}, Allowlisted: ${!protectionsEnabled}`).toEqual(
+                    expectBlocked(protectionsEnabled, url) ? 'blocked' : 'allowed',
+                );
+            }
+
+            await page.reload();
+        }
+
+        await page.close();
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -492,8 +492,7 @@
             "link": true
         },
         "node_modules/@duckduckgo/privacy-reference-tests": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
-            "integrity": "sha512-IrVXzW1Gyilt4Rqy77j7hcMPS8/ldFvsnqFMnQpqGP5MaQXpzOQN+thLUcxgMU/AJL6u3TO/GIxYdTgS9YQMPw==",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ba9468089d7c153a48a41dfd110971daf6c7b5e0",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/tracker-surrogates": {
@@ -12229,8 +12228,7 @@
             }
         },
         "@duckduckgo/privacy-reference-tests": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
-            "integrity": "sha512-IrVXzW1Gyilt4Rqy77j7hcMPS8/ldFvsnqFMnQpqGP5MaQXpzOQN+thLUcxgMU/AJL6u3TO/GIxYdTgS9YQMPw==",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ba9468089d7c153a48a41dfd110971daf6c7b5e0",
             "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {

--- a/packages/ddg2dnr/lib/extensionConfiguration.js
+++ b/packages/ddg2dnr/lib/extensionConfiguration.js
@@ -5,6 +5,7 @@ const { generateTrackerAllowlistRules } = require('./trackerAllowlist');
 const { generateTemporaryAllowlistRules } = require('./temporaryAllowlist');
 const { generateTrackingParameterRules } = require('./trackingParams');
 const { createSmarterEncryptionTemporaryRule } = require('./smarterEncryption');
+const { generateRequestBlocklistRules } = require('./requestBlocklist');
 
 /**
  * Generated an extension configuration declarativeNetRequest ruleset.
@@ -43,6 +44,11 @@ async function generateExtensionConfigurationRuleset(extensionConfig, denylisted
 
     // AMP link protection.
     for (const result of await generateAmpProtectionRules(extensionConfig, isRegexSupported)) {
+        appendRuleResult(result);
+    }
+
+    // Request Blocklist.
+    for (const result of generateRequestBlocklistRules(extensionConfig)) {
         appendRuleResult(result);
     }
 

--- a/packages/ddg2dnr/lib/requestBlocklist.js
+++ b/packages/ddg2dnr/lib/requestBlocklist.js
@@ -1,0 +1,97 @@
+/** @module requestBlocklist */
+
+const { getDomain } = require('tldts');
+
+const { processPlaintextTrackerRule, generateDNRRule } = require('./utils');
+
+const EXPECTED_RULE_KEYS = new Set(['domains', 'reason', 'rule']);
+const PRIORITY = 20000;
+
+function validRule(rule) {
+    // Missing or unknown rule properties.
+    const ruleKeys = Object.keys(rule);
+    if (ruleKeys.length !== EXPECTED_RULE_KEYS.size || !ruleKeys.every((key) => EXPECTED_RULE_KEYS.has(key))) {
+        return false;
+    }
+
+    // Reject rules using adblock filter syntax.
+    // Note: This isn't perfect since escaping isn't supported, but it's
+    //       hopefully good enough to discourage filter syntax use
+    //       without being too restrictive.
+    if (rule?.rule?.startsWith('|') || rule?.rule?.includes('^')) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @typedef generateRequestBlocklistRulesResult
+ * @property {Omit<chrome.declarativeNetRequest.Rule, 'id'>} rule
+ * @property {object} matchDetails
+ */
+
+/**
+ * Generator to produce the declarativeNetRequest rules and corresponding match
+ * details for the given requestBlocklist configuration.
+ * @param {object} extensionConfiguration
+ *   The extension configuration.
+ * @returns {Generator<generateRequestBlocklistRulesResult>}
+ */
+function* generateRequestBlocklistRules({ features: { requestBlocklist } }) {
+    const entries = requestBlocklist?.settings?.blockedRequests;
+    const domainExceptions = requestBlocklist?.exceptions?.map((e) => e.domain);
+
+    if (requestBlocklist?.state !== 'enabled' || !entries) {
+        return;
+    }
+
+    for (const [trackerDomain, entry] of Object.entries(entries)) {
+        const { rules } = entry;
+        if (!rules?.length) {
+            continue;
+        }
+
+        // Entries must use eTLD+1.
+        if (getDomain(trackerDomain) !== trackerDomain) {
+            console.log('Request Blocklist entry for non-eTLD+1 domain', trackerDomain, 'ignored.');
+            continue;
+        }
+
+        for (const rule of rules) {
+            if (!validRule(rule)) {
+                continue;
+            }
+
+            let { rule: trackerRule, domains: initiatorDomains, reason } = rule;
+            const { urlFilter } = processPlaintextTrackerRule(trackerDomain, trackerRule);
+
+            if (!initiatorDomains?.length || initiatorDomains.includes('<all>')) {
+                initiatorDomains = null;
+            }
+
+            yield {
+                rule: generateDNRRule({
+                    priority: PRIORITY,
+                    actionType: 'block',
+                    urlFilter,
+                    matchCase: true,
+                    requestDomains: [trackerDomain],
+                    initiatorDomains,
+                    excludedInitiatorDomains: domainExceptions,
+                    excludedRequestDomains: domainExceptions,
+                }),
+                matchDetails: {
+                    type: 'requestBlocklist',
+                    domain: trackerDomain,
+                    reason,
+                },
+            };
+        }
+    }
+}
+
+exports.PRIORITY = PRIORITY;
+
+exports.validRule = validRule;
+exports.generateRequestBlocklistRules = generateRequestBlocklistRules;

--- a/packages/ddg2dnr/lib/utils.js
+++ b/packages/ddg2dnr/lib/utils.js
@@ -272,10 +272,7 @@ function generateDNRRule({
     // Note: It's not necessary to exclude initiator domains for allowing rules
     //       since first-party requests will be allowed anyway.
     if (excludedInitiatorDomains && excludedInitiatorDomains.length > 0 && actionType !== 'allow') {
-        if (excludedInitiatorDomains.length === 1 && requestDomains && requestDomains.length === 1) {
-            // Assume that if only one initiator domain is excluded (and there
-            // is only one request domain), that the excluded initiator domain
-            // is the same as the request domain.
+        if (excludedInitiatorDomains.length === 1 && requestDomains?.length === 1 && excludedInitiatorDomains[0] === requestDomains[0]) {
             dnrRule.condition.domainType = castDNREnum('thirdParty');
         } else {
             dnrRule.condition.excludedInitiatorDomains = excludedInitiatorDomains;

--- a/packages/ddg2dnr/test/requestBlocklist.js
+++ b/packages/ddg2dnr/test/requestBlocklist.js
@@ -1,0 +1,252 @@
+const assert = require('assert');
+
+const { PRIORITY } = require('../lib/requestBlocklist');
+
+const { generateExtensionConfigurationRuleset } = require('../lib/extensionConfiguration');
+
+async function isRegexSupportedTrue({ regex, isCaseSensitive }) {
+    return { isSupported: true };
+}
+
+describe('Request Blocklist', () => {
+    it('should return no rules if requestBlocklist feature is disabled or ' + 'configuration is empty', async () => {
+        assert.deepEqual(
+            await generateExtensionConfigurationRuleset(
+                {
+                    features: {
+                        requestBlocklist: {},
+                        contentBlocking: { state: 'enabled' },
+                    },
+                },
+                [],
+                isRegexSupportedTrue,
+            ),
+            { ruleset: [], matchDetailsByRuleId: {} },
+        );
+
+        assert.deepEqual(
+            await generateExtensionConfigurationRuleset(
+                {
+                    features: {
+                        requestBlocklist: {
+                            state: 'disabled',
+                            settings: {
+                                blockedRequests: {
+                                    'domain.invalid': {
+                                        rules: [
+                                            {
+                                                rule: 'example',
+                                                domains: ['<all>'],
+                                                reason: 'example',
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                        contentBlocking: { state: 'enabled' },
+                    },
+                },
+                [],
+                isRegexSupportedTrue,
+            ),
+            { ruleset: [], matchDetailsByRuleId: {} },
+        );
+
+        assert.deepEqual(
+            await generateExtensionConfigurationRuleset(
+                {
+                    features: {
+                        requestBlocklist: {
+                            state: 'enabled',
+                            settings: {
+                                blockedRequests: {},
+                            },
+                        },
+                        contentBlocking: { state: 'enabled' },
+                    },
+                },
+                [],
+                isRegexSupportedTrue,
+            ),
+            { ruleset: [], matchDetailsByRuleId: {} },
+        );
+    });
+
+    it('should generate blocklists correctly', async () => {
+        const extensionConfig = {
+            features: {
+                requestBlocklist: {
+                    state: 'enabled',
+                    settings: {
+                        blockedRequests: {
+                            'domain.example': {
+                                rules: [
+                                    {
+                                        rule: 'domain.example/path',
+                                        domains: ['<all>'],
+                                        reason: 'reason 1',
+                                    },
+                                ],
+                            },
+                            'subdomain.domain.example': {
+                                rules: [
+                                    {
+                                        rule: 'subdomain.domain.example/path',
+                                        domains: ['<all>'],
+                                        reason: 'reason 2',
+                                    },
+                                ],
+                            },
+                            'second-domain.example': {
+                                rules: [
+                                    {
+                                        rule: 'second-domain.example',
+                                        domains: [],
+                                        reason: 'reason 3',
+                                    },
+                                ],
+                            },
+                            'third-domain.example': {
+                                rules: [
+                                    {
+                                        rule: 'third-domain.example',
+                                        domains: ['website1.example', 'website2.example'],
+                                        reason: 'reason 4',
+                                    },
+                                    {
+                                        rule: '12345',
+                                        domains: ['website3.example'],
+                                        reason: 'reason 5',
+                                    },
+                                ],
+                            },
+                            'fourth-domain.example': {
+                                rules: [
+                                    {
+                                        rule: 'subdomain.fourth-domain.example/path',
+                                        domains: ['<all>'],
+                                        reason: 'reason 6',
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    exceptions: [
+                        {
+                            domain: 'exception.example',
+                            reason: 'Example request-blocking exception',
+                        },
+                    ],
+                },
+                contentBlocking: { state: 'enabled' },
+            },
+        };
+
+        const extensionConfigCopy = JSON.parse(JSON.stringify(extensionConfig));
+
+        assert.deepEqual(await generateExtensionConfigurationRuleset(extensionConfig, [], isRegexSupportedTrue, 23), {
+            ruleset: [
+                {
+                    id: 23,
+                    priority: PRIORITY,
+                    action: {
+                        type: 'block',
+                    },
+                    condition: {
+                        urlFilter: '||domain.example/path',
+                        isUrlFilterCaseSensitive: true,
+                        excludedInitiatorDomains: ['exception.example'],
+                        excludedRequestDomains: ['exception.example'],
+                    },
+                },
+                {
+                    id: 24,
+                    priority: PRIORITY,
+                    action: {
+                        type: 'block',
+                    },
+                    condition: {
+                        urlFilter: '||second-domain.example',
+                        isUrlFilterCaseSensitive: true,
+                        excludedInitiatorDomains: ['exception.example'],
+                        excludedRequestDomains: ['exception.example'],
+                    },
+                },
+                {
+                    id: 25,
+                    priority: PRIORITY,
+                    action: {
+                        type: 'block',
+                    },
+                    condition: {
+                        urlFilter: '||third-domain.example',
+                        isUrlFilterCaseSensitive: true,
+                        initiatorDomains: ['website1.example', 'website2.example'],
+                        excludedInitiatorDomains: ['exception.example'],
+                        excludedRequestDomains: ['exception.example'],
+                    },
+                },
+                {
+                    id: 26,
+                    priority: PRIORITY,
+                    action: {
+                        type: 'block',
+                    },
+                    condition: {
+                        urlFilter: '12345',
+                        isUrlFilterCaseSensitive: true,
+                        requestDomains: ['third-domain.example'],
+                        initiatorDomains: ['website3.example'],
+                        excludedInitiatorDomains: ['exception.example'],
+                        excludedRequestDomains: ['exception.example'],
+                    },
+                },
+                {
+                    id: 27,
+                    priority: PRIORITY,
+                    action: {
+                        type: 'block',
+                    },
+                    condition: {
+                        urlFilter: 'subdomain.fourth-domain.example/path',
+                        isUrlFilterCaseSensitive: true,
+                        requestDomains: ['fourth-domain.example'],
+                        excludedInitiatorDomains: ['exception.example'],
+                        excludedRequestDomains: ['exception.example'],
+                    },
+                },
+            ],
+            matchDetailsByRuleId: {
+                23: {
+                    type: 'requestBlocklist',
+                    domain: 'domain.example',
+                    reason: 'reason 1',
+                },
+                24: {
+                    type: 'requestBlocklist',
+                    domain: 'second-domain.example',
+                    reason: 'reason 3',
+                },
+                25: {
+                    type: 'requestBlocklist',
+                    domain: 'third-domain.example',
+                    reason: 'reason 4',
+                },
+                26: {
+                    type: 'requestBlocklist',
+                    domain: 'third-domain.example',
+                    reason: 'reason 5',
+                },
+                27: {
+                    type: 'requestBlocklist',
+                    domain: 'fourth-domain.example',
+                    reason: 'reason 6',
+                },
+            },
+        });
+
+        // Verify that the extension configuration wasn't mutated.
+        assert.deepEqual(extensionConfig, extensionConfigCopy);
+    });
+});

--- a/packages/ddg2dnr/test/rulePriorities.js
+++ b/packages/ddg2dnr/test/rulePriorities.js
@@ -22,6 +22,8 @@ const {
 
 const { CONTENT_BLOCKING_ALLOWLIST_PRIORITY, UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY } = require('../lib/temporaryAllowlist');
 
+const { PRIORITY: REQUEST_BLOCKLIST_PRIORITY } = require('../lib/requestBlocklist');
+
 const {
     AD_ATTRIBUTION_POLICY_PRIORITY,
     SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY,
@@ -35,6 +37,7 @@ describe('Rule Priorities', () => {
         assert.equal(SMARTER_ENCRYPTION_PRIORITY, 5000);
         assert.equal(TRACKER_BLOCKING_BASELINE_PRIORITY, 10000);
         assert.equal(TRACKER_BLOCKING_CEILING_PRIORITY, 19999);
+        assert.equal(REQUEST_BLOCKLIST_PRIORITY, 20000);
         assert.equal(TRACKER_ALLOWLIST_BASELINE_PRIORITY, 20000);
         assert.equal(TRACKER_ALLOWLIST_CEILING_PRIORITY, 20100);
         assert.equal(AD_ATTRIBUTION_POLICY_PRIORITY, 30000);
@@ -77,10 +80,15 @@ describe('Rule Priorities', () => {
         assert.ok(SMARTER_ENCRYPTION_PRIORITY < USER_ALLOWLISTED_PRIORITY);
         assert.ok(SMARTER_ENCRYPTION_PRIORITY < NEWTAB_TRACKER_STATS_REDIRECT_PRIORITY);
 
-        // Tracker allowlist should take priority over tracker blocking and smarter encryption, but not
-        // other features/allowlists.
+        // Tracker allowlist should take priority over tracker blocking, the request blocklist,
+        // and smarter encryption, but not other features/allowlists.
+        //
+        // Note: TrackerAllowlist baseline priority currently equals RequestBlocklist priority,
+        //       but since allowing rules take precedence over blocking rules of equal priority
+        //       that's OK.
         assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY > SMARTER_ENCRYPTION_PRIORITY);
         assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY);
+        assert.ok(TRACKER_ALLOWLIST_BASELINE_PRIORITY >= REQUEST_BLOCKLIST_PRIORITY);
         assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < AD_ATTRIBUTION_POLICY_PRIORITY);
         assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < CONTENT_BLOCKING_ALLOWLIST_PRIORITY);
         assert.ok(TRACKER_ALLOWLIST_CEILING_PRIORITY < GPC_HEADER_PRIORITY);
@@ -121,6 +129,7 @@ describe('Rule Priorities', () => {
         assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, SERVICE_WORKER_INITIATED_ALLOWING_PRIORITY);
         assert.equal(UNPROTECTED_TEMPORARY_ALLOWLIST_PRIORITY, USER_ALLOWLISTED_PRIORITY);
         assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKER_BLOCKING_CEILING_PRIORITY);
+        assert.ok(USER_ALLOWLISTED_PRIORITY > REQUEST_BLOCKLIST_PRIORITY);
         assert.ok(USER_ALLOWLISTED_PRIORITY > TRACKER_ALLOWLIST_CEILING_PRIORITY);
         assert.ok(USER_ALLOWLISTED_PRIORITY > AD_ATTRIBUTION_POLICY_PRIORITY);
         assert.ok(USER_ALLOWLISTED_PRIORITY > CONTENT_BLOCKING_ALLOWLIST_PRIORITY);

--- a/shared/js/background/background.js
+++ b/shared/js/background/background.js
@@ -35,6 +35,7 @@ import initReloader from './devbuild-reloader';
 import tabManager from './tab-manager';
 import AbnExperimentMetrics, { setUpTestExperiment } from './components/abn-experiments';
 import MessageRouter from './components/message-router';
+import RequestBlocklist from './components/request-blocklist';
 import { AppUseMetric, SearchMetric, DashboardUseMetric, RefreshMetric } from './metrics';
 // NOTE: this needs to be the first thing that's require()d when the extension loads.
 // otherwise FF might miss the onInstalled event
@@ -99,10 +100,14 @@ if (BUILD_TARGET === 'chrome' || BUILD_TARGET === 'chrome-mv2') {
     components.fireButton = new FireButton({ settings, tabManager });
     setUpTestExperiment(abnMetrics);
 }
-// MV3-only components
+
 if (BUILD_TARGET === 'chrome') {
+    // MV3-only components
     components.scriptInjection = new MV3ContentScriptInjection();
     components.dnrListeners = new DNRListeners({ settings, tds });
+} else {
+    // MV2-only components
+    components.requestBlocklist = new RequestBlocklist();
 }
 console.log(new Date(), 'Loaded components:', components);
 // @ts-ignore

--- a/shared/js/background/components/request-blocklist.js
+++ b/shared/js/background/components/request-blocklist.js
@@ -1,0 +1,133 @@
+import { getBaseDomain, isFeatureEnabled } from '../utils';
+import tdsStorage from '../storage/tds';
+import { getHostname } from 'tldts';
+import { validRule } from '@duckduckgo/ddg2dnr/lib/requestBlocklist';
+
+const browserWrapper = require('../wrapper');
+
+// Note: Since this lookup (and the whole component) is only used by MV2 builds
+//       of the extension, it being cleared on ServiceWorker restart isn't a
+//       concern.
+//       See https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/#state
+let requestBlocklistLookup = null;
+
+/**
+ * Convert a Request Blocklist rule (literal string, but with basic wildcard
+ * support) to a regular expression.
+ * Note: Once browser support catches up, it would be nice to use RegExp.Escape
+ *       here instead of the manual escaping.
+ * @param {string} requestBlocklistRule
+ * @returns {RegExp}
+ */
+function parseRule(requestBlocklistRule) {
+    return new RegExp(requestBlocklistRule.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replaceAll('*', '.*'));
+}
+
+/**
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/config.js').GenericV4Config} Config
+ */
+
+/**
+ * Update requestBlocklist lookup, based on the given configuration.
+ *
+ * @param {import('@duckduckgo/privacy-configuration/schema/config.js').GenericV4Config} config
+ */
+function updateRequestBlocklistLookup(config) {
+    const configRules = tdsStorage?.config?.features?.requestBlocklist?.settings?.blockedRequests;
+    if (!configRules || !isFeatureEnabled('requestBlocklist', config)) {
+        requestBlocklistLookup = null;
+        return;
+    }
+
+    const newLookup = new Map();
+    for (const [domain, entry] of Object.entries(configRules)) {
+        if (entry?.rules?.length) {
+            newLookup.set(
+                domain,
+                entry.rules.filter(validRule).map((rule) => ({
+                    rule: parseRule(rule.rule),
+                    domains: new Set(rule.domains),
+                    reason: rule.reason,
+                })),
+            );
+        }
+    }
+
+    requestBlocklistLookup = newLookup;
+}
+
+/**
+ * Component for the RequestBlocklist feature, which allows for requests to be
+ * blocked in order to fix website breakage issues.
+ *
+ * TODO: Once RequestBlocklist.matchRequest() is called from another
+ *       component, make matchRequest() (and the dependendant methods) instance
+ *       methods. Also, then pass the tdsStorage etc modules into the
+ *       constructor via dependency injection, instead of importing them, to aid
+ *       unit testing.
+ */
+export default class RequestBlocklist {
+    static featureName = 'requestBlocklist';
+
+    constructor() {
+        if (browserWrapper.getManifestVersion() === 2) {
+            tdsStorage.onUpdate('config', (name, etag, config) => {
+                updateRequestBlocklistLookup(config);
+            });
+
+            updateRequestBlocklistLookup(tdsStorage?.config);
+        }
+    }
+
+    static matchRequest(siteUrl, requestUrl, requestType) {
+        // Lookup isn't ready, don't block.
+        if (!requestBlocklistLookup) {
+            return false;
+        }
+
+        // Main-frame requests (aka navigations) shouldn't be blocked.
+        if (requestType === 'main_frame') {
+            return false;
+        }
+
+        // Find entry in blocklist that matches request URL by eTLD+1.
+        const requestDomain = getBaseDomain(requestUrl);
+        if (!requestDomain) {
+            return false;
+        }
+        const rules = requestBlocklistLookup.get(requestDomain);
+        if (!rules?.length) {
+            return false;
+        }
+
+        // Normalise the URL (e.g. strip port part if redundant).
+        // TODO: Consider if this can be removed in practice, by verifying if
+        //       request URL provided by webRequest etc APIs is always already
+        //       normalised correctly.
+        requestUrl = new URL(requestUrl).href;
+
+        // See if any of the rules for the blocklist entry are a match.
+        for (const rule of rules) {
+            // First, check rule matches request URL.
+            if (!rule.rule.test(requestUrl)) {
+                continue;
+            }
+
+            // Next, check domain condition matches website URL.
+            if (rule.domains.has('<all>')) {
+                return rule;
+            }
+            const websiteDomain = getHostname(siteUrl);
+            if (!websiteDomain) {
+                continue;
+            }
+            for (let i = -1; i !== 0; i = websiteDomain.indexOf('.', i) + 1) {
+                if (rule.domains.has(websiteDomain.substring(i))) {
+                    return rule;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/unit-test/background/reference-tests/request-blocklist-tests.js
+++ b/unit-test/background/reference-tests/request-blocklist-tests.js
@@ -1,0 +1,76 @@
+import browser from 'webextension-polyfill';
+
+import surrogatesReference from '@duckduckgo/privacy-reference-tests/request-blocklist/surrogates-reference.txt';
+import configReference from '@duckduckgo/privacy-reference-tests/request-blocklist/config-reference.json';
+import tdsReference from '@duckduckgo/privacy-reference-tests/request-blocklist/tds-reference.json';
+import allowlistReference from '@duckduckgo/privacy-reference-tests/request-blocklist/user-allowlist-reference.json';
+import tests from '@duckduckgo/privacy-reference-tests/request-blocklist/tests.json';
+
+import { blockHandleResponse } from '../../../shared/js/background/before-request';
+import TabManager from '../../../shared/js/background/tab-manager';
+import RequestBlocklist from '../../../shared/js/background/components/request-blocklist';
+import tds from '../../../shared/js/background/trackers';
+import tdsStorageStub from '../../helpers/tds';
+
+describe('Request Blocklist:', () => {
+    beforeAll(async () => {
+        spyOn(browser.runtime, 'getManifest').and.callFake(() => ({
+            manifest_version: 2,
+        }));
+
+        tdsStorageStub.stub({
+            config: configReference,
+            tds: tdsReference,
+        });
+
+        for (const allowlistedDomain of allowlistReference) {
+            await TabManager.setList({ list: 'allowlisted', domain: allowlistedDomain, value: true });
+        }
+
+        this.components = [new RequestBlocklist()];
+
+        const testLists = [
+            {
+                name: 'config',
+                data: configReference,
+            },
+            {
+                name: 'tds',
+                data: tdsReference,
+            },
+            {
+                name: 'surrogates',
+                data: surrogatesReference,
+            },
+        ];
+        return tds.setLists(testLists);
+    });
+
+    const tabId = 1;
+    for (const testSet of Object.values(tests)) {
+        describe(testSet.desc + ':', () => {
+            for (const { name, requestUrl, requestType, websiteUrl, expectAction: expectedAction, exceptPlatforms } of testSet.tests) {
+                if (exceptPlatforms?.includes('web-extension-mv3')) {
+                    continue;
+                }
+
+                it(name + ':', async () => {
+                    const actualResponse = await blockHandleResponse(TabManager.create({ tabId, url: websiteUrl }), {
+                        tabId,
+                        url: requestUrl,
+                        type: requestType,
+                    });
+
+                    let actualAction = 'allow';
+                    if (actualResponse?.cancel) {
+                        actualAction = 'block';
+                    } else if (actualResponse?.redirectUrl) {
+                        actualAction = 'redirect';
+                    }
+
+                    expect(actualAction).toEqual(expectedAction);
+                });
+            }
+        });
+    }
+});


### PR DESCRIPTION
The RequestBlocklist feature allows for arbitrary requests to be blocked. Being
able to do that will be useful for resolving some website breakage issues, where
the necessary fix is to block a request (rather than to allow one).

This change includes MV2 and MV3 implementations of the feature, unit tests and
integration tests. See the reference tests:
https://github.com/duckduckgo/privacy-reference-tests/tree/main/request-blocklist

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Build both the Firefox and Chrome extension: `npm run dev-firefox` and `npm run dev-chrome`.
2. Install those builds in Firefox and Chrome respectively.
3. Navigate to https://reuters.com and ensure images (.jpg requests) load, even after holding shift and clicking refresh.
4. In the extension settings, set the custom config URL of `https://gist.githubusercontent.com/kzar/4cbfeff5d75772b2482a9124a6ea00b7/raw/9b76111d22957a033b8b3deadedd5a2066014c83/extension-config.json`
5. Shift-reload the reuters.com tab again, ensure the .jpg image requests are now blocked, and lots of images are shown as grey placeholders.

If you want to do more testing with your own configuration, here's an example `request-blocklist.json` feature config:
```json
{
    "_meta": {
        "description": "Request blocking rules necessary to fix website breakage. Note: Tracker request blocking is handled elsewhere.",
        "sampleExcludeRecords": {
            "domain": "example.com",
            "reason": "site breakage"
        }
    },
    "state": "enabled",
    "settings": {
        "blockedRequests": {
            "reuters.com": {
                "rules": [
                    {
                        "rule": "reuters.com/*.jpg",
                        "domains": ["reuters.com"],
                        "reason": ["EXAMPLE"]
                    }
                ]
            }
        }
    },
    "exceptions": []
}
```

## Automated tests:
- [x] Unit tests
- [x] Integration tests
