### PR TITLE
Add "unknown" as possible value of browser suffix in pixel schema

### DIFF
--- a/pixel-definitions/suffixes_dictionary.json
+++ b/pixel-definitions/suffixes_dictionary.json
@@ -2,7 +2,7 @@
     "browser": {
         "type": "string",
         "description": "Browser type",
-        "enum": ["chrome", "firefox", "edg", "opera", "brave"]
+        "enum": ["chrome", "firefox", "edg", "opera", "brave", "unknown"]
     },
     "extension": {
         "type": "string",


### PR DESCRIPTION
When firing pixel requests, sometimes the user's current browser is unknown. We
should include that possibility in the schema.

See https://app.asana.com/1/137249556945/task/1211814665268441?focus=true