### PR TITLE
Get the broken site report integration tests passing again

### DIFF
--- a/integration-test/broken-site-report.spec.js
+++ b/integration-test/broken-site-report.spec.js
@@ -16,7 +16,7 @@ test.describe('Broken site reports', () => {
             pixelResolver = resolve;
         });
         await routeExtensionRequests(
-            'https://improving.duckduckgo.com/t/*',
+            'https://improving.duckduckgo.com/t/epbf_*',
             /**
             @param {import('@playwright/test').Route} route
         */ (route) => {


### PR DESCRIPTION
The broken site report integration tests have some checks that assert that one
pixel (aka the broken site report) should have been sent which is now
failing. Looking at the failure, it seems to be cause by the
`experiment_metrics_fingerprintingCanvasAdditionalEnabledCheck_treatment` pixel
firing around the same time. Let's adjust the tests, so that only the breakage
report pixels are considered.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 