### PR TITLE
Update autofill to 18.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.46.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -314,7 +314,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f6c384312a9b27824333e7d23382481ee1183e9",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12087,13 +12087,13 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8f6c384312a9b27824333e7d23382481ee1183e9",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#18.5.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#139c430531e6076f4f6db94928dc29fa83dc5623",
             "integrity": "sha512-f4//SokP8OKIJD384MMEJccD21FKd9YDVKdeLHOelFgpV6lj4dA+gShvQIFp1fCkNY9/d9XFUKbEbfxGgHCNJA==",
-            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#139c430531e6076f4f6db94928dc29fa83dc5623",
+            "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#11.46.0",
             "requires": {
                 "immutable-json-patch": "^6.0.2",
                 "urlpattern-polyfill": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.46.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
+        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.4.0",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
-        "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
         "deep-freeze": "0.0.1",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.5.0


## Description
Updates Autofill to version [18.5.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.5.0).

### Autofill 18.5.0 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/909
* [Quick win] TOTP field and prompt by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/897
* [Integration test] Update extension manifest to v3 by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/910
* [CredentialsImport] Show credential import on credential inputs only by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/907
* [Windows] Remove scroll logic from attachTooltip by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/913


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.4.0...18.5.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).