### PR TITLE
Fix space doubling in omnibox search terms

### DIFF
--- a/shared/js/background/components/omnibox-search.js
+++ b/shared/js/background/components/omnibox-search.js
@@ -11,8 +11,11 @@ export default class OmniboxSearch {
                     currentWindow: true,
                     active: true,
                 });
+                const url = new URL('https://duckduckgo.com');
+                url.searchParams.set('q', text);
+                url.searchParams.set('bext', getOsName() + 'cl');
                 browser.tabs.update(tabs[0].id, {
-                    url: 'https://duckduckgo.com/?q=' + encodeURIComponent(text) + '&bext=' + getOsName() + 'cl',
+                    url: url.toString(),
                 });
             });
         }


### PR DESCRIPTION
## Description:
This fixes issue #3197 where spaces in search terms were being doubled.

fixed a bug where search terms with spaces were getting messed up.
Earlier, the code was manually sticking pieces of the URL together, which caused spaces to get double-encoded.

Now we use URL and URLSearchParams, which basically handle all the encoding automatically

