### PR TITLE
Ensure Requests blocked by Request Blocklist aren't shown as trackers

### DIFF
--- a/integration-test/request-blocklist.spec.js
+++ b/integration-test/request-blocklist.spec.js
@@ -46,6 +46,24 @@ test.describe('Test Request Blocklist feature', () => {
                 );
             }
 
+            // Verify that the requests blocked by Request Blocklist were not
+            // logged as blocked _tracking_ requests.
+            const tabManagerTrackerCount = await backgroundPage.evaluate(async () => {
+                const currentTab = await globalThis.dbg.utils.getCurrentTab();
+                const trackers = globalThis.dbg.tabManager.get({ tabId: currentTab.id })?.trackers;
+
+                let total = 0;
+                for (const { urls: entry } of Object.values(trackers)) {
+                    for (const { action } of Object.values(entry)) {
+                        if (action === 'block') {
+                            ++total;
+                        }
+                    }
+                }
+                return total;
+            });
+            expect(tabManagerTrackerCount).toEqual(0);
+
             await page.reload();
         }
 


### PR DESCRIPTION
The Request Blocklist feature lets us block arbitrary requests when necessary
to fix website breakage issues. Those requests are not necessary tracking
requests, so we should be careful not to display them as such to the user.

**Reviewer:** @jdorweiler 

## Steps to test this PR:
1. Navigate to the test page https://privacy-test-pages.site/privacy-protections/request-blocklist/
2. Click the DuckDuckGo icon, and make sure that there are no blocked tracking requests listed.

Note: This was already working in MV3 builds, the fix here is for MV2 builds.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests