### PR TITLE
Resolve breakage report

### DIFF
--- a/shared/js/background/breakage-report-request.js
+++ b/shared/js/background/breakage-report-request.js
@@ -1,0 +1,53 @@
+import { sendTabMessage } from './utils';
+
+/** @type {Map<number, {resolve: Function, timeout: ReturnType<typeof setTimeout>}>} */
+const pendingRequests = new Map();
+
+const REQUEST_TIMEOUT_MS = 500;
+
+/**
+ * Request breakage report data from content-scope-scripts for a tab.
+ * Returns a promise that resolves when breakageReportResult is received or times out.
+ *
+ * @param {number} tabId
+ * @returns {Promise<object|null>}
+ */
+export function requestBreakageReportData(tabId) {
+    // Cancel any existing pending request for this tab
+    const existing = pendingRequests.get(tabId);
+    if (existing) {
+        clearTimeout(existing.timeout);
+        existing.resolve(null);
+    }
+
+    return new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+            pendingRequests.delete(tabId);
+            resolve(null);
+        }, REQUEST_TIMEOUT_MS);
+
+        pendingRequests.set(tabId, { resolve, timeout });
+
+        sendTabMessage(tabId, { messageType: 'getBreakageReportValues' }, { frameId: 0 });
+    });
+}
+
+/**
+ * Resolve a pending breakage report request with data.
+ * Called from breakageReportResult message handler.
+ *
+ * @param {number} tabId
+ * @param {object} data
+ * @returns {boolean} true if there was a pending request
+ */
+export function resolveBreakageReportRequest(tabId, data) {
+    const pending = pendingRequests.get(tabId);
+    if (pending) {
+        clearTimeout(pending.timeout);
+        pendingRequests.delete(tabId);
+        pending.resolve(data);
+        return true;
+    }
+    return false;
+}
+

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -6,6 +6,7 @@ import { isFeatureEnabled, reloadCurrentTab } from './utils';
 import { ensureClickToLoadRuleActionDisabled } from './dnr-click-to-load';
 import tdsStorage from './storage/tds';
 import { getArgumentsObject } from './helpers/arguments-object';
+import { resolveBreakageReportRequest } from './breakage-report-request';
 import { postPopupMessage } from './popup-messaging';
 import ToggleReports from './components/toggle-reports';
 const utils = require('./utils');
@@ -304,6 +305,9 @@ export function breakageReportResult(data, sender) {
     if (!data) return;
 
     tab.breakageReportData = data;
+
+    // Resolve any pending request for this tab
+    resolveBreakageReportRequest(sender.tab.id, data);
 }
 
 /**


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:


@jdorweiler this would be a lot less fragile assuming it works (I haven't tested it).


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a timeout-backed request/resolve mechanism for breakage report data and update dashboard to await and use the returned values.
> 
> - **Background**:
>   - **New utility**: `shared/js/background/breakage-report-request.js` adds `requestBreakageReportData(tabId)` with a pending-request map and timeout, plus `resolveBreakageReportRequest(tabId, data)`.
>   - **Message handling**: `breakageReportResult` in `shared/js/background/message-handlers.js` now calls `resolveBreakageReportRequest` to fulfill pending requests (main-frame only), after storing `tab.breakageReportData`.
> - **Dashboard**:
>   - `submitBrokenSiteReport` in `shared/js/background/components/dashboard-messaging.js` now awaits `requestBreakageReportData(tab.id)` and builds `pageParams` from the returned `jsPerformance`, `referrer`, `opener`, and `detectorData`, replacing the previous fire-and-wait pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dbc416e63f98602b75fc3b9ff51e5f189b5a6cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->