### PR TITLE
Make reason field for Request Blocklist rules optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -491,7 +491,7 @@
             "link": true
         },
         "node_modules/@duckduckgo/privacy-reference-tests": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ba9468089d7c153a48a41dfd110971daf6c7b5e0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c2b49fe7ce4a75404c6a79e4dd1053710a9869ee",
             "license": "Apache-2.0"
         },
         "node_modules/@duckduckgo/tracker-surrogates": {
@@ -12226,7 +12226,7 @@
             }
         },
         "@duckduckgo/privacy-reference-tests": {
-            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ba9468089d7c153a48a41dfd110971daf6c7b5e0",
+            "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c2b49fe7ce4a75404c6a79e4dd1053710a9869ee",
             "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#main"
         },
         "@duckduckgo/tracker-surrogates": {

--- a/packages/ddg2dnr/lib/requestBlocklist.js
+++ b/packages/ddg2dnr/lib/requestBlocklist.js
@@ -4,12 +4,13 @@ const { getDomain } = require('tldts');
 
 const { processPlaintextTrackerRule, generateDNRRule } = require('./utils');
 
-const EXPECTED_RULE_KEYS = new Set(['domains', 'reason', 'rule']);
+const EXPECTED_RULE_KEYS = new Set(['domains', 'rule' /* , 'reason' */]);
 const PRIORITY = 20000;
 
 function validRule(rule) {
     // Missing or unknown rule properties.
-    const ruleKeys = Object.keys(rule);
+    // Note: Ignore "reason", since that is optional.
+    const ruleKeys = Object.keys(rule).filter((key) => key !== 'reason');
     if (ruleKeys.length !== EXPECTED_RULE_KEYS.size || !ruleKeys.every((key) => EXPECTED_RULE_KEYS.has(key))) {
         return false;
     }


### PR DESCRIPTION
While we generally want to ignore rules with missing properties, the "reason"
field is kind of an exception. We might need to strip that from the
configuration in the future if the configuration grows too large, so let's
ensure we'd still accept the rules if we did.

**Reviewer:** @jdorweiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows `requestBlocklist` rules to omit the `reason` field by excluding it from validation and expected keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59f3ec5cbcdb1ef764e04ef73d0ec5c05cb4775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->