### PR TITLE
Hotfix for change of messaging behaviour in Chrome 145

### DIFF
--- a/shared/js/background/components/message-router.js
+++ b/shared/js/background/components/message-router.js
@@ -35,6 +35,11 @@ export default class MessageRouter extends EventTarget {
         browser.runtime.onMessage.addListener((req, sender) => {
             if (sender.id !== getExtensionId()) return;
 
+            // TODO clean up legacy onboarding messaging
+            if (browserName === 'chrome' && (req === 'healthCheckRequest' || req === 'rescheduleCounterMessagingRequest')) {
+                req = { messageType: req };
+            }
+
             // TODO clean up message passing
             const legacyMessageTypes = [
                 'addUserData',
@@ -59,13 +64,6 @@ export default class MessageRouter extends EventTarget {
             if (req.messageType && req.messageType in messageHandlers) {
                 this.dispatchEvent(new MessageReceivedEvent(req));
                 return Promise.resolve(messageHandlers[req.messageType](req.options, sender, req));
-            }
-
-            // TODO clean up legacy onboarding messaging
-            if (browserName === 'chrome') {
-                if (req === 'healthCheckRequest' || req === 'rescheduleCounterMessagingRequest') {
-                    return;
-                }
             }
 
             console.error('Unrecognized message to background:', req, sender);

--- a/shared/js/background/events.js
+++ b/shared/js/background/events.js
@@ -174,16 +174,6 @@ browser.webNavigation.onCommitted.addListener(onboardingMessaging, {
  * (Chrome only)
  */
 if (browserName === 'chrome') {
-    chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
-        if (request === 'healthCheckRequest') {
-            sendResponse(true);
-        } else if (request === 'rescheduleCounterMessagingRequest') {
-            await settings.ready();
-            settings.updateSetting('rescheduleCounterMessagingOnStart', true);
-            sendResponse(true);
-        }
-    });
-
     browser.runtime.onStartup.addListener(async () => {
         await settings.ready();
 

--- a/shared/js/background/message-handlers.js
+++ b/shared/js/background/message-handlers.js
@@ -310,6 +310,16 @@ export function breakageReportResult(data, sender) {
     resolveBreakageReportRequest(sender.tab.id, data);
 }
 
+export function healthCheckRequest() {
+    return true;
+}
+
+export async function rescheduleCounterMessagingRequest() {
+    await settings.ready();
+    settings.updateSetting('rescheduleCounterMessagingOnStart', true);
+    return true;
+}
+
 /**
  * Add a new message handler.
  * @param {string} name
@@ -353,5 +363,7 @@ const messageHandlers = {
     isClickToLoadYoutubeEnabled,
     addDebugFlag,
     breakageReportResult,
+    healthCheckRequest,
+    rescheduleCounterMessagingRequest,
 };
 export default messageHandlers;


### PR DESCRIPTION
Hotfix for change of messaging behaviour in Chrome 145

While testing an upcoming release against Chrome Canary, we found that core
functionality of the extension was broken. Worryingly we noticed currently
released version of the extension was broken with Chrome Canary too. With Chrome
145 due to ship around Feb 10th (a month away)[1], we needed to investigate that
quite urgently.

Bisecting Chromium builds pointed us to this commit[2] where native support for
the `browser` namespace was added. We have been using the webextension-polyfill
library[3] to provide that namespace so far, and to "Promisify" some of the
extension APIs. It turns out that once Chrome made `browser` available, the
polyfill library let Chrome take care of those APIs and the `runtime.onMessage`
API started behaving slightly differently, which in turn broke this extension.

The change in behaviour seems to be that when there are multiple
`runtime.onMessage` listeners that provide a mix of asynchronous and synchronous
responses, the synchronous response sometimes win now even when the response is
`null`/`undefined`. Previously the asynchronous response would make it back to
the sender OK.

The Chromium issue[4] to investigate and hopefully fix that change of behaviour is
still in progress, but in the mean time let's get a hotfix out to help ensure
our users aren't impacted.

Note: Further changes might be required in the future, since we seem to have
      multiple `runtime.onMessage` listeners in the codebase. This patch is just
      a minimal hotfix to get things working for now.

1 - https://chromiumdash.appspot.com/schedule
2 - https://chromium.googlesource.com/chromium/src/+/5d4acd02f7f6a7d79530f01f2dffce4e9c8aa490
3 - https://github.com/mozilla/webextension-polyfill
4 - https://issues.chromium.org/issues/467294033



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses Chrome 145 messaging behavior by unifying how onboarding-related messages are handled.
> 
> - Normalizes legacy Chrome messages (`healthCheckRequest`, `rescheduleCounterMessagingRequest`) in `message-router.js` to structured `messageType` requests
> - Adds `healthCheckRequest` and `rescheduleCounterMessagingRequest` handlers in `message-handlers.js` and exports them through the central registry
> - Removes the separate `runtime.onMessage` listener in `events.js`; retains `onStartup` logic to reschedule counter messaging when flagged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 746c145385407402735d4c5bf0eed00ae3559512. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->