### PR TITLE
Update autofill to 19.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.13.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -314,7 +314,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8ce2e7cdcca4226c96350dcd49323298b941592",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },
@@ -12086,8 +12086,8 @@
             "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg=="
         },
         "@duckduckgo/autofill": {
-            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
-            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#17.0.1"
+            "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c8ce2e7cdcca4226c96350dcd49323298b941592",
+            "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#19.0.0"
         },
         "@duckduckgo/content-scope-scripts": {
             "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f6f38b4d3a518af92b523acb534eec769592bea2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.13.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.0.0


## Description
Updates Autofill to version [19.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.0.0).

### Autofill 19.0.0 release notes
## What's Changed
* Add screenshot tests for debug-ui by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/918
* Add theme variant support for overlay (macOS/Windows) by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/916
* Use AccentContentPrimary for all text on hover and press by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/923

## New Contributors
* @noisysocks made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/918

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.5.0...19.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update**
> 
> - Bumps `@duckduckgo/autofill` from `17.0.1` to `19.0.0` in `package.json` and `package-lock.json` (updated git commit refs)
> - Incorporates upstream changes from Autofill 19.0.0 release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f34ceaa841239d2f07c46b761e9203d7d14933e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->