### PR TITLE
Update the README for the integration tests

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -14,9 +14,13 @@ Playwright tests can be run with the following npm commands:
  - `npm run playwright` to test the Chrome MV3 extension
  - `npm run playwright-mv2` to test the Chrome MV2 extension (closest thing to testing Firefox MV2 extension we have until Playwright adds support for testing Firefox extensions)
 
-If you want to re-run tests without rebuilding the extension, you can subsequently run:
- - `npx playwright test` to run all tests
- - `npx playright test integration-test/<file>.spec.js` to just run tests in a single file.
+To run a specific test file, the commands can be called like this:
+ - `npm run playwright -- integration-test/example.spec.js`
+ - `npm run playwright-mv2 -- integration-test/example.spec.js`
+
+To check a test's reliability, it can be run repeatedly like this:
+ - `npm run playwright -- integration-test/example.spec.js --repeat-each=100`
+ - `npm run playwright-mv2 -- integration-test/example.spec.js --repeat-each=100`
 
 ## Writing tests
 


### PR DESCRIPTION
The documentation for the integration tests was a little unclear, so let's
simplify it. Also, let's add working examples for running individual tests, and
also for running an individual test repeatedly (useful when checking for
flakiness).

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @jonathanKingston 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `integration-test/README.md` to make Playwright usage clearer.
> 
> - Adds explicit examples for running a specific test file with `npm run playwright -- <file>` and `npm run playwright-mv2 -- <file>`
> - Documents how to repeat a test (`--repeat-each=100`) for flakiness checks
> - Removes outdated/ambiguous rerun instructions and fixes minor wording
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit def2fdae6829538fc2664fdca6096389da657ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->