### PR TITLE
Add .claude directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.claude
 *.pem
 jshint_log.txt
 node_modules


### PR DESCRIPTION
Claude Code seems to create a .claude/ directory within each project, let's
ignore that for now.