### PR TITLE
Get the Playwright tests running headlessly and allow retries

### DIFF
--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -50,7 +50,7 @@ export const test = base.extend({
         const extensionPath = manifestVersion === 3 ? 'build/chrome/dev' : 'build/chrome-mv2/dev';
         const pathToExtension = path.join(projectRoot, extensionPath);
         const context = await chromium.launchPersistentContext('', {
-            headless: false,
+            channel: 'chromium',
             args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`],
         });
         // intercept extension install page and use HAR

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -24,8 +24,8 @@ export default defineConfig({
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
-    retries: process.env.CI ? 2 : 0,
+    /* Retry flakey tests */
+    retries: 2,
     /* Opt out of parallel tests on CI. */
     workers: undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
Let's get the Playwright tests running headlessly, since that allows folks to
interact with their computer while the tests are running.

Also, let's allow retries consistently when running the tests, since they flake
sometimes when run locally too.