### PR TITLE
Improve Playwright harness reliability and error messages

### DIFF
--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -112,7 +112,7 @@ export const test = base.extend({
                 try {
                     background = await context.waitForEvent('serviceworker', { timeout: 5000 });
                 } catch (e) {
-                    ([background] = context.serviceWorkers());
+                    [background] = context.serviceWorkers();
                     if (!background) {
                         // Playwright sometimes fails in this way, which unfortunately is a common
                         // source of test flakes.


### PR DESCRIPTION
Unfortunately the Playwright tests still aren't running entirely reliably. At
least part of the issue is the Playwright harness, for example sometimes it
fails to find the extension's background ServiceWorker. Let's do what we can to
reduce those issues, and let's also improve the output when we still run into
problems.

Note: H/T to @jonathanKingston, who spotted the missing context.route
      awaits with https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/3330.
      Those seemed to cause more error message noise related to route callbacks when
      the tests flake.