### PR TITLE
Add breakageData parameter to breakage reports

### DIFF
--- a/shared/js/background/components/dashboard-messaging.js
+++ b/shared/js/background/components/dashboard-messaging.js
@@ -83,6 +83,7 @@ export default class DashboardMessaging {
                     docReferrer: breakageData.referrer,
                     opener: breakageData.opener,
                     detectorData: breakageData.detectorData,
+                    breakageData: breakageData.breakageData,
                 };
 
                 // Set userRefreshCount from pageReloaded: 0 if not reloaded, 1 if reloaded

--- a/unit-test/background/reference-tests/broken-site-reporting-tests.js
+++ b/unit-test/background/reference-tests/broken-site-reporting-tests.js
@@ -67,6 +67,7 @@ async function submitAndValidateReport(report) {
     const mockedPageParams = {
         jsPerformance: [Number.parseFloat(report.jsPerformance)],
         docReferrer: 'http://example.com',
+        breakageData: report.breakageData,
     };
 
     await breakageReportForTab({
@@ -248,5 +249,43 @@ describe('Broken Site Reporting tests / contentScopeExperiments (cohorts)', () =
         tab.contentScopeExperiments = {};
         const params = await submit(tab);
         expect(params.get('contentScopeExperiments')).toBeNull();
+    });
+});
+
+describe('Broken Site Reporting tests / breakageData', () => {
+    async function submitWithPageParams(tab, pageParams) {
+        loadPixelSpy = spyOn(loadPixel, 'url').and.returnValue(null);
+        await breakageReportForTab({
+            pixelName: 'epbf',
+            tab,
+            tds: 'abc123',
+            remoteConfigEtag: 'abd142',
+            remoteConfigVersion: '1234',
+            category: 'content',
+            description: 'test',
+            pageParams,
+        });
+        const requestURLString = loadPixelSpy.calls.argsFor(0)[0];
+        return requestURLString;
+    }
+
+    it('includes breakageData param when present', async () => {
+        const tab = new Tab({ url: 'https://example.com' });
+        const preEncodedBreakageData = '%7B%22test%22%3A%22value%22%7D';
+        const urlString = await submitWithPageParams(tab, { breakageData: preEncodedBreakageData });
+        // Check the raw URL string to ensure no double-encoding occurred
+        expect(urlString).toContain(`breakageData=${preEncodedBreakageData}`);
+    });
+
+    it('omits breakageData param when not present', async () => {
+        const tab = new Tab({ url: 'https://example.com' });
+        const urlString = await submitWithPageParams(tab, {});
+        expect(urlString).not.toContain('breakageData=');
+    });
+
+    it('omits breakageData param when undefined', async () => {
+        const tab = new Tab({ url: 'https://example.com' });
+        const urlString = await submitWithPageParams(tab, { breakageData: undefined });
+        expect(urlString).not.toContain('breakageData=');
     });
 });


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1202561462274611/task/1213015238129926?focus=true

**Reviewer:** @jonathanKingston

**CC:** @jdorweiler
**Depends on:** 

## Description:

Adds the `breakageData` parameter to breakage reports.

The value of this parameter is generated in the breakage reporting feature of Content Scope Scripts and should be passed along as-is to breakage reports.

## Steps to test this PR:

1. Make sure you're using the latest Content Scope Scripts
2. Add logging around `submitBrokenSiteReport` with the `breakageData` from CSS (or otherwise monitor breakage payload)
3. Ensure the `breakageReporting` feature is enabled via config
4. Visit a site and edit the page text to include "disable your adblocker"
5. Make a breakage report, check:
    - you can see the `breakageData` parameter in the response from CSS
    - you can see `&breakageData=` in the breakage report request, and that this exactly matches the value received from CSS without any double-encoding 

## Automated tests:
- [X] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to pixel URL construction and breakage reporting payloads; main risk is malformed URLs or unexpected truncation behavior if `breakageData` is large.
> 
> **Overview**
> Breakage report pixels now include an optional `breakageData` query parameter sourced from content-scope-scripts and **passed through without double-encoding**.
> 
> To support this, `broken-site-report.fire()`/URL construction accepts a set of *pre-encoded* params that are appended directly (and still omitted when truncating), `DashboardMessaging` forwards `breakageData` into `pageParams`, and unit tests assert presence/absence and no re-encoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3443c412fc8ad0caccd01c06f6cca75bc7817d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->