### PR TITLE
Ensure manuallyWaitForFunction Promise doesn't attempt to resolve twice

### DIFF
--- a/integration-test/helpers/backgroundWait.js
+++ b/integration-test/helpers/backgroundWait.js
@@ -9,13 +9,13 @@ function manuallyWaitForFunction(bgPage, func, { polling, timeout }, ...args) {
             try {
                 result = await bgPage.evaluate(func, ...args);
             } catch (e) {
-                reject(e);
+                return reject(e);
             }
             if (result) {
-                resolve(result);
+                return resolve(result);
             } else {
                 if (Date.now() - startTime > timeout) {
-                    reject(new errors.TimeoutError('Manually waiting for function timed out: ' + func.toString()));
+                    return reject(new errors.TimeoutError('Manually waiting for function timed out: ' + func.toString()));
                 } else {
                     setTimeout(waitForFunction, polling);
                 }


### PR DESCRIPTION
The (work in progress) Firefox Playwright harness is failing sometimes, when the
manuallyWaitForFunction function attempts to resolve/reject the returned Promise
more than once. Let's prevent that from happening, ready for when we add the new
harness.