### PR TITLE
Add Playwright harness wrapper for page.addScriptTag calls

### DIFF
--- a/integration-test/fingerprint-protection.spec.js
+++ b/integration-test/fingerprint-protection.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, getHARPath } from './helpers/playwrightHarness';
+import { test, expect, getHARPath, addScriptTag } from './helpers/playwrightHarness';
 import backgroundWait from './helpers/backgroundWait';
 import { overridePrivacyConfig } from './helpers/testConfig';
 
@@ -61,7 +61,7 @@ test.describe('First Party Fingerprint Randomization', () => {
     async function runTest(testCase, page) {
         await page.routeFromHAR(testCase.har);
         await page.goto(`https://${testCase.url}`);
-        await page.addScriptTag({ path: 'node_modules/@fingerprintjs/fingerprintjs/dist/fp.js' });
+        await addScriptTag(page, { path: 'node_modules/@fingerprintjs/fingerprintjs/dist/fp.js' });
 
         const fingerprint = await page.evaluate(() => {
             /* global FingerprintJS */

--- a/integration-test/fingerprint-randomization.spec.js
+++ b/integration-test/fingerprint-randomization.spec.js
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 
-import { test, expect } from './helpers/playwrightHarness';
+import { test, expect, addScriptTag } from './helpers/playwrightHarness';
 import { forExtensionLoaded } from './helpers/backgroundWait';
 
 const fakeOrigin = 'http://test.example';
 
 async function getFingerprintOfContext(ctx) {
-    await ctx.addScriptTag({ path: 'node_modules/@fingerprintjs/fingerprintjs/dist/fp.js' });
+    await addScriptTag(ctx, { path: 'node_modules/@fingerprintjs/fingerprintjs/dist/fp.js' });
     return ctx.evaluate(() => {
         /* global FingerprintJS */
         return (async () => {

--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -12,6 +12,18 @@ export function getManifestVersion() {
     return process.env.npm_lifecycle_event === 'playwright-mv2' ? 2 : 3;
 }
 
+/**
+ * Add a script tag to a page or frame context.
+ *
+ * @param {import('@playwright/test').Page | import('@playwright/test').Frame} context
+ *   Page or frame to inject script into.
+ * @param {{path?: string, content?: string, url?: string}} options
+ *   Details of the script to inject.
+ */
+export async function addScriptTag(context, options) {
+    await context.addScriptTag(options);
+}
+
 async function routeLocalResources(route) {
     const url = new URL(route.request().url());
     const localPath = path.join(testRoot, 'data', 'staticcdn', url.pathname);


### PR DESCRIPTION
The (work in progress) Firefox Playwright harness needs to add script tags in a
different way, due to Firefox using more restrictive CSP enforcement. Let's
create a simple wrapper for page.addScriptTag for now, to reduce the refactoring
required when we add the new Firefox harness.