### PR TITLE
Ensure the Playwright route handler is set up early enough

### DIFF
--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -11,7 +11,7 @@ test.describe('install workflow', () => {
         expect(postInstallURL.pathname).toBe('/extension-success');
         expect(postInstallURL.searchParams.has('atb')).toBe(true);
         // This ATB comes from the success page.
-        expect(postInstallURL.searchParams.get('atb')).not.toEqual(mockAtb.version);
+        expect(postInstallURL.searchParams.get('atb')).toMatch(/^v[\d-]+$/);
     });
 
     test.describe('atb values', () => {


### PR DESCRIPTION
Tests were sometimes timing out for the MV3 build, waiting for
`background.forAllConfiguration()` to resolve. It turned out, that occasionally
the request for the HTTPS bloom filter would start before the route handler
could be set up, which resulted in the request sometimes failing and therefore
`https.isReady` to remain false. Let's set up the route handler as soon as
possible, to avoid that from happening.

Notes:
 - The ATB tests had to be tweaked, since with this change routing was set up
   early enough for the MV3 build to ensure the initial ATB request was routed
   and uses the mock ATB value stored in the HAR file.
 - It turns out that routing on the persistent context does _not_ catch
   extension background initiated requests for the MV2 extension, so we need to
   continue routing from the background page there.
 - There is a race condition where requests can be made between when Playwright
   sets up the persistent browser context, and when the routing is set up (both
   for MV2 and MV3). Therefore we can't always be sure if the extension-success
   page is going to be routed or not.