### PR TITLE
Get the integration tests for storage blocking running more reliably

### DIFF
--- a/integration-test/storage-blocking.spec.js
+++ b/integration-test/storage-blocking.spec.js
@@ -4,6 +4,7 @@ import { overridePrivacyConfig, overrideTds } from './helpers/testConfig';
 import { TEST_SERVER_ORIGIN, routeFromLocalhost } from './helpers/testPages';
 
 const testPageDomain = 'privacy-test-pages.site';
+const testPageParams = '?timeout=10000';
 const thirdPartyDomain = 'good.third-party.site';
 const thirdPartyTracker = 'broken.third-party.site';
 const thirdPartyAd = 'convert.ad-company.site';
@@ -27,7 +28,9 @@ test.describe('Storage blocking Tests', () => {
         await backgroundWait.forAllConfiguration(backgroundPage);
         await routeFromLocalhost(page);
         await page.bringToFront();
-        await page.goto(`https://${testPageDomain}/privacy-protections/storage-blocking/?store`, { waitUntil: 'networkidle' });
+        await page.goto(`https://${testPageDomain}/privacy-protections/storage-blocking/${testPageParams}&store`, {
+            waitUntil: 'networkidle',
+        });
         await waitForAllResults(page);
         const cookies = await context.cookies();
         const nowSeconds = Date.now() / 1000;
@@ -78,7 +81,7 @@ test.describe('Storage blocking Tests', () => {
     test.describe('Cookie blocking tests', () => {
         async function runStorageTest(page, origin) {
             await page.bringToFront();
-            await page.goto(`${origin}/privacy-protections/storage-blocking/?store`);
+            await page.goto(`${origin}/privacy-protections/storage-blocking/${testPageParams}&store`);
             await waitForAllResults(page);
             await page.click('#retrive');
             await waitForAllResults(page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "lottie-web": "^5.13.0",
                 "nanohtml": "^1.10.0",
                 "normalize.scss": "0.1.0",
-                "privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.5",
+                "privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.6",
                 "punycode": "2.3.1",
                 "tldts": "^7.0.12",
                 "web-ext": "^8.9.0",
@@ -164,6 +164,7 @@
             "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -206,6 +207,7 @@
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
@@ -223,6 +225,7 @@
             "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -240,6 +243,7 @@
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -250,6 +254,7 @@
             "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -264,6 +269,7 @@
             "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -282,6 +288,7 @@
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -301,6 +308,7 @@
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -311,6 +319,7 @@
             "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -325,6 +334,7 @@
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.29.0"
             },
@@ -350,6 +360,7 @@
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -365,6 +376,7 @@
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -384,6 +396,7 @@
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.28.5"
@@ -490,7 +503,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -514,7 +526,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1431,6 +1442,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
             "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/fast-memoize": "3.1.0",
                 "@formatjs/intl-localematcher": "0.8.1",
@@ -1443,6 +1455,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
             "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.1"
             }
@@ -1452,6 +1465,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
             "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "3.1.1",
                 "@formatjs/icu-skeleton-parser": "2.1.1",
@@ -1463,6 +1477,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
             "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "3.1.1",
                 "tslib": "^2.8.1"
@@ -1473,6 +1488,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
             "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/fast-memoize": "3.1.0",
                 "tslib": "^2.8.1"
@@ -1604,6 +1620,7 @@
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1615,6 +1632,7 @@
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -2378,7 +2396,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2868,7 +2885,8 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/addons-linter/node_modules/type-fest": {
             "version": "0.20.2",
@@ -2887,7 +2905,8 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/addons-linter/node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -2895,6 +2914,7 @@
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -3466,6 +3486,7 @@
             "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
             }
@@ -3583,6 +3604,10 @@
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "license": "ISC"
+        },
+        "node_modules/bowser": {
+            "resolved": "git+ssh://git@github.com/jonathanKingston/bowser.git#f5e7f89f9b807f58d9a6787523ddaf06fa0c30e0",
+            "license": "MIT"
         },
         "node_modules/boxen": {
             "version": "8.0.1",
@@ -3878,7 +3903,8 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0"
+            "license": "CC-BY-4.0",
+            "peer": true
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -4808,8 +4834,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
             "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/dexie": {
             "version": "4.0.11",
@@ -4974,7 +4999,8 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
             "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -5383,7 +5409,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6585,6 +6610,7 @@
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -8182,6 +8208,7 @@
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -8665,6 +8692,7 @@
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -9417,7 +9445,8 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
             "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/normalize-html-whitespace": {
             "version": "0.2.0",
@@ -10064,14 +10093,15 @@
         },
         "node_modules/privacy-test-pages": {
             "name": "@duckduckgo/privacy-test-pages",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#74d9a2a3e931adf782b444ce07b0030a6663baad",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-test-pages.git#417de1735382f36487b3d561c8673bcd92d56a35",
             "dependencies": {
-                "@duckduckgo/content-scope-scripts": "git+https://git@github.com/duckduckgo/content-scope-scripts#9.8.0",
-                "body-parser": "^2.2.0",
+                "@duckduckgo/content-scope-scripts": "git+https://git@github.com/duckduckgo/content-scope-scripts#12.37.0",
+                "body-parser": "^2.2.1",
+                "bowser": "github:jonathanKingston/bowser#jkt/ddg",
                 "express": "^4.19.2",
                 "node-cache": "^5.1.2",
                 "node-cmd": "^5.0.0",
-                "ws": "^8.18.2"
+                "ws": "^8.19.0"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -12224,7 +12254,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -12334,6 +12363,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -13244,7 +13274,8 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/yargs": {
             "version": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "lottie-web": "^5.13.0",
         "nanohtml": "^1.10.0",
         "normalize.scss": "0.1.0",
-        "privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.5",
+        "privacy-test-pages": "github:duckduckgo/privacy-test-pages#1.3.6",
         "punycode": "2.3.1",
         "tldts": "^7.0.12",
         "web-ext": "^8.9.0",


### PR DESCRIPTION
The storage blocking integration tests were failing quite often. It turned out
that the test page[1] loads several iframes, and gives up waiting for them to
load after one second. When they don't load quickly enough,
`waitForAllResults()` never resolves, and the tests will timeout after 30
seconds.

Usually, the answer would be to route the iframe requests locally using
Playwright. Unfortunately, in this instance we can't do that because doing so
prevents the extension's cookie protections from being applied. Instead, let's
workaround the issue for now by having the testpage wait for up to 10 seconds
for those iframes to load instead.

1 - https://privacy-test-pages.site/privacy-protections/storage-blocking