### PR TITLE
Get the HTTPS loop protection tests running more reliably

### DIFF
--- a/integration-test/https-loop-protection.spec.js
+++ b/integration-test/https-loop-protection.spec.js
@@ -10,14 +10,37 @@ test.describe('Loop protection', () => {
         await backgroundWait.forAllConfiguration(backgroundPage);
         await routeFromLocalhost(page);
 
+        // HTTPS loop detection considers REQUEST_REDIRECT_LIMIT upgrades within
+        // MAINFRAME_RESET_MS to be a loop.
+        const [REQUEST_REDIRECT_LIMIT, MAINFRAME_RESET_MS] = await backgroundPage.evaluate(() => [
+            globalThis.dbg.HttpsRedirects.REQUEST_REDIRECT_LIMIT,
+            globalThis.dbg.HttpsRedirects.MAINFRAME_RESET_MS,
+        ]);
+
+        const upgradeTimes = [];
+        context.on('request', (request) => {
+            if (request.url().startsWith('https://') && request.url().includes('http-only.html')) {
+                upgradeTimes.push(Date.now());
+            }
+        });
+
         await page.goto(loopProtectionPage, { waitUntil: 'networkidle' });
         await page.click('#start');
         await page.waitForFunction(() => results.date !== null && results.results[0].value !== null, { polling: 100, timeout: 20000 });
-        const results = await page.evaluate(() => {
-            return results;
-        });
 
-        // The expected outcome of this test is we land back on http:// rather than upgrading forever to https://
+        // When the tests are running too slowly, the redirections don't happen
+        // quickly enough to trigger the loop protection feature.
+        // Note: Use the request after REQUEST_REDIRECT_LIMIT, since that's when
+        //       the feature's canRedirect check happens.
+        const followingRequest = REQUEST_REDIRECT_LIMIT + 1;
+        test.skip(
+            !(upgradeTimes.length > followingRequest && upgradeTimes[followingRequest] - upgradeTimes[0] < MAINFRAME_RESET_MS),
+            'Tests are running too slowly for HTTPS loop protection to activate.',
+        );
+
+        const results = await page.evaluate(() => results);
+
+        // The expected outcome is we land back on http:// rather than upgrading forever to https://
         const expectedValue = 'http://good.third-party.site/privacy-protections/https-loop-protection/http-only.html';
         expect(results.results[0].value).toEqual(expectedValue);
     });

--- a/shared/js/background/devbuild.js
+++ b/shared/js/background/devbuild.js
@@ -14,6 +14,7 @@ const https = require('./https');
 const browserWrapper = require('./wrapper');
 const utils = require('./utils');
 const Tab = require('./classes/tab');
+const HttpsRedirects = require('./classes/https-redirects');
 const { TabState } = require('./classes/tab-state');
 const Wrapper = require('./wrapper.js');
 const { setListContents, getListContents } = require('./message-handlers');
@@ -28,6 +29,7 @@ export default function initDebugBuild() {
         },
         tabManager,
         Tab,
+        HttpsRedirects,
         TabState,
         Wrapper,
         atb,


### PR DESCRIPTION
The HTTPS loop protection feature aims to protect the user from infinite
redirection loops caused by upgrading HTTP navigations to HTTPS. It works by
activating if seven such redirections happening within a three second window.

When the integration tests were running slowly, the test page's redirections
didn't happen within that three second window, so the tests would fail. Let's
add a check, so that when the tests are running too slowly to work, we skip them
instead.