### PR TITLE
Fix flaky tests for CPM pixels

### DIFF
--- a/integration-test/cookie-prompt-management.spec.js
+++ b/integration-test/cookie-prompt-management.spec.js
@@ -16,10 +16,10 @@ test.describe('Cookie Prompt Management', () => {
     }
 
     let cleanup;
-    const pixelRequests = [];
+    let pixelRequests = [];
 
     test.beforeEach(async ({ context, backgroundPage, backgroundNetworkContext }) => {
-        pixelRequests.length = 0;
+        pixelRequests = [];
         cleanup = await logPixels(backgroundPage, backgroundNetworkContext, pixelRequests, (pixel) =>
             pixel.name?.startsWith('autoconsent_'),
         );


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @kzar 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Fix playwright tests that started being flaky https://github.com/duckduckgo/duckduckgo-privacy-extension/actions/runs/22358790434/job/64710350161

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust Playwright request logging lifecycle; low production risk, with main risk being missed/over-captured pixel events if the new shared setup is incorrect.
> 
> **Overview**
> Stabilizes the CPM Playwright integration test that asserts autoconsent pixels by moving pixel logging into `beforeEach` and sharing a single `pixelRequests` buffer across tests.
> 
> Adds `afterEach` cleanup of the pixel request listeners to avoid leaking listeners/state between tests, and removes the per-test `logPixels` setup from `Fires expected pixels`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 067ef6377b25204adfa44b73d2d2d3723ba3fbd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->