### PR TITLE
Pass consentomatic rules in CPM component

### DIFF
--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -1,4 +1,5 @@
 import { filterCompactRules, evalSnippets } from '@duckduckgo/autoconsent';
+import { consentomatic } from '@duckduckgo/autoconsent/rules/consentomatic.json';
 import browser from 'webextension-polyfill';
 import { getFromSessionStorage, setToSessionStorage, createAlarm } from '../wrapper';
 import { registerMessageHandler } from '../message-registry';
@@ -439,7 +440,7 @@ export default class CookiePromptManagement {
                 const compactRuleList = autoconsentSettings.compactRuleList;
                 const rules = {
                     autoconsent: [],
-                    consentomatic: [],
+                    consentomatic,
                 };
                 if (compactRuleList) {
                     if (compactRuleList.index) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Enables consentomatic rules in the embedded CPM extension

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change limited to rule sourcing for CPM init; main risk is behavior changes in cookie prompt handling due to enabling the consentomatic ruleset.
> 
> **Overview**
> **Enables Consent-o-Matic rules in embedded Cookie Prompt Management.** The CPM background component now imports the bundled `consentomatic.json` ruleset and sends it in the `rules` payload during `init`, instead of passing an empty `consentomatic` list.
> 
> No hardcoded secrets were introduced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09f30681f32b4a317a2cebeb7366132b833c6e4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->