### PR TITLE
Fix surrogate tests

### DIFF
--- a/integration-test/data/api_schemas/facebook-sdk.json
+++ b/integration-test/data/api_schemas/facebook-sdk.json
@@ -397,6 +397,31 @@
             },
             "writable": "true"
         },
+        "FedCM": {
+            "configurable": "true",
+            "enumerable": "true",
+            "value": {
+                "getProviderConfig": {
+                    "configurable": "true",
+                    "enumerable": "true",
+                    "value": "function(0)",
+                    "writable": "true"
+                },
+                "isSupported": {
+                    "configurable": "true",
+                    "enumerable": "true",
+                    "value": "function(0)",
+                    "writable": "true"
+                },
+                "processCredential": {
+                    "configurable": "true",
+                    "enumerable": "true",
+                    "value": "function(0)",
+                    "writable": "true"
+                }
+            },
+            "writable": "true"
+        },
         "Frictionless": {
             "configurable": "true",
             "enumerable": "true",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Facebook added FedCM (Federated Credential Management) support to their JS SDK with three new methods: getProviderConfig, isSupported, and processCredential. This is part of the FedCM web standard for federated login without third-party cookies.

This change broke CI tests on main.

No surrogate script changes needed in this repo — the surrogate lives in content-scope-scripts. The FedCM methods are new additions that don't affect the existing surrogate's ability to prevent tracking. A follow-up in content-scope-scripts may be needed to add FedCM stubs to the surrogate if sites start depending on them.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts a test fixture JSON to match upstream Facebook SDK changes and does not modify runtime/surrogate behavior.
> 
> **Overview**
> Updates the Facebook SDK integration-test expected schema (`integration-test/data/api_schemas/facebook-sdk.json`) to include the new `FB.FedCM` object with `getProviderConfig`, `isSupported`, and `processCredential` methods.
> 
> This aligns the schema-drift test with the current upstream SDK API surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876a7142ee8b35b124fc506235463b3c966d7c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->