### PR TITLE
Bump @duckduckgo/privacy-dashboard to 9.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
-                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.7.0",
+                "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.10.1",
                 "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
@@ -852,7 +852,7 @@
         },
         "node_modules/@duckduckgo/privacy-dashboard": {
             "version": "7.3.2",
-            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#0f8925a4fc8f2b98df6bc7294b49fc4c1561bf16",
+            "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#40a8c752fb73a15738899dc0edb5e17e33302a37",
             "engines": {
                 "node": ">=22.0.0",
                 "npm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.7.0",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.10.1",
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",


### PR DESCRIPTION
**Reviewer:**

## Description:
Replaces #3487.

Incorporates updated copy for the extension fire button, see https://github.com/duckduckgo/privacy-dashboard/pull/604.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no direct application logic changes; primary risk is unintended UI/regression introduced by the updated `privacy-dashboard` package.
> 
> **Overview**
> Bumps the `@duckduckgo/privacy-dashboard` dependency from `9.7.0` to `9.10.1`.
> 
> Updates `package-lock.json` to the new `privacy-dashboard` git commit hash, ensuring installs pull the newer dashboard build (including updated UI copy referenced by the dependency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5948a0a26d22c2fa08fbd1ac7775521440766a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->