### PR TITLE
Update autoconsent to v14.71.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.3.31",
+    "version": "2026.4.14",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^14.67.0",
+                "@duckduckgo/autoconsent": "^14.71.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "14.67.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.67.0.tgz",
-            "integrity": "sha512-mZMpDdn7IrgtJ3JFWbxU8krkZAS11PMqASmBqEpgWvEhbcL3leB2dzh1kA/KNyrmUv/iHrIVVLuZt5HlgyfsWQ==",
+            "version": "14.71.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.71.0.tgz",
+            "integrity": "sha512-EuObajkAKp5IVze+yz7FQjQwcP09utaj+H01+ETmOhDtDImP8tzjCHMCM6sre7ykAAxlKdkvuW4z2zwi88ToTw==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^14.67.0",
+        "@duckduckgo/autoconsent": "^14.71.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214055450877035
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v14.71.0

## Description
Updates Autoconsent to version [v14.71.0](https://github.com/duckduckgo/autoconsent/releases/tag/v14.71.0).

### Autoconsent v14.71.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v14.71.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a dependency bump plus a manifest version increment; behavior changes are limited to whatever is introduced by the upstream `autoconsent` release.
> 
> **Overview**
> Updates `@duckduckgo/autoconsent` from `14.67.0` to `14.71.0` in `package.json` and `package-lock.json` (including the resolved tarball and integrity hash).
> 
> Bumps the embedded extension manifest version in `browsers/embedded/manifest.json` from `2026.3.31` to `2026.4.14`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a83d16dbeaa7e17dd56e4bad534bbaf106d390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->