### PR TITLE
Test: mock duckduckgo page in fire-button integration spec

### DIFF
--- a/integration-test/fire-button.spec.js
+++ b/integration-test/fire-button.spec.js
@@ -3,10 +3,38 @@ import { test, expect, getManifestVersion } from './helpers/playwrightHarness';
 import { routeFromLocalhost } from './helpers/testPages';
 
 const burnAnimationRegex = /^chrome-extension:\/\/[a-z]*\/html\/fire.html$/;
+const duckDuckGoMockPage = `<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>DuckDuckGo Mock Page</title>
+    </head>
+    <body>
+        <main>DuckDuckGo mock</main>
+    </body>
+</html>`;
+
+function routeFromLocalhostWithDuckDuckGoMock(page) {
+    return routeFromLocalhost(page, (route) => {
+        const url = new URL(route.request().url());
+        if (url.hostname === 'duckduckgo.com') {
+            route.fulfill({
+                status: 200,
+                contentType: 'text/html; charset=utf-8',
+                body: duckDuckGoMockPage,
+                headers: {
+                    'cache-control': 'no-store',
+                },
+            });
+            return true;
+        }
+        return false;
+    });
+}
 
 async function loadPageInNewTab(context, url) {
     const page = await context.newPage();
-    routeFromLocalhost(page);
+    await routeFromLocalhostWithDuckDuckGoMock(page);
     await page.goto(url, { waitUntil: 'networkidle' });
     return page;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Reviewer:** @kzar 

## Description:
Fixes CI failures in fire-button tests.

- Add a deterministic DuckDuckGo page mock route to `integration-test/fire-button.spec.js`.
- Update tab setup to use `routeFromLocalhost` with an override that fulfills `duckduckgo.com` requests with static HTML that does not set cookies.
- This removes dependence on live `duckduckgo.com` experiment cookies (for example `experiment_homepagerebranding`) that were causing flaky/incorrect fire-button assertions.

## Steps to test this PR:
1. `PLAYWRIGHT_HTML_OPEN=never npm run playwright -- integration-test/fire-button.spec.js --workers=1`
2. `PLAYWRIGHT_HTML_OPEN=never npm run playwright-mv2 -- integration-test/fire-button.spec.js --workers=1`
3. Confirm both suites pass.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation

###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-531d78d6-dc7e-47e2-8411-a39428fca23e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-531d78d6-dc7e-47e2-8411-a39428fca23e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

