### PR TITLE
Split out pixel suffix logic from the integration tests

### DIFF
--- a/integration-test/broken-site-report.spec.js
+++ b/integration-test/broken-site-report.spec.js
@@ -1,7 +1,7 @@
 import { test, expect, mockAtb } from './helpers/playwrightHarness';
 import backgroundWait from './helpers/backgroundWait';
 import { routeFromLocalhost } from './helpers/testPages';
-import { listenForBreakageReport } from './helpers/pixels';
+import { listenForBreakageReport, pixelBrowserSuffix } from './helpers/pixels';
 
 test.describe('Broken site reports', () => {
     test('Sends broken site reports with current page context', async ({ context, backgroundPage, page, backgroundNetworkContext }) => {
@@ -15,7 +15,7 @@ test.describe('Broken site reports', () => {
         await backgroundPage.evaluate(() => globalThis.components.dashboardMessaging.submitBrokenSiteReport({ category: 'dislike' }));
         const pixel = await breakageReport;
         expect(pixel).toMatchObject({
-            name: 'epbf_chrome',
+            name: 'epbf' + pixelBrowserSuffix,
             params: {
                 adAttributionRequests: '',
                 atb: mockAtb.version,
@@ -72,7 +72,7 @@ test.describe('Broken site reports', () => {
         await backgroundPage.evaluate(() => globalThis.components.dashboardMessaging.submitBrokenSiteReport({ category: 'dislike' }));
         const pixel = await breakageReport;
         expect(pixel).toMatchObject({
-            name: 'epbf_chrome',
+            name: 'epbf' + pixelBrowserSuffix,
             params: {
                 adAttributionRequests: '',
                 atb: mockAtb.version,

--- a/integration-test/click-attribution.spec.js
+++ b/integration-test/click-attribution.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from './helpers/playwrightHarness';
 import backgroundWait from './helpers/backgroundWait';
-import { logPixels } from './helpers/pixels';
+import { logPixels, pixelSuffix } from './helpers/pixels';
 import testCases from 'privacy-test-pages/adClickFlow/shared/testCases.json';
 
 if (testCases.length === 0) {
@@ -113,9 +113,7 @@ test.describe('Ad click blocking', () => {
                     step.expected.pixels.length,
                 );
                 for (let i = 0; i < step.expected.pixels.length; i++) {
-                    // Integration tests only run on Chrome so far, so this is a
-                    // safe assumption for now.
-                    step.expected.pixels[i].name += '_extension_chrome';
+                    step.expected.pixels[i].name += pixelSuffix;
 
                     if (step.expected.pixels[i]?.params?.appVersion === 'APP_VERSION') {
                         step.expected.pixels[i].params.appVersion = extensionVersion;

--- a/integration-test/cookie-prompt-management.spec.js
+++ b/integration-test/cookie-prompt-management.spec.js
@@ -2,7 +2,7 @@ import { test, expect, getManifestVersion } from './helpers/playwrightHarness';
 import backgroundWait from './helpers/backgroundWait';
 import { overridePrivacyConfig } from './helpers/testConfig';
 import { routeFromLocalhost } from './helpers/testPages';
-import { logPixels } from './helpers/pixels';
+import { logPixels, pixelSuffix } from './helpers/pixels';
 
 const autoconsentTestPage = 'https://privacy-test-pages.site/features/autoconsent/';
 const bannerTestPage = 'https://privacy-test-pages.site/features/autoconsent/banner.html';
@@ -145,10 +145,9 @@ test.describe('Cookie Prompt Management', () => {
         await page.waitForTimeout(2000);
 
         // Verify that at least the init and done pixels were fired.
-        // Pixel names include browser suffix, e.g. "autoconsent_init_daily_extension_chrome"
-        const pixelNames = pixelRequests.map((p) => p.name);
-        expect(pixelNames.some((n) => n.includes('autoconsent_init_daily'))).toBeTruthy();
-        expect(pixelNames.some((n) => n.includes('autoconsent_popup-found_daily'))).toBeTruthy();
-        expect(pixelNames.some((n) => n.includes('autoconsent_done_daily'))).toBeTruthy();
+        const seenPixels = new Set(pixelRequests.map((p) => p.name));
+        expect(seenPixels.has('autoconsent_init_daily' + pixelSuffix)).toBe(true);
+        expect(seenPixels.has('autoconsent_popup-found_daily' + pixelSuffix)).toBe(true);
+        expect(seenPixels.has('autoconsent_done_daily' + pixelSuffix)).toBe(true);
     });
 });

--- a/integration-test/helpers/pixels.js
+++ b/integration-test/helpers/pixels.js
@@ -1,12 +1,30 @@
 import { logPageRequests } from './requests';
 import { _formatPixelRequestForTesting } from '../../shared/js/shared-utils/pixels';
 
+const expectedBrowserSuffix = /_chrome$/;
+
+// Most pixel names have a suffix something like "_extension_chrome", the
+// exception being breakage report pixels, which end with just something like
+// "_chrome".
+export const pixelBrowserSuffix = '_BROWSER';
+export const pixelSuffix = '_extension' + pixelBrowserSuffix;
+
 function requestIsPixel(request) {
     return request?.url?.hostname === 'improving.duckduckgo.com';
 }
 
 function formatPixelRequest(request) {
-    return _formatPixelRequestForTesting(request.url);
+    const pixel = _formatPixelRequestForTesting(request.url);
+
+    // Replace browser suffix with placeholder, so that the pixel tests can run
+    // against all platforms.
+    // Note: Only replace pixel suffix if it is correct, to ensure later
+    //       assertions fail otherwise.
+    if (pixel?.name) {
+        pixel.name = pixel.name.replace(expectedBrowserSuffix, pixelBrowserSuffix);
+    }
+
+    return pixel;
 }
 
 export function logPixels(backgroundPage, page, pixelRequests, filter) {


### PR DESCRIPTION
Some of the integration tests verify that the expected pixel requests are firing
correctly, including that the "_extension_BROWSER" suffix was included in the
name. So far, the browser part was hardcoded to "_chrome" in the tests as they
only ran against Chrome. Now that we are working to get them running against
Firefox as well, let's split out the pixel suffix logic into the helper.