### PR TITLE
Remove productSub assertion from fingerprinting integration tests

### DIFF
--- a/integration-test/fingerprint-protection.spec.js
+++ b/integration-test/fingerprint-protection.spec.js
@@ -9,7 +9,6 @@ const expectedFingerprintValues = {
     wAvailLeft: 0,
     colorDepth: 24,
     pixelDepth: 24,
-    productSub: '20030107',
     vendorSub: '',
 };
 
@@ -41,7 +40,6 @@ test.describe('Fingerprint Defense Tests', () => {
                     wAvailLeft: globalThis.screen.availLeft,
                     colorDepth: screen.colorDepth,
                     pixelDepth: screen.pixelDepth,
-                    productSub: navigator.productSub,
                     vendorSub: navigator.vendorSub,
                 };
             });


### PR DESCRIPTION
The anti-fingerprinting integration tests check that certain values that are
sometimes misused for fingerprinting are correctly sanitised by the
content-scope-scripts protections.

Let's remove the `navigator.productSub` assertion, since:

a. The value differs for Firefox vs Chrome, and so will require changes when we
   get the tests running against Firefox.
b. The content-scope-scripts fingerprint protections don't actually change the
   productSub value anyway.
c. The tests (including the productSub) check are duplicated in the
   content-scope-scripts repository[1] as well.

1 - https://github.com/duckduckgo/content-scope-scripts/blob/main/injected/integration-test/fingerprint.spec.js