### PR TITLE
Remove deep-freeze dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
                 "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
                 "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
-                "deep-freeze": "0.0.1",
                 "dexie": "4.0.11",
                 "eventemitter2": "6.4.9",
                 "i18next": "^25.2.1",
@@ -4789,12 +4788,6 @@
             "engines": {
                 "node": ">=4.0.0"
             }
-        },
-        "node_modules/deep-freeze": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
-            "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
-            "license": "public domain"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
         "@duckduckgo/privacy-grade": "file:packages/privacy-grade",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#main",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#1.3.2",
-        "deep-freeze": "0.0.1",
         "dexie": "4.0.11",
         "eventemitter2": "6.4.9",
         "i18next": "^25.2.1",

--- a/shared/js/ui/base/store.js
+++ b/shared/js/ui/base/store.js
@@ -37,9 +37,29 @@
 
 // Dependencies
 const { isPlainObject } = require('is-plain-object');
-const deepFreeze = require('deep-freeze');
 const EventEmitter2 = require('eventemitter2');
 const notifiers = require('./notifiers.js');
+
+/**
+ * Recursively freezes objects and arrays to keep notifications immutable.
+ * Mirrors the behavior we previously relied on from `deep-freeze`.
+ * @param {any} value
+ * @returns {any}
+ */
+function deepFreeze(value) {
+    Object.freeze(value);
+    Object.getOwnPropertyNames(value).forEach((property) => {
+        if (
+            Object.prototype.hasOwnProperty.call(value, property) &&
+            value[property] !== null &&
+            (typeof value[property] === 'object' || typeof value[property] === 'function') &&
+            !Object.isFrozen(value[property])
+        ) {
+            deepFreeze(value[property]);
+        }
+    });
+    return value;
+}
 
 /**
  * .register() creates a notifier function for each caller.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Reviewer:**

## Description:
- Remove the `deep-freeze` npm dependency from the extension root package.
- Replace its single usage in `shared/js/ui/base/store.js` with an internal recursive `deepFreeze` helper to preserve immutable notification behavior.

## Steps to test this PR:
1. Run `npm run test.unit`.
2. Run `npm run playwright -- integration-test/onboarding.spec.js`.

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation

###### PR Author Checklist:
- [x] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b6158e-c0fe-4c70-8270-1c3d61bd3c7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b6158e-c0fe-4c70-8270-1c3d61bd3c7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

