### PR TITLE
Ensure urlParametersRemoved flag is preserved for tabs reliably

### DIFF
--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -118,19 +118,20 @@ function handleRequest(requestData) {
 
         // Tracking parameter stripping.
 
-        thisTab.urlParametersRemoved =
-            // Tracking parameters were stripped previously, this is the request
-            // event that fired after the redirection to strip the parameters.
-            (thisTab.urlParametersRemovedUrl && thisTab.urlParametersRemovedUrl === requestData.url) ||
-            // Strip tracking parameters if 1. there are any and 2. the feature
-            // is enabled for both the request URL and the initiator URL.
-            (trackingParametersStrippingEnabled(thisTab.site, requestData.initiator || requestData.originUrl) &&
-                stripTrackingParameters(mainFrameRequestURL));
+        // Strip tracking parameters if 1. there are any and 2. the feature is
+        // enabled for both the request URL and the initiator URL.
+        const urlParametersRemovedForThisRequest =
+            trackingParametersStrippingEnabled(thisTab.site, requestData.initiator || requestData.originUrl) &&
+            stripTrackingParameters(mainFrameRequestURL);
 
-        // To strip tracking parameters, the request is redirected and this event
-        // listener fires again for the redirected request. Take note of the URL
-        // before redirecting the request, so that  the `urlParametersRemoved`
-        // breakage flag persists after the redirection.
+        // Ensure the urlParametersRemoved flag is preserved for the tab after
+        // the redirection to remove the parameters has happened. That is needed
+        // for inclusion in breakage reports.
+        thisTab.urlParametersRemoved =
+            (thisTab.urlParametersRemovedUrl && thisTab.urlParametersRemovedUrl === requestData.url) || urlParametersRemovedForThisRequest;
+
+        // Note the redirection URL for the above urlParametersRemoved check,
+        // and ensure the flag is cleared for subsequent navigations.
         if (thisTab.urlParametersRemoved && !thisTab.urlParametersRemovedUrl) {
             thisTab.urlParametersRemovedUrl = mainFrameRequestURL.href;
         } else {
@@ -140,7 +141,7 @@ function handleRequest(requestData) {
         // add atb params only to main_frame
         const atbParametersAdded = ATB.addParametersMainFrameRequestUrl(mainFrameRequestURL);
 
-        if (thisTab.urlParametersRemoved || ampRedirected || atbParametersAdded) {
+        if (urlParametersRemovedForThisRequest || ampRedirected || atbParametersAdded) {
             return { redirectUrl: mainFrameRequestURL.href };
         }
     } else {

--- a/shared/js/background/tab-manager.js
+++ b/shared/js/background/tab-manager.js
@@ -18,7 +18,14 @@ const { getCurrentTab } = require('./utils');
 
 // These tab properties are preserved when a new tab Object replaces an existing
 // one for the same tab ID.
-const persistentTabProperties = ['ampUrl', 'cleanAmpUrl', 'dnrRuleIdsByDisabledClickToLoadRuleAction', 'userRefreshCount'];
+const persistentTabProperties = [
+    'ampUrl',
+    'cleanAmpUrl',
+    'dnrRuleIdsByDisabledClickToLoadRuleAction',
+    'urlParametersRemoved',
+    'urlParametersRemovedUrl',
+    'userRefreshCount',
+];
 
 class TabManager {
     constructor() {


### PR DESCRIPTION
The tracking parameter protection feature takes care to strip common tracking
parameters from URLs, to help reduce their use in tracking the user. When
tracking parameters have been stripped, we set the urlParametersRemoved flag for
the current tab, so that if the user then reports a website as being broken, we
can see that the feature was active for it. That way, we can work to improve the
rules so that the feature doesn't break websites.

It turned out that on Firefox this flag wasn't being preserved correctly, as the
navigation and request events fire in a slightly different order. Instead of
`webNavigation.onBeforeNavigate` firing before `webRequest.onBeforeRequest` for
navigations like is expected on Chrome, we found the opposite on Firefox. That
was causing the integration tests for the feature to fail on Firefox.

To fix this, we needed to make two changes. Firstly, we needed to set the flag as
a persistent Tab property, as it can be set _before_ the latest Tab Object's
creation. Secondly, we needed to better differentiate when parameters need to be
stripped vs when they were just stripped to avoid a redirect loop in Firefox
given the event order.

**Reviewer:** @sammacbeth 

## Steps to test this PR:
1. Navigate to https://privacy-test-pages.site/privacy-protections/query-parameters/
2. Click the first link
3. Check that the tracking parameter was stripped from the URL
4. Send a breakage report for the page, ensure `urlParametersRemoved=true` is included with the report that was sent.
5. Navigate to https://news.ycombinator.com in the same tab.
6. Send a second breakage report, ensure `urlParametersRemoved=false` is sent in the report this time.

## Automated tests:
- [ ] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
