### PR TITLE
Adjust the integration test blocklist for Click to Load

### DIFF
--- a/integration-test/data/click-to-load-tds.json
+++ b/integration-test/data/click-to-load-tds.json
@@ -38,36 +38,6 @@
                     "action": "block-ctl-fb"
                 },
                 {
-                    "rule": "facebook\\.com\\/tr\\/",
-                    "fingerprinting": 0,
-                    "cookies": 0.000543,
-                    "comment": "pixel"
-                },
-                {
-                    "rule": "facebook\\.com\\/tr",
-                    "fingerprinting": 0,
-                    "cookies": 0,
-                    "comment": "pixel"
-                },
-                {
-                    "rule": "facebook\\.com\\/photo\\.php",
-                    "fingerprinting": 0,
-                    "cookies": 0,
-                    "comment": "pixel"
-                },
-                {
-                    "rule": "facebook\\.com\\/ajax\\/bz",
-                    "fingerprinting": 0,
-                    "cookies": 0,
-                    "comment": "pixel"
-                },
-                {
-                    "rule": "facebook\\.com\\/method\\/links\\.getStats",
-                    "fingerprinting": 0,
-                    "cookies": 0,
-                    "comment": "pixel"
-                },
-                {
                     "rule": "facebook\\.com\\/",
                     "action": "block-ctl-fb"
                 }


### PR DESCRIPTION
The Click to Load feature works by blocking embedded content and replacing it
with a placeholder that allows the user to click to load it. That way, the idea
was to protect the user's privacy while still giving them the option to view
such embedded content if they need to. Some requests continue to be blocked even
after the user clicks to load embedded content, for example some pixel/analytics
requests.

The integration tests for Facebook Click to Load were checking that no further
Facebook requests were blocked after the placeholder was clicked, but they
didn't consider the pixel requests that we always expect to be blocked. Those
tests happened to pass anyway, since the Facebook script requests were stubbed
with routeFromLocalhost and so the subsequent pixel requests weren't being
made (and therefore weren't being blocked).

Unfortunately however, for the WIP Firefox test harness we don't have
routeFromLocalhost and so the real script is loading and those pixel requests
are therefore blocked. For now, let's remove those pixel requests from the test
blocklist used by the integration tests, so that the tests can pass on Firefox
as well.

Note: This blocklist is only used by the integration tests, and does not impact
      which requests are blocked for users.
