### PR TITLE
Fix flake in the request blocking integration tests

### DIFF
--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -57,7 +57,9 @@ test.describe('Test request blocking', () => {
                 urls: {
                     'bad.third-party.site:block': {
                         action: 'block',
-                        url: 'https://bad.third-party.site/privacy-protections/request-blocking/block-me/script.js',
+                        // Note: The exact URL recorded depends on which
+                        //       request's webRequest event happened to fire first.
+                        url: expect.stringMatching(/^https:\/\/bad\.third-party\.site\/privacy-protections\/request-blocking\/block-me\//),
                         eTLDplus1: 'third-party.site',
                         pageUrl: 'https://privacy-test-pages.site/privacy-protections/request-blocking/',
                         entityName: 'Bad Third Party Site',


### PR DESCRIPTION
One of the assertions in the request blocking tests was flaking sometimes since
it depended on the order that request events were being fired, which sometimes
varies. Let's adjust that, so that it will pass more reliably.