### PR TITLE
Update extension name in all locales.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ chrome-beta-zip: prepare-chrome-beta chrome-release-zip
 .PHONY: chrome-beta-zip
 
 prepare-chrome-beta:
-	sed 's/__MSG_appName__/DuckDuckGo Search & Tracker Protection Beta/' ./browsers/chrome/manifest.json > build/chrome/release/manifest.json
+	sed 's/__MSG_appName__/DuckDuckGo Search \& Tracker Protection Beta/' ./browsers/chrome/manifest.json > build/chrome/release/manifest.json
 	cp -r build/chrome/release/img/beta/* build/chrome/release/img/
 
 .PHONY: prepare-chrome-beta

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ chrome-beta-zip: prepare-chrome-beta chrome-release-zip
 .PHONY: chrome-beta-zip
 
 prepare-chrome-beta:
-	sed 's/__MSG_appName__/DuckDuckGo Privacy Essentials Beta/' ./browsers/chrome/manifest.json > build/chrome/release/manifest.json
+	sed 's/__MSG_appName__/DuckDuckGo Search & Tracker Protection Beta/' ./browsers/chrome/manifest.json > build/chrome/release/manifest.json
 	cp -r build/chrome/release/img/beta/* build/chrome/release/img/
 
 .PHONY: prepare-chrome-beta

--- a/browsers/chrome/_locales/ar/messages.json
+++ b/browsers/chrome/_locales/ar/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "عنوان الإضافة، المعروض في المتجر الإلكتروني"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/ca/messages.json
+++ b/browsers/chrome/_locales/ca/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "Privacy Essentials de DuckDuckGo ",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "El títol de l'extensió, que es mostra a la botiga web"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/el/messages.json
+++ b/browsers/chrome/_locales/el/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "Ο τίτλος της επέκτασης, όπως εμφανίζεται στο διαδικτυακό κατάστημα"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/hr/messages.json
+++ b/browsers/chrome/_locales/hr/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "Naslov proširenja, prikazan u web trgovini"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/id/messages.json
+++ b/browsers/chrome/_locales/id/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "Judul ekstensi, ditampilkan di web store"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/ja/messages.json
+++ b/browsers/chrome/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "ウェブストアに表示される拡張機能名"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/ko/messages.json
+++ b/browsers/chrome/_locales/ko/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "웹 스토어에 표시되는 확장 프로그램 제목"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/nb/messages.json
+++ b/browsers/chrome/_locales/nb/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "Utvidelsens tittel i nettbutikken"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/nl/messages.json
+++ b/browsers/chrome/_locales/nl/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "De titel van de extensie, weergegeven in de webwinkel"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/no/messages.json
+++ b/browsers/chrome/_locales/no/messages.json
@@ -1,6 +1,6 @@
 {
     "appName" : {
-      "message" : "DuckDuckGo Privacy Essentials",
+      "message" : "DuckDuckGo Search & Tracker Protection",
       "description" : "Utvidelsens tittel i nettbutikken"
     },
     "appDesc" : {

--- a/browsers/chrome/_locales/tr/messages.json
+++ b/browsers/chrome/_locales/tr/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "Uzantının web mağazasında görüntülenen başlığı"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/zh_CN/messages.json
+++ b/browsers/chrome/_locales/zh_CN/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "在网络商店显示的扩展插件标题"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/zh_HK/messages.json
+++ b/browsers/chrome/_locales/zh_HK/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "在網上商店顯示的擴充功能標題"
   },
   "appDesc" : {

--- a/browsers/chrome/_locales/zh_TW/messages.json
+++ b/browsers/chrome/_locales/zh_TW/messages.json
@@ -1,6 +1,6 @@
 {
   "appName" : {
-    "message" : "DuckDuckGo Privacy Essentials",
+    "message" : "DuckDuckGo Search & Tracker Protection",
     "description" : "擴充的標題，顯示於線上商店中"
   },
   "appDesc" : {

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "DuckDuckGo Privacy Essentials",
+    "name": "DuckDuckGo Search & Tracker Protection",
     "applications": {
         "gecko": {
             "id": "jid1-ZAdIEUB7XOzOJw@jetpack",

--- a/packages/ddg2dnr/README.md
+++ b/packages/ddg2dnr/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This is a library and command line utility to generate the [declarativeNetRequest][1]
-rulesets necessary for the [DuckDuckGo Privacy Essentials extension][2].
+rulesets necessary for the [DuckDuckGo Search & Tracker Protection extension][2].
 
 
 ## Setup

--- a/packages/ddg2dnr/package.json
+++ b/packages/ddg2dnr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duckduckgo/ddg2dnr",
-    "description": "Scripts to generate declarativeNetRequest rulesets for the DuckDuckGo Privacy Essentials extension",
+    "description": "Scripts to generate declarativeNetRequest rulesets for the DuckDuckGo Search & Tracker Protection extension",
     "license": "Apache-2.0",
     "repository": "duckduckgo/ddg2dnr",
     "bin": "cli.js",

--- a/shared/html/devtools-panel.html
+++ b/shared/html/devtools-panel.html
@@ -20,7 +20,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>DuckDuckGo Privacy Essentials Debugger</title>
+  <title>DuckDuckGo Tracker Protection Debugger</title>
   
   <link rel="stylesheet" href="../public/css/base.css">
 
@@ -199,7 +199,7 @@
 
   <div class="page-container">
 
-    <h1>DuckDuckGo Privacy Essentials Debugger</h1>
+    <h1>DuckDuckGo Tracker Protection Debugger</h1>
     
     <div id="settings-panel">
       <div class="header">

--- a/shared/locales/bg/feedback.json
+++ b/shared/locales/bg/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Изпращането на анонимен отзив ни помага да подобрим DuckDuckGo Privacy Essentials.",
+    "title" : "Изпращането на анонимен отзив ни помага да подобрим DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/de/feedback.json
+++ b/shared/locales/de/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Das Senden von anonymem Feedback hilft uns, DuckDuckGo Privacy Essentials zu verbessern.",
+    "title" : "Das Senden von anonymem Feedback hilft uns, DuckDuckGo Search & Tracker Protection zu verbessern.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/el/feedback.json
+++ b/shared/locales/el/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Η υποβολή ανώνυμων σχολίων μάς βοηθά να βελτιώνουμε το DuckDuckGo Privacy Essentials.",
+    "title" : "Η υποβολή ανώνυμων σχολίων μάς βοηθά να βελτιώνουμε το DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/en/feedback.json
+++ b/shared/locales/en/feedback.json
@@ -24,7 +24,7 @@
         "note": "Placeholder text on feedback form input."
     },
     "submittingFeedbackHelps": {
-        "title": "Submitting anonymous feedback helps us improve DuckDuckGo Privacy Essentials.",
+        "title": "Submitting anonymous feedback helps us improve DuckDuckGo Search & Tracker Protection.",
         "note": "Description at top of feedback form."
     },
     "reportBrokenSite": {

--- a/shared/locales/et/feedback.json
+++ b/shared/locales/et/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Anonüümne tagasiside aitab meil DuckDuckGo Privacy Essentialsi täiustada.",
+    "title" : "Anonüümne tagasiside aitab meil DuckDuckGo Search & Tracker Protectioni täiustada.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/fi/feedback.json
+++ b/shared/locales/fi/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Lähettämällä nimetöntä palautetta autat meitä parantamaan DuckDuckGo Privacy Essentialsia.",
+    "title" : "Lähettämällä nimetöntä palautetta autat meitä parantamaan DuckDuckGo Search & Tracker Protectionia.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/fr/feedback.json
+++ b/shared/locales/fr/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "En répondant à ce questionnaire anonyme, vous nous aiderez à améliorer DuckDuckGo Privacy Essentials.",
+    "title" : "En répondant à ce questionnaire anonyme, vous nous aiderez à améliorer DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/hr/feedback.json
+++ b/shared/locales/hr/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Slanje anonimnih povratnih informacija pomaže nam poboljšati DuckDuckGo Privacy Essentials.",
+    "title" : "Slanje anonimnih povratnih informacija pomaže nam poboljšati DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/hu/feedback.json
+++ b/shared/locales/hu/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Az anonim visszajelzések beküldése segít a DuckDuckGo Privacy Essentials fejlesztésében.",
+    "title" : "Az anonim visszajelzések beküldése segít a DuckDuckGo Search & Tracker Protection fejlesztésében.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/it/feedback.json
+++ b/shared/locales/it/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "L'invio di feedback anonimi ci aiuta a migliorare DuckDuckGo Privacy Essentials.",
+    "title" : "L'invio di feedback anonimi ci aiuta a migliorare DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/lt/feedback.json
+++ b/shared/locales/lt/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Anoniminių atsiliepimų pateikimas padeda mums tobulinti „DuckDuckGo Privacy Essentials“.",
+    "title" : "Anoniminių atsiliepimų pateikimas padeda mums tobulinti „DuckDuckGo Search & Tracker Protection“.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/lv/feedback.json
+++ b/shared/locales/lv/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Anonīmu atsauksmju sniegšana palīdz mums uzlabot DuckDuckGo Privacy Essentials.",
+    "title" : "Anonīmu atsauksmju sniegšana palīdz mums uzlabot DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/nl/feedback.json
+++ b/shared/locales/nl/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Het indienen van anonieme feedback helpt ons om DuckDuckGo Privacy Essentials te verbeteren.",
+    "title" : "Het indienen van anonieme feedback helpt ons om DuckDuckGo Search & Tracker Protection te verbeteren.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/pt/feedback.json
+++ b/shared/locales/pt/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "O feedback anónimo ajuda-nos a melhorar os DuckDuckGo Privacy Essentials.",
+    "title" : "O feedback anónimo ajuda-nos a melhorar os DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/ro/feedback.json
+++ b/shared/locales/ro/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Trimiterea de feedback anonim ne ajută să îmbunătățim DuckDuckGo Privacy Essentials.",
+    "title" : "Trimiterea de feedback anonim ne ajută să îmbunătățim DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/ru/feedback.json
+++ b/shared/locales/ru/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Анонимные отзывы помогают нам улучшить DuckDuckGo Privacy Essentials.",
+    "title" : "Анонимные отзывы помогают нам улучшить DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/sk/feedback.json
+++ b/shared/locales/sk/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Odosielanie anonymnej spätnej väzby nám pomáha zlepšovať DuckDuckGo Privacy Essentials.",
+    "title" : "Odosielanie anonymnej spätnej väzby nám pomáha zlepšovať DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/sl/feedback.json
+++ b/shared/locales/sl/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Pošiljanje anonimnih povratnih informacij nam pomaga izboljšati razširitev DuckDuckGo Privacy Essentials.",
+    "title" : "Pošiljanje anonimnih povratnih informacij nam pomaga izboljšati razširitev DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/sv/feedback.json
+++ b/shared/locales/sv/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Om du skickar in anonym återkoppling hjälper du oss att förbättra DuckDuckGo Privacy Essentials.",
+    "title" : "Om du skickar in anonym återkoppling hjälper du oss att förbättra DuckDuckGo Search & Tracker Protection.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {

--- a/shared/locales/tr/feedback.json
+++ b/shared/locales/tr/feedback.json
@@ -25,7 +25,7 @@
     "note" : "Placeholder text on feedback form input."
   },
   "submittingFeedbackHelps" : {
-    "title" : "Anonim geri bildirim göndermek, DuckDuckGo Privacy Essentials'ı geliştirmemize yardımcı olur.",
+    "title" : "Anonim geri bildirim göndermek, DuckDuckGo Search & Tracker Protection'ı geliştirmemize yardımcı olur.",
     "note" : "Description at top of feedback form."
   },
   "reportBrokenSite" : {


### PR DESCRIPTION
Some translations were using our old 'Privacy Essentials' name. This PR updates strings to use the same name everywhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string/branding updates only; no functional logic changes beyond what name appears in builds and UI.
> 
> **Overview**
> Updates the extension’s displayed branding from **“DuckDuckGo Privacy Essentials”** to **“DuckDuckGo Search & Tracker Protection”** across Chrome locale `appName` strings, Firefox `manifest.json`, and feedback-form copy in many `shared/locales/*/feedback.json` translations.
> 
> Also updates the Chrome beta packaging step in the `Makefile` to inject the new beta name, and refreshes related documentation/UI labels (e.g., `ddg2dnr` description and the DevTools panel title).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329bfc6216e03444ce7fcc39b6f36fb6e8e29182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->