### PR TITLE
Correct the ServiceWorker initiated request blocking tests

### DIFF
--- a/integration-test/request-blocking.spec.js
+++ b/integration-test/request-blocking.spec.js
@@ -100,14 +100,18 @@ test.describe('Test request blocking', () => {
         }, testHost);
         const { pageRequests, pageResults } = await runRequestBlockingTest(backgroundPage, page, testSite);
 
-        // Verify that no logged requests were allowed.
+        // Verify that only ServiceWorker initiated requests were allowed.
         for (const { url, method, type, status } of pageRequests) {
             const description = `URL: ${url}, Method: ${method}, Type: ${type}`;
-            expect(status, description).toEqual('blocked');
+            if (url.search.includes('serviceworker-')) {
+                expect(status, description).toEqual('allowed');
+            } else {
+                expect(status, description).toEqual('blocked');
+            }
         }
 
-        // Check that the test page itself agrees that no requests were
-        // allowed.
+        // Check that the test page itself agrees that only ServiceWorker
+        // initiated requests were allowed.
         for (const { id, category, status } of pageResults) {
             const description = `ID: ${id}, Category: ${category}`;
             if (id === 'serviceworker-fetch') {


### PR DESCRIPTION
The integration test that checks ServiceWorker initiated requests are allowed
when an exception is active, was for some reason asserting that the requests
should be blocked. That was causing the tests to fail when run with the WIP
Firefox test runner. The test was passing on Chrome since the standard
Playwright harness doesn't surface the events for those requests.