### PR TITLE
Update autoconsent to v14.77.1

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.5.4",
+    "version": "2026.5.7",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^14.74.0",
+                "@duckduckgo/autoconsent": "^14.77.1",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "14.74.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.74.0.tgz",
-            "integrity": "sha512-bbOICTHGuM0LQvZUWPdGHG1CRM/1hf9DKhNn57P8wWkq70Wa1O9czN7qQ6RXoWZ0lmDgfR5ApxbncsUEIaAlZA==",
+            "version": "14.77.1",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.77.1.tgz",
+            "integrity": "sha512-/4iRDgv3M4Z1karrarDOXKWjv3ChCLdheJMGeIDh1ugCzUwrbCOK+a8L0jnH88M178Z3JYZyiKT0o9FW5uST2w==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^14.74.0",
+        "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214601869950179
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v14.77.1
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1214602053957956 apple_task_gid: 1214602053957956 -->

## Description
Updates Autoconsent to version [v14.77.1](https://github.com/duckduckgo/autoconsent/releases/tag/v14.77.1).

### Autoconsent v14.77.1 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v14.77.1/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade in consent automation logic may change site-specific behavior/regressions despite being a small diff. Manifest version bump is low risk but affects release/versioning.
> 
> **Overview**
> Updates the embedded extension release metadata by bumping `browsers/embedded/manifest.json` version to `2026.5.7`.
> 
> Upgrades `@duckduckgo/autoconsent` from `14.74.0` to `14.77.1` in `package.json` and `package-lock.json`, refreshing the resolved tarball/integrity pins accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87dccac702280f1b5d402099ccdf51148cd1cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->