### PR TITLE
Properly anchor the getSpecialDomain() localhost checks

### DIFF
--- a/shared/js/background/classes/site.js
+++ b/shared/js/background/classes/site.js
@@ -219,12 +219,12 @@ export default class Site {
 
         // Both 'localhost' and the loopback IP have to be specified
         // since they're treated as different domains.
-        if (domain === localhostName || domain.match(/^127\.0\.0\.1/) || publicSuffix === localhostName) {
+        if (domain === localhostName || domain.match(/^127\.0\.0\.1$/) || publicSuffix === localhostName) {
             return localhostName;
         }
 
         // Handle non-routable meta-address.
-        if (domain.match(/^0\.0\.0\.0/)) {
+        if (domain.match(/^0\.0\.0\.0$/)) {
             return domain;
         }
 

--- a/unit-test/background/classes/site.js
+++ b/unit-test/background/classes/site.js
@@ -18,6 +18,11 @@ describe('Site', () => {
         const tests = [
             { url: 'https://duckduckgo.com', expected: null },
             { url: 'localhost:3000', expected: 'localhost' },
+            { url: 'http://127.0.0.1:8080', expected: 'localhost' },
+            { url: 'https://127.0.0.1.evil.example', expected: null },
+            { url: 'https://127.0.0.10', expected: null },
+            { url: 'http://0.0.0.0', expected: '0.0.0.0' },
+            { url: 'https://0.0.0.0.evil.example', expected: null },
             { url: '', expected: 'new tab' },
             { url: 'chrome-search://local-ntp/local-ntp.html', expected: 'new tab' },
             { url: 'chrome://extensions', expected: 'extensions' },


### PR DESCRIPTION
The `127.0.0.1` and `0.0.0.0` regexes in `getSpecialDomain()` weren't properly
anchored, and so could match a hostname like `127.0.0.1.evil.example`. Let's fix
that.

**Reviewer:** @jonathanKingston 
**CC:** @sammacbeth 

## Automated tests:
- [x] Unit tests
- [ ] Integration tests