### PR TITLE
Update autofill to 19.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
             ],
             "dependencies": {
                 "@duckduckgo/autoconsent": "^14.77.1",
-                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+                "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.1.0",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
                 "@duckduckgo/jsbloom": "^1.0.2",
@@ -606,7 +606,7 @@
             }
         },
         "node_modules/@duckduckgo/autofill": {
-            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
+            "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
             "hasInstallScript": true,
             "license": "Apache-2.0"
         },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     },
     "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
         "@duckduckgo/jsbloom": "^1.0.2",


### PR DESCRIPTION
Task/Issue URL: 
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.1.0


## Description
Updates Autofill to version [19.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.1.0).

### Autofill 19.1.0 release notes
## What's new
- Passkey-specific rendering in the autofill credentials dropdown (#930) — passkeys from the host (e.g. Windows Hello) now display with a dedicated icon and a "provider" subtitle line. Backward compatible: credentials without `credentialType` are unchanged.

## Fixes
- Skip `firstname` / `lastname` in username detection (#924)
- Android error management audit fixes (#925)

## CI / infra
- Add Asana PR sync workflow (#931)


## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the embedded Autofill component, which can change credential/field detection and UI behavior across the extension. Risk is limited to dependency update and lockfile changes, but impacts a user-facing, security-adjacent feature area.
> 
> **Overview**
> Updates the `@duckduckgo/autofill` dependency from `17.0.1` to `19.1.0` in `package.json`.
> 
> Refreshes `package-lock.json` to point at the new Autofill git commit, pulling in the updated Autofill implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef43df79e76b1cd2b5fec331fc28e52ec90bb86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->