### PR TITLE
Add extension installed flag to homepage visits

### DIFF
--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -252,7 +252,10 @@ test.describe('search workflow', () => {
         expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
     });
 
-    test('should not add the extensioninstalled param to the URL when the user is not on the homepage', async ({ backgroundPage, page }) => {
+    test('should not add the extensioninstalled param to the URL when the user is not on the homepage', async ({
+        backgroundPage,
+        page,
+    }) => {
         await page.goto('https://duckduckgo.com/about', { waitUntil: 'domcontentloaded' });
 
         const searchUrl = new URL(page.url());

--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -250,6 +250,7 @@ test.describe('search workflow', () => {
         expect(searchUrl.hostname).toEqual('duckduckgo.com');
         expect(searchUrl.pathname).toEqual('/');
         expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
+        expect(searchUrl.searchParams.get('atb')).toBeNull();
     });
 
     test('should add the extensioninstalled param to the URL on the start.duckduckgo.com homepage', async ({ backgroundPage, page }) => {
@@ -259,6 +260,7 @@ test.describe('search workflow', () => {
         expect(searchUrl.hostname).toEqual('start.duckduckgo.com');
         expect(searchUrl.pathname).toEqual('/');
         expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
+        expect(searchUrl.searchParams.get('atb')).toBeNull();
     });
 
     test('should not add the extensioninstalled param to the URL when the user is not on the homepage', async ({

--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -242,4 +242,22 @@ test.describe('search workflow', () => {
         expect(searchUrl.searchParams.get('q')).toEqual('alternative-search-disabled-test');
         expect(searchUrl.searchParams.get('atb')).toMatch(/^v[\d-]+$/);
     });
+
+    test('should add the extensioninstalled param to the URL when the user is on the homepage', async ({ backgroundPage, page }) => {
+        await page.goto('https://duckduckgo.com/', { waitUntil: 'domcontentloaded' });
+
+        const searchUrl = new URL(page.url());
+        expect(searchUrl.hostname).toEqual('duckduckgo.com');
+        expect(searchUrl.pathname).toEqual('/');
+        expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
+    });
+
+    test('should not add the extensioninstalled param to the URL when the user is not on the homepage', async ({ backgroundPage, page }) => {
+        await page.goto('https://duckduckgo.com/about', { waitUntil: 'domcontentloaded' });
+
+        const searchUrl = new URL(page.url());
+        expect(searchUrl.hostname).toEqual('duckduckgo.com');
+        expect(searchUrl.pathname).toEqual('/about');
+        expect(searchUrl.search).toEqual('');
+    });
 });

--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -252,6 +252,15 @@ test.describe('search workflow', () => {
         expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
     });
 
+    test('should add the extensioninstalled param to the URL on the start.duckduckgo.com homepage', async ({ backgroundPage, page }) => {
+        await page.goto('https://start.duckduckgo.com/', { waitUntil: 'domcontentloaded' });
+
+        const searchUrl = new URL(page.url());
+        expect(searchUrl.hostname).toEqual('start.duckduckgo.com');
+        expect(searchUrl.pathname).toEqual('/');
+        expect(searchUrl.searchParams.get('extensioninstalled')).toEqual('1');
+    });
+
     test('should not add the extensioninstalled param to the URL when the user is not on the homepage', async ({
         backgroundPage,
         page,

--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -253,6 +253,15 @@ test.describe('search workflow', () => {
         expect(searchUrl.searchParams.get('atb')).toBeNull();
     });
 
+    test('should keep extensioninstalled on homepage if no-ai is enabled', async ({ backgroundPage, page }) => {
+        await setUseNoAiSearch(backgroundPage, true);
+        await page.goto('https://duckduckgo.com/', { waitUntil: 'domcontentloaded' });
+
+        const url = new URL(page.url());
+        expect(url.hostname).toEqual('duckduckgo.com');
+        expect(url.searchParams.get('extensioninstalled')).toEqual('1');
+        expect(url.searchParams.get('atb')).toBeNull();
+    });
     test('should add the extensioninstalled param to the URL on the start.duckduckgo.com homepage', async ({ backgroundPage, page }) => {
         await page.goto('https://start.duckduckgo.com/', { waitUntil: 'domcontentloaded' });
 

--- a/integration-test/data/har/README.md
+++ b/integration-test/data/har/README.md
@@ -3,6 +3,7 @@
 This directory contains HAR files used for integration tests. These files specify mock HTTP responses to be 
 used when loading pages, allowing tests to be run without relying on internet connectivity.
 
-The following HAR files are current included:
+The following HAR files are currently included:
  - duckduckgo.com/extension-success (post install page). Regenerate with `npx playwright open --save-har=duckduckgo.com/extension-success.har https://duckduckgo.com/extension-success`
+ - duckduckgo.com/about (used by fingerprint protection tests). Regenerate with `npx playwright open --save-har=duckduckgo.com/about.har https://duckduckgo.com/about`
  

--- a/integration-test/fingerprint-protection.spec.js
+++ b/integration-test/fingerprint-protection.spec.js
@@ -13,7 +13,7 @@ const expectedFingerprintValues = {
 };
 
 const tests = [
-    { url: 'duckduckgo.com', har: getHARPath('duckduckgo.com/homepage.har') },
+    { url: 'duckduckgo.com/about', har: getHARPath('duckduckgo.com/about.har') },
     { url: 'example.com', har: getHARPath('example.com/example.har') },
 ];
 

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -265,7 +265,7 @@ const ATB = (() => {
                     },
                 },
                 resourceTypes: ['main_frame'],
-                regexFilter: '^https://duckduckgo\\.com/$',
+                regexFilter: '^https://((start|noai)\\.)?duckduckgo\\.com/$',
             });
             const addRules = [atbRule, extensionInstalledRule, homePageRule];
             if (useNoAiSearch) {

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -8,7 +8,7 @@ const settings = require('./settings');
 const parseUserAgentString = require('../shared-utils/parse-user-agent-string');
 const load = require('./load');
 const browserWrapper = require('./wrapper');
-const { ATB_PARAM_RULE_ID, SEARCH_REDIRECT_RULE_ID } = require('./dnr-utils');
+const { ATB_PARAM_RULE_ID, SEARCH_REDIRECT_RULE_ID, HOME_PAGE_RULE_ID, ATB_EXTENSIONINSTALLED_RULE_ID } = require('./dnr-utils');
 const { ATB_PARAM_PRIORITY, ALTERNATIVE_SEARCH_PRIORITY } = require('@duckduckgo/ddg2dnr/lib/rulePriorities');
 const { generateDNRRule } = require('@duckduckgo/ddg2dnr/lib/utils');
 
@@ -82,8 +82,18 @@ const ATB = (() => {
                 return false;
             }
 
+            if (url.hostname === 'duckduckgo.com' && url.pathname === '/' && url.searchParams.size === 0) {
+                url.searchParams.append('extensioninstalled', '1');
+                return true;
+            }
+
             const atbSetting = settings.getSetting('atb');
             if (!atbSetting || !regExpAboutPage.test(url.href)) {
+                return false;
+            }
+
+            // Exclude URLs with only the extensioninstalled param (handled by HOME_PAGE_RULE_ID).
+            if (url.searchParams.has('extensioninstalled') && url.searchParams.size === 1) {
                 return false;
             }
 
@@ -233,7 +243,31 @@ const ATB = (() => {
                 requestDomains: ['duckduckgo.com'],
                 regexFilter: regExpAboutPage.source,
             });
-            const addRules = [atbRule];
+            // This rule disables the atbRule when only the extensioninstalled param is present (i.e. homepage)
+            const extensionInstalledRule = generateDNRRule({
+                id: ATB_EXTENSIONINSTALLED_RULE_ID,
+                priority: ATB_PARAM_PRIORITY + 1,
+                actionType: 'allow',
+                resourceTypes: ['main_frame'],
+                requestDomains: ['duckduckgo.com'],
+                regexFilter: '^https?:\\/\\/([\\w-]+\\.)?duckduckgo\\.com\\/\\?extensioninstalled(?:=[^&]*)?$',
+            });
+            // This rule adds the extensioninstalled param to the URL when the user is on the homepage
+            const homePageRule = generateDNRRule({
+                id: HOME_PAGE_RULE_ID,
+                priority: ATB_PARAM_PRIORITY,
+                actionType: 'redirect',
+                redirect: {
+                    transform: {
+                        queryTransform: {
+                            addOrReplaceParams: [{ key: 'extensioninstalled', value: '1' }],
+                        },
+                    },
+                },
+                resourceTypes: ['main_frame'],
+                regexFilter: '^https://duckduckgo\\.com/$',
+            });
+            const addRules = [atbRule, extensionInstalledRule, homePageRule];
             if (useNoAiSearch) {
                 addRules.push(
                     generateDNRRule({
@@ -251,9 +285,13 @@ const ATB = (() => {
                 );
             }
 
-            chrome.declarativeNetRequest.updateDynamicRules({
-                removeRuleIds: [atbRule.id, SEARCH_REDIRECT_RULE_ID],
-                addRules,
+            Promise.resolve(
+                chrome.declarativeNetRequest.updateDynamicRules({
+                    removeRuleIds: [atbRule.id, ATB_EXTENSIONINSTALLED_RULE_ID, HOME_PAGE_RULE_ID, SEARCH_REDIRECT_RULE_ID],
+                    addRules,
+                }),
+            ).catch((error) => {
+                console.error('Error updating ATB DNR rules:', error);
             });
         },
 

--- a/shared/js/background/atb.js
+++ b/shared/js/background/atb.js
@@ -25,6 +25,7 @@ const ATB = (() => {
     // Matching subdomains, searches, newsletter page and chrome new tab page
     const regExpAboutPage = /^https?:\/\/([\w-]+\.)?duckduckgo\.com\/(\?.*|about#newsletter|chrome_newtab)/;
     const matchPage = /^https:\/\/([\w-]+\.)?duckduckgo.com\/\?/;
+    const matchHomePage = /^https:\/\/((start|noai)\.)?duckduckgo\.com\/$/;
     const ddgAtbURL = 'https://duckduckgo.com/atb.js?';
 
     return {
@@ -82,7 +83,7 @@ const ATB = (() => {
                 return false;
             }
 
-            if (url.hostname === 'duckduckgo.com' && url.pathname === '/' && url.searchParams.size === 0) {
+            if (matchHomePage.test(url.href)) {
                 url.searchParams.append('extensioninstalled', '1');
                 return true;
             }
@@ -265,7 +266,7 @@ const ATB = (() => {
                     },
                 },
                 resourceTypes: ['main_frame'],
-                regexFilter: '^https://((start|noai)\\.)?duckduckgo\\.com/$',
+                regexFilter: matchHomePage.source,
             });
             const addRules = [atbRule, extensionInstalledRule, homePageRule];
             if (useNoAiSearch) {

--- a/shared/js/background/before-request.js
+++ b/shared/js/background/before-request.js
@@ -145,7 +145,7 @@ function handleRequest(requestData) {
         const shouldRedirectSearch =
             mainFrameRequestURL.hostname === 'duckduckgo.com' &&
             mainFrameRequestURL.pathname === '/' &&
-            mainFrameRequestURL.search !== '' &&
+            mainFrameRequestURL.searchParams.has('q') &&
             settings.getSetting('useNoAiSearch') === true;
         if (shouldRedirectSearch) {
             mainFrameRequestURL.hostname = 'noai.duckduckgo.com';

--- a/shared/js/background/dnr-utils.js
+++ b/shared/js/background/dnr-utils.js
@@ -20,6 +20,8 @@ import settings from './settings';
 // rule IDs here.
 export const USER_ALLOWLIST_RULE_ID = 20001;
 export const ATB_PARAM_RULE_ID = 20003;
+export const ATB_EXTENSIONINSTALLED_RULE_ID = 20008;
+export const HOME_PAGE_RULE_ID = 20010;
 export const NEWTAB_TRACKER_STATS_REDIRECT_RULE_ID = 20006;
 export const SEARCH_REDIRECT_RULE_ID = 20009;
 
@@ -45,8 +47,10 @@ export const ruleIdRangeByConfigName = {
 const RESERVED_DYNAMIC_RULE_IDS = [
     USER_ALLOWLIST_RULE_ID,
     ATB_PARAM_RULE_ID,
+    ATB_EXTENSIONINSTALLED_RULE_ID,
     NEWTAB_TRACKER_STATS_REDIRECT_RULE_ID,
     SEARCH_REDIRECT_RULE_ID,
+    HOME_PAGE_RULE_ID,
 ];
 
 /**

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -3,8 +3,17 @@ chrome.runtime.getManifest = () => ({ version: '1234.56', manifest_version: 3 })
 const atb = require('../../shared/js/background/atb').default;
 const settings = require('../../shared/js/background/settings');
 const load = require('../../shared/js/background/load');
-const { ATB_PARAM_RULE_ID, SEARCH_REDIRECT_RULE_ID } = require('../../shared/js/background/dnr-utils');
-const { ATB_PARAM_PRIORITY, ALTERNATIVE_SEARCH_PRIORITY } = require('@duckduckgo/ddg2dnr/lib/rulePriorities');
+const {
+    ATB_PARAM_RULE_ID,
+    SEARCH_REDIRECT_RULE_ID,
+    HOME_PAGE_RULE_ID,
+    ATB_EXTENSIONINSTALLED_RULE_ID,
+} = require('../../shared/js/background/dnr-utils');
+const {
+    ATB_PARAM_PRIORITY,
+    ATB_EXTENSIONINSTALLED_ALLOW_PRIORITY,
+    ALTERNATIVE_SEARCH_PRIORITY,
+} = require('@duckduckgo/ddg2dnr/lib/rulePriorities');
 
 const settingHelper = require('../helpers/settings');
 
@@ -85,6 +94,8 @@ describe('atb.addParametersMainFrameRequestUrl()', () => {
         { url: 'https://beta.duckduckgo.com/?q=something&atb=v70-1', rewrite: false },
         { url: 'https://dev-testing.duckduckgo.com/?q=something', rewrite: true },
         { url: 'https://dev-testing.duckduckgo.com/chrome_newtab', rewrite: true },
+        { url: 'https://duckduckgo.com/?extensioninstalled=', rewrite: false },
+        { url: 'https://duckduckgo.com/?extensioninstalled', rewrite: false },
     ];
 
     beforeEach(() => {
@@ -140,12 +151,18 @@ describe('atb.setOrUpdateATBdnrRule()', () => {
 
         expect(updateDynamicRulesSpy).toHaveBeenCalledTimes(1);
         const [[{ addRules }]] = updateDynamicRulesSpy.calls.allArgs();
-        expect(addRules.length).toEqual(2);
+        expect(addRules.length).toEqual(4);
 
         const atbRule = addRules.find((rule) => rule.id === ATB_PARAM_RULE_ID);
+        const extensionInstalledRule = addRules.find((rule) => rule.id === ATB_EXTENSIONINSTALLED_RULE_ID);
+        const homePageRule = addRules.find((rule) => rule.id === HOME_PAGE_RULE_ID);
         const searchRedirectRule = addRules.find((rule) => rule.id === SEARCH_REDIRECT_RULE_ID);
 
         expect(atbRule.priority).toEqual(ATB_PARAM_PRIORITY);
+        expect(extensionInstalledRule.action.type).toEqual('allow');
+        expect(extensionInstalledRule.priority).toEqual(ATB_EXTENSIONINSTALLED_ALLOW_PRIORITY);
+        expect(extensionInstalledRule.priority).toBeGreaterThan(searchRedirectRule.priority);
+        expect(homePageRule.priority).toEqual(ATB_PARAM_PRIORITY);
         expect(searchRedirectRule.priority).toEqual(ALTERNATIVE_SEARCH_PRIORITY);
         expect(searchRedirectRule.priority).toBeGreaterThan(atbRule.priority);
     });

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -92,6 +92,9 @@ describe('atb.addParametersMainFrameRequestUrl()', () => {
         { url: 'https://dev-testing.duckduckgo.com/chrome_newtab', rewrite: true },
         { url: 'https://duckduckgo.com/?extensioninstalled=', rewrite: false },
         { url: 'https://duckduckgo.com/?extensioninstalled', rewrite: false },
+        { url: 'https://duckduckgo.com/', rewrite: true },
+        { url: 'https://start.duckduckgo.com/', rewrite: true },
+        { url: 'https://noai.duckduckgo.com/', rewrite: true },
     ];
 
     beforeEach(() => {
@@ -112,6 +115,9 @@ describe('atb.addParametersMainFrameRequestUrl()', () => {
     });
 
     const correctUrlTests = [
+        { url: 'https://duckduckgo.com/', expected: 'https://duckduckgo.com/?extensioninstalled=1' },
+        { url: 'https://start.duckduckgo.com/', expected: 'https://start.duckduckgo.com/?extensioninstalled=1' },
+        { url: 'https://noai.duckduckgo.com/', expected: 'https://noai.duckduckgo.com/?extensioninstalled=1' },
         { url: 'https://duckduckgo.com/?q=something', expected: 'https://duckduckgo.com/?q=something&atb=v123-4ab' },
         { url: 'https://duckduckgo.com/about#newsletter', expected: 'https://duckduckgo.com/about?atb=v123-4ab#newsletter' },
         { url: 'https://duckduckgo.com/chrome_newtab', expected: 'https://duckduckgo.com/chrome_newtab?atb=v123-4ab' },

--- a/unit-test/background/atb.js
+++ b/unit-test/background/atb.js
@@ -9,11 +9,7 @@ const {
     HOME_PAGE_RULE_ID,
     ATB_EXTENSIONINSTALLED_RULE_ID,
 } = require('../../shared/js/background/dnr-utils');
-const {
-    ATB_PARAM_PRIORITY,
-    ATB_EXTENSIONINSTALLED_ALLOW_PRIORITY,
-    ALTERNATIVE_SEARCH_PRIORITY,
-} = require('@duckduckgo/ddg2dnr/lib/rulePriorities');
+const { ATB_PARAM_PRIORITY, ALTERNATIVE_SEARCH_PRIORITY } = require('@duckduckgo/ddg2dnr/lib/rulePriorities');
 
 const settingHelper = require('../helpers/settings');
 
@@ -160,8 +156,7 @@ describe('atb.setOrUpdateATBdnrRule()', () => {
 
         expect(atbRule.priority).toEqual(ATB_PARAM_PRIORITY);
         expect(extensionInstalledRule.action.type).toEqual('allow');
-        expect(extensionInstalledRule.priority).toEqual(ATB_EXTENSIONINSTALLED_ALLOW_PRIORITY);
-        expect(extensionInstalledRule.priority).toBeGreaterThan(searchRedirectRule.priority);
+        expect(extensionInstalledRule.priority).toBeGreaterThan(ATB_PARAM_PRIORITY);
         expect(homePageRule.priority).toEqual(ATB_PARAM_PRIORITY);
         expect(searchRedirectRule.priority).toEqual(ALTERNATIVE_SEARCH_PRIORITY);
         expect(searchRedirectRule.priority).toBeGreaterThan(atbRule.priority);


### PR DESCRIPTION
https://app.asana.com/1/137249556945/task/1214735261462419?focus=true

**Reviewer:** @kzar 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Add an `extensioninstalled=1` parameter to home page visits when the extension is installed. This is to allow server-side optimization of the page load in this case (no need to load extension install promos).

## Steps to test this PR:

1. Visit https://duckduckgo.com.
2. Check that `extensioninstalled=1` was added, and ATB was not.
3. Make a search
4. Check that ATB is added correctly to search URL.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration-test coverage and a README tweak, with no production logic modified.
> 
> **Overview**
> Adds integration tests asserting that visiting DuckDuckGo homepages (`duckduckgo.com/` and `start.duckduckgo.com/`) appends `extensioninstalled=1` and does **not** include `atb`, including when *no-ai search* is enabled. Also adds a regression test ensuring `extensioninstalled` is not added on non-homepage paths (e.g. `/about`) and fixes/updates the HAR README wording and list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f14516994fd5b81d1fe5655f62bdf4c1952516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->