### PR TITLE
Fix sliding subview header text overflow for long translated strings

### DIFF
--- a/shared/scss/_mixins.scss
+++ b/shared/scss/_mixins.scss
@@ -197,6 +197,10 @@
                 color: vars.$slate;
                 padding: 14px 0 10px 0;
                 text-decoration: none;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
         }
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. The issue page has sufficient information to help reproduce and test ths issue: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/3368 
-->

## Automated tests:
- [x] Unit tests
- [x] Integration tests

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that affects layout of the sliding subview header title; potential risk is minor visual regressions due to truncation/overflow behavior.
> 
> **Overview**
> Fixes long (e.g., translated) sliding subview header titles overflowing their container by forcing the `.sliding-subview__header__title` to shrink and truncate with an ellipsis (`min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ffbe9481802c78e71a6df6fbf62f8a155697e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->