### PR TITLE
Update autoconsent to v14.85.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.5.22",
+    "version": "2026.5.27",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^14.77.1",
+                "@duckduckgo/autoconsent": "^14.85.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -595,9 +595,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "14.77.1",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.77.1.tgz",
-            "integrity": "sha512-/4iRDgv3M4Z1karrarDOXKWjv3ChCLdheJMGeIDh1ugCzUwrbCOK+a8L0jnH88M178Z3JYZyiKT0o9FW5uST2w==",
+            "version": "14.85.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.85.0.tgz",
+            "integrity": "sha512-yDOLcm6b14s2q7mCMgF7EZw1MCKDVgs31bmiGgz3jR4854GUJrHRZtku365BW/pRFwivHko0FxOqFZGHyrhVbA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^14.77.1",
+        "@duckduckgo/autoconsent": "^14.85.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215158271009344
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v14.85.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1215158271309431 apple_task_gid: 1215158271309431 -->

## Description
Updates Autoconsent to version [v14.85.0](https://github.com/duckduckgo/autoconsent/releases/tag/v14.85.0).

### Autoconsent v14.85.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v14.85.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent runs in-page for cookie prompts; behavior changes come entirely from the upstream package, so regressions depend on that release rather than extension code edits.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **14.77.1** to **14.85.0** in `package.json` and `package-lock.json`, pulling in the upstream cookie-prompt / consent automation release without local code changes.
> 
> Also bumps the **embedded** extension **`version`** in `browsers/embedded/manifest.json` from **2026.5.22** to **2026.5.27** so the embedded build tracks this dependency update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659022111dd95f165c76e9f58e3b6844c12c495c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->