### PR TITLE
Update Playwright dependency to 1.60.0

### DIFF
--- a/integration-test/helpers/playwrightHarness.js
+++ b/integration-test/helpers/playwrightHarness.js
@@ -125,37 +125,7 @@ let test = base.extend({
             return serviceWorker;
         };
 
-        const restartBackgroundServiceWorker = async () => {
-            // There is a race condition, whereby Playwright sometimes
-            // fails to attach to the extension's background ServiceWorker,
-            // possibly because it was created too early. When that happens,
-            // restart the ServiceWorker via CDP to give Playwright another
-            // chance to spot it.
-            const page = context.pages()[0];
-            if (page) {
-                const cdp = await context.newCDPSession(page);
-                try {
-                    // Stop the ServiceWorker
-                    await cdp.send('ServiceWorker.enable');
-                    await cdp.send('ServiceWorker.stopAllWorkers');
-
-                    // Start it again.
-                    const newPage = await context.newPage();
-                    await newPage.goto('https://duckduckgo.com/extension-success');
-
-                    console.log('Restarted ServiceWorker.');
-                } finally {
-                    await cdp.detach().catch(() => {});
-                }
-            }
-        };
-
-        let background = await getBackgroundServiceWorker();
-        if (!background) {
-            await restartBackgroundServiceWorker();
-            background = await getBackgroundServiceWorker();
-        }
-
+        const background = await getBackgroundServiceWorker();
         if (!background) {
             throw new Error("Failed to find extension's background ServiceWorker.");
         }

--- a/integration-test/helpers/requests.js
+++ b/integration-test/helpers/requests.js
@@ -88,6 +88,17 @@ export async function logPageRequests(page, requests, requestFilter, transform, 
     };
 }
 
+async function waitFor(page, predicate, { timeout, interval = 100 }) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        if (await predicate()) {
+            return true;
+        }
+        await page.waitForTimeout(interval);
+    }
+    return false;
+}
+
 /**
  * Load the Request Blocking privacy test page, run the tests and return the
  * results.
@@ -123,30 +134,53 @@ export async function runRequestBlockingTest(page, url) {
     // Wait for up to 15 seconds for all the requests to be made, but only wait
     // two seconds after the reliable requests.
     const reliableTestCount = testCount - flakeyTestCount;
-    const timeout = 15000;
     const flakeyTimeout = 2000;
-
-    const deadline = Date.now() + timeout;
     let flakeyDeadline = null;
-    while (Date.now() < deadline) {
-        if (pageRequests.length >= testCount) break;
-
-        if (pageRequests.length >= reliableTestCount) {
-            if (!flakeyDeadline) {
-                flakeyDeadline = Date.now() + flakeyTimeout;
-            } else if (Date.now() >= flakeyDeadline) {
-                break;
+    await waitFor(
+        page,
+        () => {
+            if (pageRequests.length >= testCount) {
+                return true;
             }
-        }
-
-        await page.waitForTimeout(100);
-    }
+            if (pageRequests.length >= reliableTestCount) {
+                if (flakeyDeadline === null) {
+                    flakeyDeadline = Date.now() + flakeyTimeout;
+                }
+                return Date.now() >= flakeyDeadline;
+            }
+            return false;
+        },
+        { timeout: 15000 },
+    );
 
     if (pageRequests.length < reliableTestCount) {
         throw new Error(
             "Timed out waiting for Request Blocking test page's requests " + `(Received ${pageRequests.length} of ${testCount}).`,
         );
     }
+
+    // Page results for iframe and worker initiated requests settle a little
+    // while the requests are fired. Reading those results immediately gives us
+    // stale "not loaded" results, so wait until `results.results` has stopped
+    // changing before checking the final results.
+    let prevSnapshot = null;
+    let stableSince = Date.now();
+    await waitFor(
+        page,
+        async () => {
+            // @ts-ignore
+            // eslint-disable-next-line no-undef
+            const snapshot = await page.evaluate(() => JSON.stringify(results.results));
+            if (snapshot === prevSnapshot) {
+                return Date.now() - stableSince >= 1500;
+            }
+
+            prevSnapshot = snapshot;
+            stableSince = Date.now();
+            return false;
+        },
+        { timeout: 10000, interval: 150 },
+    );
 
     let pageResults = await page.evaluate(
         // @ts-ignore

--- a/integration-test/playwright-harness.spec.js
+++ b/integration-test/playwright-harness.spec.js
@@ -92,7 +92,12 @@ test.describe('Request logging', () => {
     test('page-initiated requests', async ({ page }) => {
         await routeFromLocalhost(page);
         await page.goto('https://privacy-test-pages.site/', { waitUntil: 'networkidle' });
-        await testLogPageRequests(page, page, expectedRequests);
+        // Note: Chrome blocks page-initiated requests to the local network, so
+        //       swap the 'allowed' request for a routed public host here.
+        await testLogPageRequests(page, page, [
+            { url: 'https://good.third-party.site/?allow', method: 'GET', type: 'fetch', status: 'allowed' },
+            ...expectedRequests.filter((r) => r.status !== 'allowed'),
+        ]);
     });
 
     test('extension-initiated requests', async ({ backgroundPage, backgroundNetworkContext }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v2.1.0",
                 "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration",
                 "@fingerprintjs/fingerprintjs": "^4.6.2",
-                "@playwright/test": "1.54.2",
+                "@playwright/test": "1.60.0",
                 "@types/chrome": "^0.0.269",
                 "@types/jasmine": "^5.1.9",
                 "@types/node": "^22.1.0",
@@ -2141,13 +2141,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-            "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.54.2"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -10144,13 +10144,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-            "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.54.2"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -10163,9 +10163,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-            "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v2.1.0",
         "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration",
         "@fingerprintjs/fingerprintjs": "^4.6.2",
-        "@playwright/test": "1.54.2",
+        "@playwright/test": "1.60.0",
         "@types/chrome": "^0.0.269",
         "@types/jasmine": "^5.1.9",
         "@types/node": "^22.1.0",


### PR DESCRIPTION
Chrome 148 is included with the update, which broke one of our integration
tests, since page-initiated requests to local networks are now blocked by
default.

Firefox 150 is included as well, which exacerbated an existing flake in the
request blocking tests. Let's fix that here too.

Let's also remove the background ServiceWorker retry fallback, as that
Playwright issue has been fixed[1] upstream now.

1 - https://github.com/microsoft/playwright/issues/39075