### PR TITLE
Update autoconsent to v14.95.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.5.27",
+    "version": "2026.6.15",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^14.85.0",
+                "@duckduckgo/autoconsent": "^14.95.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "14.85.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.85.0.tgz",
-            "integrity": "sha512-yDOLcm6b14s2q7mCMgF7EZw1MCKDVgs31bmiGgz3jR4854GUJrHRZtku365BW/pRFwivHko0FxOqFZGHyrhVbA==",
+            "version": "14.95.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.95.0.tgz",
+            "integrity": "sha512-iQWR1ui2Y2xaobp8WWitAQR7DzWa8XIIeMcWtMo5ZZCEpk9qdJfSvyWudII0Mw1SL2fJlF9Eer3nsqH4LC2zIg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^14.85.0",
+        "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215716402057722
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v14.95.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1215716401839742 apple_task_gid: 1215716401839742 -->

## Description
Updates Autoconsent to version [v14.95.0](https://github.com/duckduckgo/autoconsent/releases/tag/v14.95.0).

### Autoconsent v14.95.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v14.95.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent drives on-page consent handling across sites; a minor version bump can change which banners are dismissed or how, but this is a routine dependency update with no local code changes.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **14.85.0** to **14.95.0** in `package.json` and `package-lock.json`, pulling in the latest cookie/consent management (CPM) rules and behavior from that release.
> 
> Also bumps the **embedded extension** manifest version from **2026.5.27** to **2026.6.15**, aligning the embedded build with this dependency update for native app integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f11cd55b9a153f95c6601b172daf23b69e73ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->