### PR TITLE
CPM: do not cache consentManaged flag per domain

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.6.15",
+    "version": "2026.6.16",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -330,13 +330,6 @@ export default class CookiePromptManagement {
         // @ts-expect-error - origin is not available in the type
         const frameUrl = sender.url || sender.origin || 'about:blank';
         const tabUrl = sender.tab.url || sender.tab.pendingUrl || 'about:blank';
-        let tabDomain = '';
-        try {
-            tabDomain = new URL(tabUrl).hostname;
-        } catch (e) {
-            this.cpmMessaging.logMessage(`error getting tab domain: ${e}`);
-            return;
-        }
 
         // use the cached config
         const remoteConfig = await this.remoteConfigJson;

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -6,10 +6,6 @@ import { registerMessageHandler } from '../message-registry';
 import { registerContentScripts, unregisterContentScripts } from './mv3-content-script-injection';
 
 /**
- * @typedef {import('../tab-manager.js')} TabManager
- */
-
-/**
  * @typedef {Object} CpmState
  * @property {Set<string>} sitesNotifiedCache
  * @property {{
@@ -155,7 +151,7 @@ export default class CookiePromptManagement {
     }
 
     /**
-     * @param {object} jsonCpmState
+     * @param {any} jsonCpmState
      * @returns {CpmState}
      */
     _deserializeCpmState(jsonCpmState) {
@@ -261,6 +257,7 @@ export default class CookiePromptManagement {
      */
     updateTopUrl(tabId, url) {
         const oldTopUrl = this._tabUrlsCache.get(tabId) || new URL('about:blank');
+        /** @type {URL | null} */
         let newTopUrl = null;
         try {
             newTopUrl = new URL(url);
@@ -337,7 +334,7 @@ export default class CookiePromptManagement {
         // @ts-expect-error - origin is not available in the type
         const frameUrl = sender.url || sender.origin || 'about:blank';
         const tabUrl = sender.tab.url || sender.tab.pendingUrl || 'about:blank';
-        let tabDomain = null;
+        let tabDomain = '';
         try {
             tabDomain = new URL(tabUrl).hostname;
         } catch (e) {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -7,7 +7,6 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
 
 /**
  * @typedef {Object} CpmState
- * @property {Set<string>} sitesNotifiedCache
  * @property {{
  *  patterns: Set<string>,
  *  onlyRules: Set<string>,
@@ -156,7 +155,6 @@ export default class CookiePromptManagement {
      */
     _deserializeCpmState(jsonCpmState) {
         return {
-            sitesNotifiedCache: new Set(jsonCpmState.sitesNotifiedCache || []),
             detectionCache: {
                 patterns: new Set(jsonCpmState.detectionCache?.patterns || []),
                 both: new Set(jsonCpmState.detectionCache?.both || []),
@@ -172,7 +170,6 @@ export default class CookiePromptManagement {
      */
     _serializeCpmState(cpmState) {
         return {
-            sitesNotifiedCache: Array.from(cpmState.sitesNotifiedCache),
             detectionCache: {
                 patterns: Array.from(cpmState.detectionCache.patterns),
                 both: Array.from(cpmState.detectionCache.both),
@@ -188,7 +185,6 @@ export default class CookiePromptManagement {
     async getCpmState() {
         if (!this._jsonCpmState) {
             this._jsonCpmState = (await getFromSessionStorage('cpmState')) || {
-                sitesNotifiedCache: [],
                 detectionCache: {
                     patterns: [],
                     both: [],
@@ -405,8 +401,7 @@ export default class CookiePromptManagement {
                 if (isMainFrame) {
                     // no await
                     this.cpmMessaging.refreshDashboardState(tabId, tabUrl, {
-                        // keep "cookies managed" if we did it for this site since app launch
-                        consentManaged: (await this.getCpmState()).sitesNotifiedCache.has(tabDomain),
+                        consentManaged: false,
                         cosmetic: null,
                         optoutFailed: null,
                         selftestFailed: null,
@@ -515,9 +510,6 @@ export default class CookiePromptManagement {
                 } else {
                     this.firePixel(msg.isCosmetic ? 'done_cosmetic' : 'done');
                 }
-                await this.modifyCpmState((cpmState) => {
-                    cpmState.sitesNotifiedCache.add(tabDomain);
-                });
                 this.cpmMessaging.showCpmAnimation(tabId, tabUrl, msg.isCosmetic);
                 this.firePixel(msg.isCosmetic ? 'animation-shown_cosmetic' : 'animation-shown');
                 this.cpmMessaging.notifyPopupHandled(tabId, msg);


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @sammacbeth

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Removes per-domain caching for the consentManaged PD flag
See https://app.asana.com/1/137249556945/project/1163321984198618/task/1215747457572013?focus=true

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy-dashboard consent state for repeat visits to previously handled sites; behavior is intentional but user-visible in CPM/PD.
> 
> **Overview**
> **Cookie Prompt Management** no longer remembers which domains already had consent handled for the life of the session. The **`sitesNotifiedCache`** field is removed from persisted **`cpmState`**, along with the logic that wrote a domain to that cache when **`autoconsentDone`** fired.
> 
> On main-frame **init**, the privacy dashboard **`consentManaged`** flag is now always **`false`** instead of staying **`true`** on return visits to a site that was handled earlier since app launch. **`consentManaged`** still becomes **`true`** when a tab actually completes handling (**`autoconsentDone`** or failed opt-out), unchanged for that navigation.
> 
> Also bumps the embedded extension manifest version to **`2026.6.16`** and drops unused **`tabDomain`** parsing in the CPM message path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded85e13710e7579a268a76fc377889cf8646eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->