### PR TITLE
Set heuristic mode config option based on user preference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^14.95.0",
+                "@duckduckgo/autoconsent": "^15.0.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "14.95.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.95.0.tgz",
-            "integrity": "sha512-iQWR1ui2Y2xaobp8WWitAQR7DzWa8XIIeMcWtMo5ZZCEpk9qdJfSvyWudII0Mw1SL2fJlF9Eer3nsqH4LC2zIg==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-15.0.0.tgz",
+            "integrity": "sha512-Ei/WktmW88wexwKje+iZfER5cEWTjJWjwLWebVsU6d/BO4wJI9LCWcEssLYVMlOKILRDhqb+7P436hug1KYN1g==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ghostery/adblocker": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^15.0.0",
+                "@duckduckgo/autoconsent": "^16.0.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,14 +596,12 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-15.0.0.tgz",
-            "integrity": "sha512-Ei/WktmW88wexwKje+iZfER5cEWTjJWjwLWebVsU6d/BO4wJI9LCWcEssLYVMlOKILRDhqb+7P436hug1KYN1g==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.0.0.tgz",
+            "integrity": "sha512-KhNs66HzfH0dfLwtQtE00ZQQfNn7wsxRoouf2W+8nSM0zl15DlPO+uiKMe8kmdHae/CK7OyEbc9FjXtrXQEEvQ==",
             "license": "MPL-2.0",
             "dependencies": {
-                "@ghostery/adblocker": "^2.0.4",
-                "@ghostery/adblocker-content": "^2.0.4",
-                "tldts-experimental": "^7.0.4"
+                "tldts-experimental": "^7.4.3"
             }
         },
         "node_modules/@duckduckgo/autofill": {
@@ -1554,45 +1552,6 @@
                 "node": ">= 0.10.0"
             }
         },
-        "node_modules/@ghostery/adblocker": {
-            "version": "2.13.4",
-            "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.4.tgz",
-            "integrity": "sha512-rI7MbS+F2ckIr/2brV+QHMyl55W7F1vazAFiJYHcOBi6i4ClI47Ep95HakwB2qM95gv9igQDTE1zFisV2YKgGg==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@ghostery/adblocker-content": "^2.13.4",
-                "@ghostery/adblocker-extended-selectors": "^2.13.4",
-                "@ghostery/url-parser": "^1.3.0",
-                "@remusao/guess-url-type": "^2.1.0",
-                "@remusao/small": "^2.1.0",
-                "@remusao/smaz": "^2.2.0",
-                "tldts-experimental": "^7.0.18"
-            }
-        },
-        "node_modules/@ghostery/adblocker-content": {
-            "version": "2.13.4",
-            "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.4.tgz",
-            "integrity": "sha512-VPa4dyHqTyMWxut/wCYYlHdVRsQ2ZXXezTv31WiRhUC86LFKz8rL/Jnj1baHXlRrO5Ndhpll1/e/J/Tzwu6mqg==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@ghostery/adblocker-extended-selectors": "^2.13.4"
-            }
-        },
-        "node_modules/@ghostery/adblocker-extended-selectors": {
-            "version": "2.13.4",
-            "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.4.tgz",
-            "integrity": "sha512-nDNK72R9Ly+AOBsd3f0SAxtF3FELx7ogOPCDD2MVJtv3qYZG76fHUmUoCGRmN2oHlPPNUQJ+vI4Rm/LRM1B5XQ==",
-            "license": "MPL-2.0"
-        },
-        "node_modules/@ghostery/url-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.1.tgz",
-            "integrity": "sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "tldts-experimental": "^7.0.8"
-            }
-        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2338,49 +2297,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/@remusao/guess-url-type": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
-            "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
-            "license": "MPL-2.0"
-        },
-        "node_modules/@remusao/small": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
-            "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
-            "license": "MPL-2.0"
-        },
-        "node_modules/@remusao/smaz": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
-            "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@remusao/smaz-compress": "^2.2.0",
-                "@remusao/smaz-decompress": "^2.2.0"
-            }
-        },
-        "node_modules/@remusao/smaz-compress": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
-            "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@remusao/trie": "^2.1.0"
-            }
-        },
-        "node_modules/@remusao/smaz-decompress": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
-            "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
-            "license": "MPL-2.0"
-        },
-        "node_modules/@remusao/trie": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
-            "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
-            "license": "MPL-2.0"
         },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
@@ -12095,18 +12011,18 @@
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.22",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
-            "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+            "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
             "license": "MIT"
         },
         "node_modules/tldts-experimental": {
-            "version": "7.0.22",
-            "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.22.tgz",
-            "integrity": "sha512-SHhoOcwbcARDYeXX1pcNI41MYdejjbBHf5aX5cF39Up8+dgwtyD8nKkgYFVH39r+apOVbW4HaoU390X6eXlQ4Q==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.4.tgz",
+            "integrity": "sha512-L1xvJQNZQFrhjyAFmFlOoijmd9lSOvK6bGs0+z8Nz91UCAIyVIShwOsPPStuQH4XCFwif5Hlmcr6DnEz7Ag7Xw==",
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.22"
+                "tldts-core": "^7.4.4"
             }
         },
         "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^14.95.0",
+        "@duckduckgo/autoconsent": "^15.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^15.0.0",
+        "@duckduckgo/autoconsent": "^16.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -227,8 +227,10 @@ export default class CookiePromptManagement {
         return this._deserializeCpmState(this._jsonCpmState);
     }
 
-    checkHeuristicActionEnabled() {
-        return this.cpmMessaging.checkSubfeatureEnabled('heuristicAction');
+    async checkHeuristicActionEnabled() {
+        const settings = await this.cpmMessaging.checkAutoconsentSetting();
+        const heuristicMode = heuristicModeNameToValue[this.settingsToHeuristicModeName(settings)];
+        return heuristicMode > PopupHandlingModes.None;
     }
 
     /**
@@ -337,23 +339,6 @@ export default class CookiePromptManagement {
             this._reloadLoopDetected.add(tabId);
             this.firePixel('error_reload-loop');
         }
-    }
-
-    /**
-     *
-     * @param {boolean} heuristicActionEnabled
-     * @param {'off' | 'default' | 'max'} preference
-     */
-    getHeuristicMode(heuristicActionEnabled, preference) {
-        if (!heuristicActionEnabled) {
-            return PopupHandlingModes.None;
-        }
-        if (preference === 'max') {
-            return PopupHandlingModes.Tier2;
-        } else if (preference === 'default') {
-            return PopupHandlingModes.Tier1;
-        }
-        return PopupHandlingModes.Reject;
     }
 
     /**
@@ -542,7 +527,7 @@ export default class CookiePromptManagement {
                         selftestFailed: null,
                         consentReloadLoop: this._reloadLoopDetected.has(tabId),
                         consentRule: msg.cmp,
-                        consentHeuristicEnabled: await this.cpmMessaging.checkSubfeatureEnabled('heuristicAction'),
+                        consentHeuristicEnabled: await this.checkHeuristicActionEnabled(),
                     });
                 } else {
                     // TODO: implement self-tests
@@ -559,7 +544,7 @@ export default class CookiePromptManagement {
                     selftestFailed: null,
                     consentReloadLoop: this._reloadLoopDetected.has(tabId),
                     consentRule: msg.cmp,
-                    consentHeuristicEnabled: await this.cpmMessaging.checkSubfeatureEnabled('heuristicAction'),
+                    consentHeuristicEnabled: await this.checkHeuristicActionEnabled(),
                 });
                 if (msg.cmp === 'HEURISTIC') {
                     this.firePixel('done_heuristic');
@@ -685,7 +670,7 @@ export default class CookiePromptManagement {
         if (userPreference === 'max') {
             return 'tier2';
         }
-        return '';
+        return 'off';
     }
 
     async getPixelHeuristicParameter() {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -38,7 +38,6 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  *  refreshDashboardState: (tabId: number, url: string, dashboardState: Partial<CpmDashboardState>) => Promise<void>;
  *  showCpmAnimation: (tabId: number, topUrl: string, isCosmetic: boolean) => Promise<void>;
  *  notifyPopupHandled: (tabId: number, msg: import('@duckduckgo/autoconsent').DoneMessage) => Promise<void>;
- *  checkAutoconsentSettingEnabled: () => Promise<boolean>;
  *  checkAutoconsentEnabledForSite: (url: string) => Promise<boolean>;
  *  checkAutoconsentSetting: () => Promise<AutoconsentUserSettings>;
  *  checkSubfeatureEnabled: (subfeatureName: string) => Promise<boolean>;

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -55,22 +55,6 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
 
 /* global DEBUG, BUILD_TARGET */
 
-// From @duckduckgo/autoconsent/dist/types/types.ts
-const PopupHandlingModes = {
-    None: -1,
-    Reject: 0,
-    Tier1: 1,
-    Tier2: 2,
-};
-
-const heuristicModeNameToValue = {
-    off: PopupHandlingModes.None,
-    0: PopupHandlingModes.None,
-    1: PopupHandlingModes.Reject,
-    tier1: PopupHandlingModes.Tier1,
-    tier2: PopupHandlingModes.Tier2,
-};
-
 /**
  * @type {import('@duckduckgo/autoconsent').Config['logs']}
  */
@@ -229,8 +213,8 @@ export default class CookiePromptManagement {
 
     async checkHeuristicActionEnabled() {
         const settings = await this.cpmMessaging.checkAutoconsentSetting();
-        const heuristicMode = heuristicModeNameToValue[this.settingsToHeuristicModeName(settings)];
-        return heuristicMode > PopupHandlingModes.None;
+        const heuristicMode = this.settingsToHeuristicModeName(settings);
+        return heuristicMode != 'off';
     }
 
     /**
@@ -426,8 +410,8 @@ export default class CookiePromptManagement {
                 // - default and new settings enabled: Tier1
                 // - default and new settings disabled: Reject
                 // - off: Reject (isEnabled should already be disabling it)
-                const heuristicMode = heuristicModeNameToValue[this.settingsToHeuristicModeName(settings)];
-                const heuristicActionEnabled = heuristicMode > PopupHandlingModes.None;
+                const heuristicMode = this.settingsToHeuristicModeName(settings);
+                const heuristicActionEnabled = heuristicMode != 'off';
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */
                 let autoAction = 'optOut';
@@ -468,7 +452,6 @@ export default class CookiePromptManagement {
                     enableGeneratedRules: true,
                     enableFilterList: false,
                     enableHeuristicDetection: true,
-                    enableHeuristicAction: heuristicActionEnabled,
                     heuristicMode,
                     visualTest,
                     logs: logsConfig,
@@ -651,18 +634,15 @@ export default class CookiePromptManagement {
      *  - 'tier2' if user preference is 'max'.
      *  - '' if the operating mode is not determined.
      * @param {AutoconsentUserSettings} settings
-     * @returns {'off' | '0' | '1' | 'tier1' | 'tier2' | ''}
+     * @returns {'off' | 'reject' | 'tier1' | 'tier2'}
      */
     settingsToHeuristicModeName(settings) {
         const { enabled, userPreference, featureFlags } = settings;
-        if (!enabled || userPreference === 'off') {
+        if (!enabled || userPreference === 'off' || !featureFlags.heuristicAction) {
             return 'off';
         }
-        if (!featureFlags.heuristicAction) {
-            return '0';
-        }
         if (!featureFlags.cookiePopupPreferenceSetting) {
-            return '1';
+            return 'reject';
         }
         if (userPreference === 'default') {
             return 'tier1';

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -332,9 +332,9 @@ export default class CookiePromptManagement {
     }
 
     /**
-     * 
-     * @param {boolean} heuristicActionEnabled 
-     * @param {'off' | 'default' | 'max'} preference 
+     *
+     * @param {boolean} heuristicActionEnabled
+     * @param {'off' | 'default' | 'max'} preference
      */
     getHeuristicMode(heuristicActionEnabled, preference) {
         if (!heuristicActionEnabled) {
@@ -401,7 +401,11 @@ export default class CookiePromptManagement {
             this.cpmMessaging.logMessage(`autoconsentSettings not ready: ${autoconsentSettings}`);
             return;
         }
-        const { enabled: autoconsentFeatureEnabled, preference, heuristicActionEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
+        const {
+            enabled: autoconsentFeatureEnabled,
+            preference,
+            heuristicActionEnabled,
+        } = await this.cpmMessaging.checkAutoconsentSetting();
         if (!autoconsentFeatureEnabled) {
             this.cpmMessaging.logMessage('autoconsent setting not enabled');
             return;
@@ -432,7 +436,12 @@ export default class CookiePromptManagement {
                 // - default and new settings enabled: Tier1
                 // - default and new settings disabled: Reject
                 // - off: Reject (isEnabled should already be disabling it)
-                const heuristicMode = preference === 'max' ? PopupHandlingModes.Tier2 : preference === 'default' ? PopupHandlingModes.Tier1 : PopupHandlingModes.Reject
+                const heuristicMode =
+                    preference === 'max'
+                        ? PopupHandlingModes.Tier2
+                        : preference === 'default'
+                          ? PopupHandlingModes.Tier1
+                          : PopupHandlingModes.Reject;
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */
                 let autoAction = 'optOut';
@@ -653,7 +662,7 @@ export default class CookiePromptManagement {
             return '-1';
         }
         if (!heuristicActionEnabled) {
-            return '0'
+            return '0';
         }
         if (preference === 'default') {
             return '1';

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -627,18 +627,21 @@ export default class CookiePromptManagement {
 
     /**
      * Determine the autoconsent operating mode from user settings and feature flags.
-     *  - 'off' if autoconsent is disabled.
-     *  - '0' if heuristic action is disabled.
-     *  - '1' if cookie popup preference setting is disabled (this is the old settings UI)
+     *  - '' if autoconsent is disabled.
+     *  - 'off' if heuristic action is disabled.
+     *  - 'reject' if cookie popup preference setting is disabled (this is the old settings UI)
      *  - 'tier1' if user preference is 'default'.
      *  - 'tier2' if user preference is 'max'.
      *  - '' if the operating mode is not determined.
      * @param {AutoconsentUserSettings} settings
-     * @returns {'off' | 'reject' | 'tier1' | 'tier2'}
+     * @returns {'' | 'off' | 'reject' | 'tier1' | 'tier2'}
      */
     settingsToHeuristicModeName(settings) {
         const { enabled, userPreference, featureFlags } = settings;
-        if (!enabled || userPreference === 'off' || !featureFlags.heuristicAction) {
+        if (!enabled || userPreference === 'off') {
+            return '';
+        }
+        if (!featureFlags.heuristicAction) {
             return 'off';
         }
         if (!featureFlags.cookiePopupPreferenceSetting) {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -386,7 +386,7 @@ export default class CookiePromptManagement {
                 // - max: Tier2
                 // - default and new settings enabled: Tier1
                 // - default and new settings disabled: Reject
-                // - off: Reject (isEnabled should already be disabling it)
+                // - off: disabled.
                 const heuristicMode = this.settingsToHeuristicModeName(settings);
                 const heuristicActionEnabled = heuristicMode !== 'off';
 

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -214,7 +214,7 @@ export default class CookiePromptManagement {
     async checkHeuristicActionEnabled() {
         const settings = await this.cpmMessaging.checkAutoconsentSetting();
         const heuristicMode = this.settingsToHeuristicModeName(settings);
-        return heuristicMode != 'off' && heuristicMode != '';
+        return heuristicMode !== 'off' && heuristicMode !== '';
     }
 
     /**
@@ -388,9 +388,9 @@ export default class CookiePromptManagement {
                 // - default and new settings disabled: Reject
                 // - off: Reject (isEnabled should already be disabling it)
                 const heuristicMode = this.settingsToHeuristicModeName(settings);
-                const heuristicActionEnabled = heuristicMode != 'off';
+                const heuristicActionEnabled = heuristicMode !== 'off';
 
-                if (heuristicMode == '') {
+                if (heuristicMode === '') {
                     this.cpmMessaging.logMessage('autoconsent setting not enabled');
                     return;
                 }

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -40,13 +40,28 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  *  notifyPopupHandled: (tabId: number, msg: import('@duckduckgo/autoconsent').DoneMessage) => Promise<void>;
  *  checkAutoconsentSettingEnabled: () => Promise<boolean>;
  *  checkAutoconsentEnabledForSite: (url: string) => Promise<boolean>;
+ *  checkAutoconsentSetting: () => Promise<AutoconsentUserSettings>;
  *  checkSubfeatureEnabled: (subfeatureName: string) => Promise<boolean>;
  *  sendPixel: (pixelName: string, type: 'standard' | 'daily', params: Record<string, any>) => Promise<void>;
  *  refreshRemoteConfig: () => Promise<import('@duckduckgo/privacy-configuration/schema/config.ts').CurrentGenericConfig?>;
  * }} CPMMessagingBase
+ * @typedef {{
+ *  enabled: boolean,
+ *  preference?: 'off' | 'default' | 'max',
+ *  heuristicActionEnabled?: boolean,
+ *  preferenceSettingEnabled?: boolean,
+ * }} AutoconsentUserSettings
  */
 
 /* global DEBUG, BUILD_TARGET */
+
+// From @duckduckgo/autoconsent/dist/types/types.ts
+const PopupHandlingModes = {
+    None: -1,
+    Reject: 0,
+    Tier1: 1,
+    Tier2: 2,
+};
 
 /**
  * @type {import('@duckduckgo/autoconsent').Config['logs']}
@@ -317,6 +332,23 @@ export default class CookiePromptManagement {
     }
 
     /**
+     * 
+     * @param {boolean} heuristicActionEnabled 
+     * @param {'off' | 'default' | 'max'} preference 
+     */
+    getHeuristicMode(heuristicActionEnabled, preference) {
+        if (!heuristicActionEnabled) {
+            return PopupHandlingModes.None;
+        }
+        if (preference === 'max') {
+            return PopupHandlingModes.Tier2;
+        } else if (preference === 'default') {
+            return PopupHandlingModes.Tier1;
+        }
+        return PopupHandlingModes.Reject;
+    }
+
+    /**
      *
      * @param {import('@duckduckgo/autoconsent').ContentScriptMessage} msg
      * @param {browser.Runtime.MessageSender} sender
@@ -369,12 +401,11 @@ export default class CookiePromptManagement {
             this.cpmMessaging.logMessage(`autoconsentSettings not ready: ${autoconsentSettings}`);
             return;
         }
-        const autoconsentFeatureEnabled = await this.cpmMessaging.checkAutoconsentSettingEnabled();
+        const { enabled: autoconsentFeatureEnabled, preference, heuristicActionEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
         if (!autoconsentFeatureEnabled) {
             this.cpmMessaging.logMessage('autoconsent setting not enabled');
             return;
         }
-        const heuristicActionEnabled = await this.checkHeuristicActionEnabled();
 
         switch (msg.type) {
             case 'init': {
@@ -396,6 +427,12 @@ export default class CookiePromptManagement {
                 }
 
                 const visualTest = DEBUG;
+                // Map preference to heuristic mode:
+                // - max: Tier2
+                // - default and new settings enabled: Tier1
+                // - default and new settings disabled: Reject
+                // - off: Reject (isEnabled should already be disabling it)
+                const heuristicMode = preference === 'max' ? PopupHandlingModes.Tier2 : preference === 'default' ? PopupHandlingModes.Tier1 : PopupHandlingModes.Reject
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */
                 let autoAction = 'optOut';
@@ -437,6 +474,7 @@ export default class CookiePromptManagement {
                     enableFilterList: false,
                     enableHeuristicDetection: true,
                     enableHeuristicAction: heuristicActionEnabled,
+                    heuristicMode,
                     visualTest,
                     logs: logsConfig,
                 };
@@ -609,6 +647,23 @@ export default class CookiePromptManagement {
         });
     }
 
+    async getPixelHeuristicParameter() {
+        const { enabled, preference, heuristicActionEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
+        if (!enabled || preference === 'off') {
+            return '-1';
+        }
+        if (!heuristicActionEnabled) {
+            return '0'
+        }
+        if (preference === 'default') {
+            return '1';
+        }
+        if (preference === 'max') {
+            return '2';
+        }
+        return '';
+    }
+
     async firePixel(eventName) {
         this.modifyCpmState((cpmState) => {
             cpmState.summaryEvents[eventName] = (cpmState.summaryEvents[eventName] || 0) + 1;
@@ -622,7 +677,7 @@ export default class CookiePromptManagement {
         // request "daily" pixel firing
         const pixelName = `autoconsent_${eventName}`;
         this.cpmMessaging.sendPixel(pixelName, 'daily', {
-            consentHeuristicEnabled: (await this.checkHeuristicActionEnabled()) ? '1' : '0',
+            consentHeuristicEnabled: await this.getPixelHeuristicParameter(),
             fromExtension: '1',
         });
     }
@@ -638,7 +693,7 @@ export default class CookiePromptManagement {
         });
         this.cpmMessaging.sendPixel('autoconsent_summary', 'standard', {
             ...summaryEvents,
-            consentHeuristicEnabled: (await this.checkHeuristicActionEnabled()) ? '1' : '0',
+            consentHeuristicEnabled: await this.getPixelHeuristicParameter(),
             fromExtension: '1',
         });
     }

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -657,18 +657,21 @@ export default class CookiePromptManagement {
     }
 
     async getPixelHeuristicParameter() {
-        const { enabled, preference, heuristicActionEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
+        const { enabled, preference, heuristicActionEnabled, preferenceSettingEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
         if (!enabled || preference === 'off') {
-            return '-1';
+            return 'off';
         }
         if (!heuristicActionEnabled) {
             return '0';
         }
-        if (preference === 'default') {
+        if (!preferenceSettingEnabled) {
             return '1';
         }
+        if (preference === 'default') {
+            return 'tier1';
+        }
         if (preference === 'max') {
-            return '2';
+            return 'tier2';
         }
         return '';
     }

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -214,7 +214,7 @@ export default class CookiePromptManagement {
     async checkHeuristicActionEnabled() {
         const settings = await this.cpmMessaging.checkAutoconsentSetting();
         const heuristicMode = this.settingsToHeuristicModeName(settings);
-        return heuristicMode != 'off';
+        return heuristicMode != 'off' && heuristicMode != '';
     }
 
     /**

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -1,5 +1,4 @@
 import { filterCompactRules, evalSnippets } from '@duckduckgo/autoconsent';
-import { consentomatic } from '@duckduckgo/autoconsent/rules/consentomatic.json';
 import browser from 'webextension-polyfill';
 import { getFromSessionStorage, setToSessionStorage, createAlarm } from '../wrapper';
 import { registerMessageHandler } from '../message-registry';
@@ -449,7 +448,6 @@ export default class CookiePromptManagement {
                     prehideTimeout: 2000,
                     enableCosmeticRules: true,
                     enableGeneratedRules: true,
-                    enableFilterList: false,
                     enableHeuristicDetection: true,
                     heuristicMode,
                     visualTest,
@@ -458,7 +456,6 @@ export default class CookiePromptManagement {
                 const compactRuleList = autoconsentSettings.compactRuleList;
                 const rules = {
                     autoconsent: [],
-                    consentomatic,
                 };
                 if (compactRuleList) {
                     if (compactRuleList.index) {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -382,8 +382,15 @@ export default class CookiePromptManagement {
         switch (msg.type) {
             case 'init': {
                 const settings = await this.cpmMessaging.checkAutoconsentSetting();
+                // Map preference to heuristic mode:
+                // - max: Tier2
+                // - default and new settings enabled: Tier1
+                // - default and new settings disabled: Reject
+                // - off: Reject (isEnabled should already be disabling it)
+                const heuristicMode = this.settingsToHeuristicModeName(settings);
+                const heuristicActionEnabled = heuristicMode != 'off';
 
-                if (!settings.enabled) {
+                if (heuristicMode == '') {
                     this.cpmMessaging.logMessage('autoconsent setting not enabled');
                     return;
                 }
@@ -405,13 +412,6 @@ export default class CookiePromptManagement {
                 }
 
                 const visualTest = DEBUG;
-                // Map preference to heuristic mode:
-                // - max: Tier2
-                // - default and new settings enabled: Tier1
-                // - default and new settings disabled: Reject
-                // - off: Reject (isEnabled should already be disabling it)
-                const heuristicMode = this.settingsToHeuristicModeName(settings);
-                const heuristicActionEnabled = heuristicMode != 'off';
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */
                 let autoAction = 'optOut';

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -47,10 +47,10 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  * }} CPMMessagingBase
  * @typedef {{
  *  enabled: boolean,
- *  preference?: 'off' | 'default' | 'max',
- *  heuristicActionEnabled?: boolean,
- *  preferenceSettingEnabled?: boolean,
+ *  userPreference?: AutoconsentModePreference,
+ *  featureFlags: Record<string, boolean>,
  * }} AutoconsentUserSettings
+ * @typedef {'off' | 'default' | 'max'} AutoconsentModePreference
  */
 
 /* global DEBUG, BUILD_TARGET */
@@ -61,6 +61,14 @@ const PopupHandlingModes = {
     Reject: 0,
     Tier1: 1,
     Tier2: 2,
+};
+
+const heuristicModeNameToValue = {
+    off: PopupHandlingModes.None,
+    0: PopupHandlingModes.None,
+    1: PopupHandlingModes.Reject,
+    tier1: PopupHandlingModes.Tier1,
+    tier2: PopupHandlingModes.Tier2,
 };
 
 /**
@@ -401,18 +409,15 @@ export default class CookiePromptManagement {
             this.cpmMessaging.logMessage(`autoconsentSettings not ready: ${autoconsentSettings}`);
             return;
         }
-        const {
-            enabled: autoconsentFeatureEnabled,
-            preference,
-            heuristicActionEnabled,
-        } = await this.cpmMessaging.checkAutoconsentSetting();
-        if (!autoconsentFeatureEnabled) {
-            this.cpmMessaging.logMessage('autoconsent setting not enabled');
-            return;
-        }
 
         switch (msg.type) {
             case 'init': {
+                const settings = await this.cpmMessaging.checkAutoconsentSetting();
+
+                if (!settings.enabled) {
+                    this.cpmMessaging.logMessage('autoconsent setting not enabled');
+                    return;
+                }
                 // do the navigation check before checking if the domain is allowlisted
                 if (isMainFrame) {
                     // update the cached top url for this tab
@@ -436,12 +441,8 @@ export default class CookiePromptManagement {
                 // - default and new settings enabled: Tier1
                 // - default and new settings disabled: Reject
                 // - off: Reject (isEnabled should already be disabling it)
-                const heuristicMode =
-                    preference === 'max'
-                        ? PopupHandlingModes.Tier2
-                        : preference === 'default'
-                          ? PopupHandlingModes.Tier1
-                          : PopupHandlingModes.Reject;
+                const heuristicMode = heuristicModeNameToValue[this.settingsToHeuristicModeName(settings)];
+                const heuristicActionEnabled = heuristicMode > PopupHandlingModes.None;
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */
                 let autoAction = 'optOut';
@@ -541,7 +542,7 @@ export default class CookiePromptManagement {
                         selftestFailed: null,
                         consentReloadLoop: this._reloadLoopDetected.has(tabId),
                         consentRule: msg.cmp,
-                        consentHeuristicEnabled: heuristicActionEnabled,
+                        consentHeuristicEnabled: await this.cpmMessaging.checkSubfeatureEnabled('heuristicAction'),
                     });
                 } else {
                     // TODO: implement self-tests
@@ -558,7 +559,7 @@ export default class CookiePromptManagement {
                     selftestFailed: null,
                     consentReloadLoop: this._reloadLoopDetected.has(tabId),
                     consentRule: msg.cmp,
-                    consentHeuristicEnabled: heuristicActionEnabled,
+                    consentHeuristicEnabled: await this.cpmMessaging.checkSubfeatureEnabled('heuristicAction'),
                 });
                 if (msg.cmp === 'HEURISTIC') {
                     this.firePixel('done_heuristic');
@@ -656,24 +657,39 @@ export default class CookiePromptManagement {
         });
     }
 
-    async getPixelHeuristicParameter() {
-        const { enabled, preference, heuristicActionEnabled, preferenceSettingEnabled } = await this.cpmMessaging.checkAutoconsentSetting();
-        if (!enabled || preference === 'off') {
+    /**
+     * Determine the autoconsent operating mode from user settings and feature flags.
+     *  - 'off' if autoconsent is disabled.
+     *  - '0' if heuristic action is disabled.
+     *  - '1' if cookie popup preference setting is disabled (this is the old settings UI)
+     *  - 'tier1' if user preference is 'default'.
+     *  - 'tier2' if user preference is 'max'.
+     *  - '' if the operating mode is not determined.
+     * @param {AutoconsentUserSettings} settings
+     * @returns {'off' | '0' | '1' | 'tier1' | 'tier2' | ''}
+     */
+    settingsToHeuristicModeName(settings) {
+        const { enabled, userPreference, featureFlags } = settings;
+        if (!enabled || userPreference === 'off') {
             return 'off';
         }
-        if (!heuristicActionEnabled) {
+        if (!featureFlags.heuristicAction) {
             return '0';
         }
-        if (!preferenceSettingEnabled) {
+        if (!featureFlags.cookiePopupPreferenceSetting) {
             return '1';
         }
-        if (preference === 'default') {
+        if (userPreference === 'default') {
             return 'tier1';
         }
-        if (preference === 'max') {
+        if (userPreference === 'max') {
             return 'tier2';
         }
         return '';
+    }
+
+    async getPixelHeuristicParameter() {
+        return this.settingsToHeuristicModeName(await this.cpmMessaging.checkAutoconsentSetting());
     }
 
     async firePixel(eventName) {

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -119,8 +119,17 @@ export class CPMEmbeddedMessaging {
     }
 
     async checkAutoconsentSettingEnabled() {
+        const result = await this.checkAutoconsentSetting();
+        return result.enabled;
+    }
+
+    /**
+     * Check autoconsent enabled state and user preference.
+     * @returns {Promise<import('./cookie-prompt-management').AutoconsentUserSettings>}
+     */
+    async checkAutoconsentSetting() {
         const result = await this._request('isAutoconsentSettingEnabled', {}, 'userSetting', SETTING_CHECK_TTL);
-        return result?.enabled ?? false;
+        return result ?? { enabled: false };
     }
 
     async checkAutoconsentEnabledForSite(url) {

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -118,11 +118,6 @@ export class CPMEmbeddedMessaging {
         });
     }
 
-    async checkAutoconsentSettingEnabled() {
-        const result = await this.checkAutoconsentSetting();
-        return result.enabled;
-    }
-
     /**
      * Check autoconsent enabled state and user preference.
      * @returns {Promise<import('./cookie-prompt-management').AutoconsentUserSettings>}

--- a/shared/js/background/components/cpm-standalone-messaging.js
+++ b/shared/js/background/components/cpm-standalone-messaging.js
@@ -34,11 +34,6 @@ export class CPMStandaloneMessaging {
         // no-op
     }
 
-    async checkAutoconsentSettingEnabled() {
-        // there's no Autoconsent setting in the extension yet
-        return true;
-    }
-
     async checkAutoconsentSetting() {
         // there's no Autoconsent setting in the extension yet
         /** @type {import('./cookie-prompt-management').AutoconsentModePreference} */

--- a/shared/js/background/components/cpm-standalone-messaging.js
+++ b/shared/js/background/components/cpm-standalone-messaging.js
@@ -39,6 +39,11 @@ export class CPMStandaloneMessaging {
         return true;
     }
 
+    async checkAutoconsentSetting() {
+        // there's no Autoconsent setting in the extension yet
+        return { enabled: true };
+    }   
+
     async checkAutoconsentEnabledForSite(url) {
         await this.remoteConfig.ready;
         const site = new Site(url);

--- a/shared/js/background/components/cpm-standalone-messaging.js
+++ b/shared/js/background/components/cpm-standalone-messaging.js
@@ -42,7 +42,7 @@ export class CPMStandaloneMessaging {
     async checkAutoconsentSetting() {
         // there's no Autoconsent setting in the extension yet
         return { enabled: true };
-    }   
+    }
 
     async checkAutoconsentEnabledForSite(url) {
         await this.remoteConfig.ready;

--- a/shared/js/background/components/cpm-standalone-messaging.js
+++ b/shared/js/background/components/cpm-standalone-messaging.js
@@ -41,7 +41,9 @@ export class CPMStandaloneMessaging {
 
     async checkAutoconsentSetting() {
         // there's no Autoconsent setting in the extension yet
-        return { enabled: true };
+        /** @type {import('./cookie-prompt-management').AutoconsentModePreference} */
+        const userPreference = 'default';
+        return { enabled: true, userPreference, featureFlags: { heuristicAction: true, cookiePopupPreferenceSetting: true } };
     }
 
     async checkAutoconsentEnabledForSite(url) {

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -14,18 +14,16 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
         checkAutoconsentSettingEnabled: jasmine
             .createSpy('checkAutoconsentSettingEnabled')
             .and.returnValue(Promise.resolve(autoconsentSettingEnabled)),
-        checkAutoconsentSetting: jasmine
-            .createSpy('checkAutoconsentSetting')
-            .and.returnValue(
-                Promise.resolve({
-                    enabled: autoconsentSettingEnabled,
-                    userPreference: 'default',
-                    featureFlags: {
-                        heuristicAction: true,
-                        cookiePopupPreferenceSetting: true,
-                    },
-                }),
-            ),
+        checkAutoconsentSetting: jasmine.createSpy('checkAutoconsentSetting').and.returnValue(
+            Promise.resolve({
+                enabled: autoconsentSettingEnabled,
+                userPreference: 'default',
+                featureFlags: {
+                    heuristicAction: true,
+                    cookiePopupPreferenceSetting: true,
+                },
+            }),
+        ),
         checkAutoconsentEnabledForSite: jasmine
             .createSpy('checkAutoconsentEnabledForSite')
             .and.returnValue(Promise.resolve(autoconsentEnabledForSite)),

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -11,9 +11,6 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
         refreshDashboardState: jasmine.createSpy('refreshDashboardState').and.returnValue(Promise.resolve()),
         showCpmAnimation: jasmine.createSpy('showCpmAnimation').and.returnValue(Promise.resolve()),
         notifyPopupHandled: jasmine.createSpy('notifyPopupHandled').and.returnValue(Promise.resolve()),
-        checkAutoconsentSettingEnabled: jasmine
-            .createSpy('checkAutoconsentSettingEnabled')
-            .and.returnValue(Promise.resolve(autoconsentSettingEnabled)),
         checkAutoconsentSetting: jasmine.createSpy('checkAutoconsentSetting').and.returnValue(
             Promise.resolve({
                 enabled: autoconsentSettingEnabled,

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -14,6 +14,18 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
         checkAutoconsentSettingEnabled: jasmine
             .createSpy('checkAutoconsentSettingEnabled')
             .and.returnValue(Promise.resolve(autoconsentSettingEnabled)),
+        checkAutoconsentSetting: jasmine
+            .createSpy('checkAutoconsentSetting')
+            .and.returnValue(
+                Promise.resolve({
+                    enabled: autoconsentSettingEnabled,
+                    userPreference: 'default',
+                    featureFlags: {
+                        heuristicAction: true,
+                        cookiePopupPreferenceSetting: true,
+                    },
+                }),
+            ),
         checkAutoconsentEnabledForSite: jasmine
             .createSpy('checkAutoconsentEnabledForSite')
             .and.returnValue(Promise.resolve(autoconsentEnabledForSite)),

--- a/unit-test/background/cpm-embedded-messaging.js
+++ b/unit-test/background/cpm-embedded-messaging.js
@@ -251,38 +251,41 @@ describe('CPMEmbeddedMessaging', () => {
         });
     });
 
-    describe('checkAutoconsentSettingEnabled', () => {
-        it('returns true when native response has enabled: true', async () => {
-            nativeMessaging.request.and.returnValue(Promise.resolve({ enabled: true }));
-            const result = await messaging.checkAutoconsentSettingEnabled();
-            expect(result).toBeTrue();
+    describe('checkAutoconsentSetting', () => {
+        it('returns the native response when autoconsent is enabled', async () => {
+            const settings = {
+                enabled: true,
+                userPreference: 'default',
+                featureFlags: { heuristicAction: true },
+            };
+            nativeMessaging.request.and.returnValue(Promise.resolve(settings));
+            const result = await messaging.checkAutoconsentSetting();
+            expect(result).toEqual(settings);
             expect(nativeMessaging.request).toHaveBeenCalledWith('isAutoconsentSettingEnabled', {});
         });
 
-        it('returns false when native response has enabled: false', async () => {
-            nativeMessaging.request.and.returnValue(Promise.resolve({ enabled: false }));
-            const result = await messaging.checkAutoconsentSettingEnabled();
-            expect(result).toBeFalse();
+        it('returns the native response when autoconsent is disabled', async () => {
+            const settings = { enabled: false, featureFlags: {} };
+            nativeMessaging.request.and.returnValue(Promise.resolve(settings));
+            const result = await messaging.checkAutoconsentSetting();
+            expect(result).toEqual(settings);
         });
 
-        it('returns false when native response is null/undefined', async () => {
-            nativeMessaging.request.and.returnValue(Promise.resolve(null));
-            const result = await messaging.checkAutoconsentSettingEnabled();
-            expect(result).toBeFalse();
+        it('returns { enabled: false } when native response is null/undefined', async () => {
+            nativeMessaging.request.and.returnValue(Promise.resolve(undefined));
+            const result = await messaging.checkAutoconsentSetting();
+            expect(result).toEqual({ enabled: false });
         });
 
         it('caches the result with SETTING_CHECK_TTL', async () => {
-            nativeMessaging.request.and.returnValue(Promise.resolve({ enabled: true }));
+            nativeMessaging.request.and.returnValue(Promise.resolve({ enabled: true, featureFlags: {} }));
 
-            await messaging.checkAutoconsentSettingEnabled();
-            await messaging.checkAutoconsentSettingEnabled();
-
-            // Only one actual request due to caching
+            await messaging.checkAutoconsentSetting();
+            await messaging.checkAutoconsentSetting();
             expect(nativeMessaging.request).toHaveBeenCalledTimes(1);
 
-            // After TTL expires, request is made again
             jasmine.clock().tick(SETTING_CHECK_TTL + 1);
-            await messaging.checkAutoconsentSettingEnabled();
+            await messaging.checkAutoconsentSetting();
             expect(nativeMessaging.request).toHaveBeenCalledTimes(2);
         });
     });

--- a/unit-test/background/cpm-standalone-messaging.js
+++ b/unit-test/background/cpm-standalone-messaging.js
@@ -73,10 +73,17 @@ describe('CPMStandaloneMessaging', () => {
         });
     });
 
-    describe('checkAutoconsentSettingEnabled', () => {
-        it('always returns true', async () => {
-            const result = await messaging.checkAutoconsentSettingEnabled();
-            expect(result).toBeTrue();
+    describe('checkAutoconsentSetting', () => {
+        it('returns enabled with default user preference and feature flags', async () => {
+            const result = await messaging.checkAutoconsentSetting();
+            expect(result).toEqual({
+                enabled: true,
+                userPreference: 'default',
+                featureFlags: {
+                    heuristicAction: true,
+                    cookiePopupPreferenceSetting: true,
+                },
+            });
         });
     });
 


### PR DESCRIPTION

**Reviewer:** @muodov 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
 - Integrates the new heuristicMode option added in https://github.com/duckduckgo/autoconsent/pull/1390. This adds support for 'acknowledge' and 'accept' buttons in the heuristic detector.
 - Updates the `consentHeuristicEnabled` pixel parameter to include the state of this option in pixels.
 - Add a new `checkAutoconsentSetting` API function that includes extra user settings in the return from native.


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cookie consent popups are detected and acted on site-wide; incorrect mode mapping could weaken opt-out behavior or skew telemetry, though logic is covered by updated unit tests.
> 
> **Overview**
> Upgrades **`@duckduckgo/autoconsent`** to **16.0.0** and wires cookie prompt management to the library’s **`heuristicMode`** option (replacing the boolean **`enableHeuristicAction`**), so heuristic handling can follow user tier settings and support broader button behavior from the upstream change.
> 
> **Settings API:** **`checkAutoconsentSettingEnabled`** becomes **`checkAutoconsentSetting`**, returning **`enabled`**, **`userPreference`** (`off` / `default` / `max`), and **`featureFlags`**. Embedded builds pass through the native **`isAutoconsentSettingEnabled`** payload; standalone stubs **`default`** with heuristic and cookie-popup preference flags enabled. **`settingsToHeuristicModeName`** maps those inputs to **`tier1`**, **`tier2`**, **`reject`**, **`off`**, or disabled (`''`); init bails when mode is empty.
> 
> **Init config:** Rules no longer bundle **`consentomatic`**; **`enableFilterList`** is dropped. Pixels use **`consentHeuristicEnabled`** as the mode string (via **`getPixelHeuristicParameter`**) instead of **`'1'`/`'0'`**. Unit tests for embedded/standalone messaging and CPM mocks are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f749c5c3dcb6e4d2168bef37f1a661b170dfe4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->