### PR TITLE
Extra CPM breakage flags

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.6.22",
+    "version": "2026.6.24",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.6.16",
+    "version": "2026.6.22",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -39,7 +39,7 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
 /**
  * Base interface for CPM communications with the "browser" side.
  * @typedef {{
- *  logMessage: (message: string) => Promise<void>;
+ *  logMessage: (message: string, isDebug?: boolean) => Promise<void>;
  *  refreshDashboardState: (tabId: number, url: string, dashboardState: Partial<CpmDashboardState>) => Promise<void>;
  *  showCpmAnimation: (tabId: number, topUrl: string, isCosmetic: boolean) => Promise<void>;
  *  notifyPopupHandled: (tabId: number, msg: import('@duckduckgo/autoconsent').DoneMessage) => Promise<void>;

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -358,7 +358,7 @@ export default class CookiePromptManagement {
     }
 
     /**
-     * Record a diagnostic error in the CPM dashboard state (extension side only).
+     * Record a diagnostic error in the CPM dashboard state (no propagation to native side).
      * @param {number | null} tabId
      * @param {string} errorName
      * @returns {Promise<CpmDashboardState | null>}

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -33,7 +33,7 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  */
 
 /**
- * @typedef {'not_started' | 'config_unavailable' | 'settings_missing' | 'setting_disabled' | 'site_disabled' | 'init_received' | 'popup_found'} CpmStage
+ * @typedef {'not_started' | 'config_unavailable' | 'settings_missing' | 'setting_disabled' | 'site_disabled' | 'init_received' | 'popup_found' | 'optout_failed' | 'done'} CpmStage
  */
 
 /**
@@ -660,6 +660,7 @@ export default class CookiePromptManagement {
                             optoutFailed: true,
                             selftestFailed: null,
                             consentRule: msg.cmp,
+                            cpmStage: 'optout_failed',
                         }),
                     );
                 } else {
@@ -678,6 +679,7 @@ export default class CookiePromptManagement {
                         cosmetic: msg.isCosmetic,
                         optoutFailed: false,
                         consentRule: msg.cmp,
+                        cpmStage: 'done',
                     }),
                 );
                 if (msg.cmp === 'HEURISTIC') {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -638,17 +638,18 @@ export default class CookiePromptManagement {
                 break;
             }
             case 'popupFound': {
+                // Check for reload loop first so the dashboard update reflects it
+                this.detectReloadLoop(tabId, msg.cmp);
                 this.cpmMessaging.refreshDashboardState(
                     tabId,
                     tabUrl,
                     await this.updateCpmDashboardState(tabId, {
                         cpmStage: 'popup_found',
                         consentRule: msg.cmp,
+                        consentReloadLoop: this._reloadLoopDetected.has(tabId),
                     }),
                 );
                 this.firePixel('popup-found');
-                // Check for reload loop
-                this.detectReloadLoop(tabId, msg.cmp);
                 break;
             }
             case 'optOutResult': {
@@ -680,6 +681,8 @@ export default class CookiePromptManagement {
                         consentManaged: true,
                         cosmetic: msg.isCosmetic,
                         optoutFailed: false,
+                        // Re-read after rememberLastHandledCMP, which can clear the loop state, so the done state stays authoritative.
+                        consentReloadLoop: this._reloadLoopDetected.has(tabId),
                         consentRule: msg.cmp,
                         cpmStage: 'done',
                     }),

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -26,7 +26,7 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  * @property {string?} consentRule
  * @property {boolean?} consentHeuristicEnabled
  * @property {CpmStage} cpmStage
- * @property {Set<string>} cpmErrors
+ * @property {string[]} cpmErrors
  * @property {number=} cpmQueueSize
  * @property {string} cpmConfigVersion
  */
@@ -169,40 +169,6 @@ export default class CookiePromptManagement {
     }
 
     /**
-     * make sure we deserialize the cpmErrors as a Set
-     * @param {Record<string, any>} jsonDashboardStates
-     * @returns {Record<string, CpmDashboardState>}
-     */
-    _deserializeCpmDashboardStates(jsonDashboardStates) {
-        return Object.fromEntries(
-            Object.entries(jsonDashboardStates || {}).map(([tabId, dashboardState]) => [
-                tabId,
-                {
-                    ...dashboardState,
-                    cpmErrors: new Set(dashboardState.cpmErrors || []),
-                },
-            ]),
-        );
-    }
-
-    /**
-     * make sure we serialize the cpmErrors as an array
-     * @param {Record<string, CpmDashboardState>} dashboardStates
-     * @returns {Record<string, object>}
-     */
-    _serializeCpmDashboardStates(dashboardStates) {
-        return Object.fromEntries(
-            Object.entries(dashboardStates).map(([tabId, dashboardState]) => [
-                tabId,
-                {
-                    ...dashboardState,
-                    cpmErrors: Array.from(dashboardState.cpmErrors),
-                },
-            ]),
-        );
-    }
-
-    /**
      * @param {any} jsonCpmState
      * @returns {CpmState}
      */
@@ -214,7 +180,7 @@ export default class CookiePromptManagement {
                 onlyRules: new Set(jsonCpmState.detectionCache?.onlyRules || []),
             },
             summaryEvents: structuredClone(jsonCpmState.summaryEvents || {}),
-            dashboardStates: this._deserializeCpmDashboardStates(jsonCpmState.dashboardStates || {}),
+            dashboardStates: structuredClone(jsonCpmState.dashboardStates || {}),
             globalErrors: new Set(jsonCpmState.globalErrors || []),
         };
     }
@@ -231,7 +197,7 @@ export default class CookiePromptManagement {
                 onlyRules: Array.from(cpmState.detectionCache.onlyRules),
             },
             summaryEvents: structuredClone(cpmState.summaryEvents),
-            dashboardStates: this._serializeCpmDashboardStates(cpmState.dashboardStates),
+            dashboardStates: structuredClone(cpmState.dashboardStates),
             globalErrors: Array.from(cpmState.globalErrors),
         };
     }
@@ -348,7 +314,7 @@ export default class CookiePromptManagement {
             consentRule: null,
             consentHeuristicEnabled: null,
             cpmStage: 'not_started',
-            cpmErrors: new Set(),
+            cpmErrors: [],
             cpmConfigVersion: '',
         };
     }
@@ -377,8 +343,7 @@ export default class CookiePromptManagement {
                 const key = `${tabId}`;
                 cpmState.dashboardStates[key] ||= this.defaultCpmDashboardState();
                 const dashboardState = cpmState.dashboardStates[key];
-                dashboardState.cpmErrors.add(errorName);
-                dashboardState.cpmErrors = new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors]);
+                dashboardState.cpmErrors = [...new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors, errorName])];
                 updatedDashboardState = structuredClone(dashboardState);
             } else {
                 cpmState.globalErrors.add(errorName);
@@ -402,7 +367,7 @@ export default class CookiePromptManagement {
             const dashboardState = cpmState.dashboardStates[key];
             Object.assign(dashboardState, updates);
             // add global errors so they get pushed to native in the next update
-            dashboardState.cpmErrors = new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors]);
+            dashboardState.cpmErrors = [...new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors])];
             updatedDashboardState = structuredClone(dashboardState);
         });
         return updatedDashboardState;

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -13,6 +13,8 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  *  both: Set<string>,
  * }} detectionCache
  * @property {Record<string, number>} summaryEvents
+ * @property {Record<string, CpmDashboardState>} dashboardStates
+ * @property {Set<string>} globalErrors
  */
 
 /**
@@ -24,6 +26,14 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  * @property {boolean?} consentReloadLoop
  * @property {string?} consentRule
  * @property {boolean?} consentHeuristicEnabled
+ * @property {CpmStage} cpmStage
+ * @property {Set<string>} cpmErrors
+ * @property {number=} cpmQueueSize
+ * @property {string} cpmConfigVersion
+ */
+
+/**
+ * @typedef {'not_started' | 'config_unavailable' | 'settings_missing' | 'setting_disabled' | 'site_disabled' | 'init_received' | 'popup_found'} CpmStage
  */
 
 /**
@@ -33,11 +43,12 @@ import { registerContentScripts, unregisterContentScripts } from './mv3-content-
  *  refreshDashboardState: (tabId: number, url: string, dashboardState: Partial<CpmDashboardState>) => Promise<void>;
  *  showCpmAnimation: (tabId: number, topUrl: string, isCosmetic: boolean) => Promise<void>;
  *  notifyPopupHandled: (tabId: number, msg: import('@duckduckgo/autoconsent').DoneMessage) => Promise<void>;
- *  checkAutoconsentSettingEnabled: () => Promise<boolean>;
- *  checkAutoconsentEnabledForSite: (url: string) => Promise<boolean>;
- *  checkSubfeatureEnabled: (subfeatureName: string) => Promise<boolean>;
+ *  checkAutoconsentSettingEnabled: (tabId?: number) => Promise<boolean>;
+ *  checkAutoconsentEnabledForSite: (url: string, tabId?: number) => Promise<boolean>;
+ *  checkSubfeatureEnabled: (subfeatureName: string, tabId?: number) => Promise<boolean>;
  *  sendPixel: (pixelName: string, type: 'standard' | 'daily', params: Record<string, any>) => Promise<void>;
  *  refreshRemoteConfig: () => Promise<import('@duckduckgo/privacy-configuration/schema/config.ts').CurrentGenericConfig?>;
+ *  setDiagnosticsErrorHandler?: (handler: (tabId: number | null, errorName: string) => void) => void;
  * }} CPMMessagingBase
  */
 
@@ -70,6 +81,9 @@ export default class CookiePromptManagement {
      */
     constructor({ cpmMessaging }) {
         this.cpmMessaging = cpmMessaging;
+        this.cpmMessaging.setDiagnosticsErrorHandler?.((tabId, errorName) => {
+            this.recordCpmDiagnosticError(tabId, errorName);
+        });
         this.scheduleConfigRefresh();
 
         // In the standalone Chrome extension, the CPM content script is not in
@@ -150,6 +164,40 @@ export default class CookiePromptManagement {
     }
 
     /**
+     * make sure we deserialize the cpmErrors as a Set
+     * @param {Record<string, any>} jsonDashboardStates
+     * @returns {Record<string, CpmDashboardState>}
+     */
+    _deserializeCpmDashboardStates(jsonDashboardStates) {
+        return Object.fromEntries(
+            Object.entries(jsonDashboardStates || {}).map(([tabId, dashboardState]) => [
+                tabId,
+                {
+                    ...dashboardState,
+                    cpmErrors: new Set(dashboardState.cpmErrors || []),
+                },
+            ]),
+        );
+    }
+
+    /**
+     * make sure we serialize the cpmErrors as an array
+     * @param {Record<string, CpmDashboardState>} dashboardStates
+     * @returns {Record<string, object>}
+     */
+    _serializeCpmDashboardStates(dashboardStates) {
+        return Object.fromEntries(
+            Object.entries(dashboardStates).map(([tabId, dashboardState]) => [
+                tabId,
+                {
+                    ...dashboardState,
+                    cpmErrors: Array.from(dashboardState.cpmErrors),
+                },
+            ]),
+        );
+    }
+
+    /**
      * @param {any} jsonCpmState
      * @returns {CpmState}
      */
@@ -161,6 +209,8 @@ export default class CookiePromptManagement {
                 onlyRules: new Set(jsonCpmState.detectionCache?.onlyRules || []),
             },
             summaryEvents: structuredClone(jsonCpmState.summaryEvents || {}),
+            dashboardStates: this._deserializeCpmDashboardStates(jsonCpmState.dashboardStates || {}),
+            globalErrors: new Set(jsonCpmState.globalErrors || []),
         };
     }
 
@@ -176,6 +226,8 @@ export default class CookiePromptManagement {
                 onlyRules: Array.from(cpmState.detectionCache.onlyRules),
             },
             summaryEvents: structuredClone(cpmState.summaryEvents),
+            dashboardStates: this._serializeCpmDashboardStates(cpmState.dashboardStates),
+            globalErrors: Array.from(cpmState.globalErrors),
         };
     }
 
@@ -191,13 +243,18 @@ export default class CookiePromptManagement {
                     onlyRules: [],
                 },
                 summaryEvents: {},
+                dashboardStates: {},
+                globalErrors: [],
             };
         }
         return this._deserializeCpmState(this._jsonCpmState);
     }
 
-    checkHeuristicActionEnabled() {
-        return this.cpmMessaging.checkSubfeatureEnabled('heuristicAction');
+    /**
+     * @param {number=} tabId
+     */
+    checkHeuristicActionEnabled(tabId) {
+        return this.cpmMessaging.checkSubfeatureEnabled('heuristicAction', tabId);
     }
 
     /**
@@ -266,9 +323,84 @@ export default class CookiePromptManagement {
         if (oldTopUrl.host !== newTopUrl.host || oldTopUrl.pathname !== newTopUrl.pathname || oldTopUrl.protocol !== newTopUrl.protocol) {
             // url has changed (as far as reload loop prevention is concerned)
             this.clearReloadLoopState(tabId);
+            // no await; state mutations are serialized and the next dashboard update will queue after this reset
+            this.resetCpmDashboardState(tabId);
         }
         this._tabUrlsCache.set(tabId, newTopUrl);
         return newTopUrl;
+    }
+
+    /**
+     * @returns {CpmDashboardState}
+     */
+    defaultCpmDashboardState() {
+        return {
+            consentManaged: false,
+            cosmetic: null,
+            optoutFailed: null,
+            selftestFailed: null,
+            consentReloadLoop: false,
+            consentRule: null,
+            consentHeuristicEnabled: null,
+            cpmStage: 'not_started',
+            cpmErrors: new Set(),
+            cpmConfigVersion: '',
+        };
+    }
+
+    /**
+     * @param {number} tabId
+     */
+    resetCpmDashboardState(tabId) {
+        this.modifyCpmState((cpmState) => {
+            cpmState.dashboardStates[`${tabId}`] = this.defaultCpmDashboardState();
+        });
+    }
+
+    /**
+     * Record a diagnostic error in the CPM dashboard state (extension side only).
+     * @param {number | null} tabId
+     * @param {string} errorName
+     * @returns {Promise<CpmDashboardState | null>}
+     */
+    async recordCpmDiagnosticError(tabId, errorName) {
+        /** @type {CpmDashboardState | null} */
+        let updatedDashboardState = null;
+        // just modify the state. We don't trigger the dashboard update to avoid recursive calls.
+        await this.modifyCpmState((cpmState) => {
+            if (typeof tabId === 'number') {
+                const key = `${tabId}`;
+                cpmState.dashboardStates[key] ||= this.defaultCpmDashboardState();
+                const dashboardState = cpmState.dashboardStates[key];
+                dashboardState.cpmErrors.add(errorName);
+                dashboardState.cpmErrors = new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors]);
+                updatedDashboardState = structuredClone(dashboardState);
+            } else {
+                cpmState.globalErrors.add(errorName);
+            }
+        });
+        return updatedDashboardState;
+    }
+
+    /**
+     * Atomically read-modify-write the CPM dashboard state  (extension side only).
+     * @param {number} tabId
+     * @param {Partial<Omit<CpmDashboardState, 'cpmErrors'>>} updates - cpmErrors should be updated with recordCpmDiagnosticError
+     * @returns {Promise<CpmDashboardState>}
+     */
+    async updateCpmDashboardState(tabId, updates) {
+        /** @type {CpmDashboardState} */
+        let updatedDashboardState = this.defaultCpmDashboardState();
+        await this.modifyCpmState((cpmState) => {
+            const key = `${tabId}`;
+            cpmState.dashboardStates[key] ||= this.defaultCpmDashboardState();
+            const dashboardState = cpmState.dashboardStates[key];
+            Object.assign(dashboardState, updates);
+            // add global errors so they get pushed to native in the next update
+            dashboardState.cpmErrors = new Set([...cpmState.globalErrors, ...dashboardState.cpmErrors]);
+            updatedDashboardState = structuredClone(dashboardState);
+        });
+        return updatedDashboardState;
     }
 
     /**
@@ -310,7 +442,8 @@ export default class CookiePromptManagement {
     }
 
     /**
-     *
+     * Called on EVERY message from the content script.
+     * Make sure not to trigger anything heavy (e.g. native messaging) without a message type filter!
      * @param {import('@duckduckgo/autoconsent').ContentScriptMessage} msg
      * @param {browser.Runtime.MessageSender} sender
      * @returns
@@ -330,14 +463,29 @@ export default class CookiePromptManagement {
         // @ts-expect-error - origin is not available in the type
         const frameUrl = sender.url || sender.origin || 'about:blank';
         const tabUrl = sender.tab.url || sender.tab.pendingUrl || 'about:blank';
+        if (msg.type === 'init' && isMainFrame) {
+            // update the cached top url for this tab
+            this.updateTopUrl(tabId, tabUrl);
+        }
 
         // use the cached config
         const remoteConfig = await this.remoteConfigJson;
         if (!remoteConfig) {
             this.cpmMessaging.logMessage('Remote config not ready, scheduling retry');
             this.scheduleConfigRefresh();
+            if (isMainFrame) {
+                this.cpmMessaging.refreshDashboardState(
+                    tabId,
+                    tabUrl,
+                    await this.updateCpmDashboardState(tabId, {
+                        cpmStage: 'config_unavailable',
+                        cpmConfigVersion: 'unknown',
+                    }),
+                );
+            }
             return;
         }
+        const cpmConfigVersion = `${remoteConfig.version || 'unknown'}`;
         const autoconsentRemoteConfig = remoteConfig.features?.autoconsent;
         const autoconsentSettings = autoconsentRemoteConfig?.settings;
         DEBUG &&
@@ -353,29 +501,56 @@ export default class CookiePromptManagement {
 
         if (!autoconsentSettings) {
             this.cpmMessaging.logMessage(`autoconsentSettings not ready: ${autoconsentSettings}`);
+            if (isMainFrame) {
+                this.cpmMessaging.refreshDashboardState(
+                    tabId,
+                    tabUrl,
+                    await this.updateCpmDashboardState(tabId, {
+                        cpmStage: 'settings_missing',
+                        cpmConfigVersion,
+                    }),
+                );
+            }
             return;
         }
-        const autoconsentFeatureEnabled = await this.cpmMessaging.checkAutoconsentSettingEnabled();
+        // FIXME: Cache this or do not request on EVERY message!
+        const autoconsentFeatureEnabled = await this.cpmMessaging.checkAutoconsentSettingEnabled(tabId);
         if (!autoconsentFeatureEnabled) {
             this.cpmMessaging.logMessage('autoconsent setting not enabled');
+            if (isMainFrame) {
+                this.cpmMessaging.refreshDashboardState(
+                    tabId,
+                    tabUrl,
+                    await this.updateCpmDashboardState(tabId, {
+                        cpmStage: 'setting_disabled',
+                        cpmConfigVersion,
+                    }),
+                );
+            }
             return;
         }
-        const heuristicActionEnabled = await this.checkHeuristicActionEnabled();
+        // FIXME: Cache this or do not request on EVERY message!
+        const heuristicActionEnabled = await this.checkHeuristicActionEnabled(tabId);
 
         switch (msg.type) {
             case 'init': {
-                // do the navigation check before checking if the domain is allowlisted
                 if (isMainFrame) {
-                    // update the cached top url for this tab
-                    this.updateTopUrl(tabId, tabUrl);
                     // schedule config refresh (will be used next time)
                     this.scheduleConfigRefresh();
                 }
 
-                const isEnabled = await this.cpmMessaging.checkAutoconsentEnabledForSite(tabUrl);
+                const isEnabled = await this.cpmMessaging.checkAutoconsentEnabledForSite(tabUrl, tabId);
                 if (!isEnabled) {
                     this.cpmMessaging.logMessage(`autoconsent disabled for site: ${tabUrl}`);
                     if (isMainFrame) {
+                        this.cpmMessaging.refreshDashboardState(
+                            tabId,
+                            tabUrl,
+                            await this.updateCpmDashboardState(tabId, {
+                                cpmStage: 'site_disabled',
+                                cpmConfigVersion,
+                            }),
+                        );
                         this.firePixel('disabled-for-site');
                     }
                     return;
@@ -393,15 +568,13 @@ export default class CookiePromptManagement {
 
                 if (isMainFrame) {
                     // no await
-                    this.cpmMessaging.refreshDashboardState(tabId, tabUrl, {
-                        consentManaged: false,
-                        cosmetic: null,
-                        optoutFailed: null,
-                        selftestFailed: null,
+                    this.updateCpmDashboardState(tabId, {
                         consentReloadLoop: this._reloadLoopDetected.has(tabId),
                         consentRule: this._lastHandledCMP.get(tabId) || null,
                         consentHeuristicEnabled: heuristicActionEnabled,
-                    });
+                        cpmStage: 'init_received',
+                        cpmConfigVersion,
+                    }).then((dashboardState) => this.cpmMessaging.refreshDashboardState(tabId, tabUrl, dashboardState));
                     // no await
                     this.firePixel('init');
                 }
@@ -464,6 +637,14 @@ export default class CookiePromptManagement {
                 break;
             }
             case 'popupFound': {
+                this.cpmMessaging.refreshDashboardState(
+                    tabId,
+                    tabUrl,
+                    await this.updateCpmDashboardState(tabId, {
+                        cpmStage: 'popup_found',
+                        consentRule: msg.cmp,
+                    }),
+                );
                 this.firePixel('popup-found');
                 // Check for reload loop
                 this.detectReloadLoop(tabId, msg.cmp);
@@ -472,15 +653,16 @@ export default class CookiePromptManagement {
             case 'optOutResult': {
                 if (!msg.result) {
                     this.firePixel('error_optout');
-                    this.cpmMessaging.refreshDashboardState(tabId, tabUrl, {
-                        consentManaged: true,
-                        cosmetic: null,
-                        optoutFailed: true,
-                        selftestFailed: null,
-                        consentReloadLoop: this._reloadLoopDetected.has(tabId),
-                        consentRule: msg.cmp,
-                        consentHeuristicEnabled: heuristicActionEnabled,
-                    });
+                    this.cpmMessaging.refreshDashboardState(
+                        tabId,
+                        tabUrl,
+                        await this.updateCpmDashboardState(tabId, {
+                            consentManaged: true,
+                            optoutFailed: true,
+                            selftestFailed: null,
+                            consentRule: msg.cmp,
+                        }),
+                    );
                 } else {
                     // TODO: implement self-tests
                 }
@@ -489,15 +671,16 @@ export default class CookiePromptManagement {
             case 'autoconsentDone': {
                 // Remember the last handled CMP for reload loop detection
                 this.rememberLastHandledCMP(tabId, msg.cmp, msg.isCosmetic);
-                this.cpmMessaging.refreshDashboardState(tabId, tabUrl, {
-                    consentManaged: true,
-                    cosmetic: msg.isCosmetic,
-                    optoutFailed: false,
-                    selftestFailed: null,
-                    consentReloadLoop: this._reloadLoopDetected.has(tabId),
-                    consentRule: msg.cmp,
-                    consentHeuristicEnabled: heuristicActionEnabled,
-                });
+                this.cpmMessaging.refreshDashboardState(
+                    tabId,
+                    tabUrl,
+                    await this.updateCpmDashboardState(tabId, {
+                        consentManaged: true,
+                        cosmetic: msg.isCosmetic,
+                        optoutFailed: false,
+                        consentRule: msg.cmp,
+                    }),
+                );
                 if (msg.cmp === 'HEURISTIC') {
                     this.firePixel('done_heuristic');
                 } else {
@@ -559,6 +742,10 @@ export default class CookiePromptManagement {
             }
             case 'autoconsentError': {
                 if (msg.details?.msg?.includes('Found multiple CMPs')) {
+                    const dashboardState = await this.recordCpmDiagnosticError(tabId, 'multiple_cmps');
+                    if (dashboardState) {
+                        this.cpmMessaging.refreshDashboardState(tabId, tabUrl, dashboardState);
+                    }
                     this.firePixel('error_multiple-popups');
                 }
                 break;

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -323,8 +323,6 @@ export default class CookiePromptManagement {
         if (oldTopUrl.host !== newTopUrl.host || oldTopUrl.pathname !== newTopUrl.pathname || oldTopUrl.protocol !== newTopUrl.protocol) {
             // url has changed (as far as reload loop prevention is concerned)
             this.clearReloadLoopState(tabId);
-            // no await; state mutations are serialized and the next dashboard update will queue after this reset
-            this.resetCpmDashboardState(tabId);
         }
         this._tabUrlsCache.set(tabId, newTopUrl);
         return newTopUrl;
@@ -466,6 +464,10 @@ export default class CookiePromptManagement {
         if (msg.type === 'init' && isMainFrame) {
             // update the cached top url for this tab
             this.updateTopUrl(tabId, tabUrl);
+
+            // reset the dashboard state on each main frame init
+            // no await; state mutations are serialized and the next dashboard update will queue after this reset
+            this.resetCpmDashboardState(tabId);
         }
 
         // use the cached config

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -319,7 +319,7 @@ export default class CookiePromptManagement {
             return oldTopUrl;
         }
 
-        DEBUG && this.cpmMessaging.logMessage(`${tabId} Main frame navigated from ${oldTopUrl} to ${newTopUrl}`);
+        this.cpmMessaging.logMessage(`${tabId} Main frame navigated from ${oldTopUrl} to ${newTopUrl}`);
         if (oldTopUrl.host !== newTopUrl.host || oldTopUrl.pathname !== newTopUrl.pathname || oldTopUrl.protocol !== newTopUrl.protocol) {
             // url has changed (as far as reload loop prevention is concerned)
             this.clearReloadLoopState(tabId);
@@ -513,30 +513,23 @@ export default class CookiePromptManagement {
             }
             return;
         }
-        // FIXME: Cache this or do not request on EVERY message!
-        const autoconsentFeatureEnabled = await this.cpmMessaging.checkAutoconsentSettingEnabled(tabId);
-        if (!autoconsentFeatureEnabled) {
-            this.cpmMessaging.logMessage('autoconsent setting not enabled');
-            if (isMainFrame) {
-                this.cpmMessaging.refreshDashboardState(
-                    tabId,
-                    tabUrl,
-                    await this.updateCpmDashboardState(tabId, {
-                        cpmStage: 'setting_disabled',
-                        cpmConfigVersion,
-                    }),
-                );
-            }
-            return;
-        }
-        // FIXME: Cache this or do not request on EVERY message!
-        const heuristicActionEnabled = await this.checkHeuristicActionEnabled(tabId);
 
         switch (msg.type) {
             case 'init': {
-                if (isMainFrame) {
-                    // schedule config refresh (will be used next time)
-                    this.scheduleConfigRefresh();
+                const autoconsentFeatureEnabled = await this.cpmMessaging.checkAutoconsentSettingEnabled(tabId);
+                if (!autoconsentFeatureEnabled) {
+                    this.cpmMessaging.logMessage('autoconsent setting not enabled');
+                    if (isMainFrame) {
+                        this.cpmMessaging.refreshDashboardState(
+                            tabId,
+                            tabUrl,
+                            await this.updateCpmDashboardState(tabId, {
+                                cpmStage: 'setting_disabled',
+                                cpmConfigVersion,
+                            }),
+                        );
+                    }
+                    return;
                 }
 
                 const isEnabled = await this.cpmMessaging.checkAutoconsentEnabledForSite(tabUrl, tabId);
@@ -556,6 +549,12 @@ export default class CookiePromptManagement {
                     return;
                 }
 
+                if (isMainFrame) {
+                    // schedule config refresh (will be used next time)
+                    this.scheduleConfigRefresh();
+                }
+
+                const heuristicActionEnabled = await this.checkHeuristicActionEnabled(tabId);
                 const visualTest = DEBUG;
 
                 /** @type {import('@duckduckgo/autoconsent').Config['autoAction']} */

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -124,9 +124,11 @@ export class CPMEmbeddedMessaging {
 
     async logMessage(message) {
         console.log(message);
-        await this._notify('extensionLog', {
-            message,
-        });
+        if (DEBUG) {
+            await this._notify('extensionLog', {
+                message,
+            });
+        }
     }
 
     /**

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -4,6 +4,7 @@ import { getFromSessionStorage, setToSessionStorage } from '../wrapper';
 
 /**
  * @typedef {import('./cookie-prompt-management').CPMMessagingBase} CPMMessagingBase
+ * @typedef {import('./cookie-prompt-management').CpmDashboardState} CpmDashboardState
  * @typedef {import('./native-messaging').NativeMessagingInterface} NativeMessagingInterface
  * @typedef {{ time: number, value: any }} CacheEntry
  */
@@ -27,9 +28,30 @@ export class CPMEmbeddedMessaging {
         this._cache = new Map();
         /** @type {Promise<void>} */
         this._queue = Promise.resolve();
+        this._queueSize = 0;
+        /** @type {((tabId: number | null, errorName: string) => void) | null} */
+        this._diagnosticsErrorHandler = null; // callback to record diagnostics errors in CPM state
         // in-memory cached config, will be lost on extension sleep, in which case we fetch from session storage
         /** @type {import('@duckduckgo/privacy-configuration/schema/config.ts').CurrentGenericConfig | null} */
         this._cachedConfig = null;
+    }
+
+    /**
+     * @param {(tabId: number | null, errorName: string) => void} handler
+     */
+    setDiagnosticsErrorHandler(handler) {
+        this._diagnosticsErrorHandler = handler;
+    }
+
+    /**
+     * @param {number | null} tabId
+     * @param {string} method
+     */
+    _recordDiagnosticsError(tabId, method) {
+        // generate a diagnostic error name for a native message, e.g. 'tab_getResourceIfNew'
+        const scope = typeof tabId === 'number' ? 'tab' : 'glob';
+        const errorName = `${scope}_${method}`;
+        this._diagnosticsErrorHandler?.(tabId, errorName);
     }
 
     /**
@@ -38,12 +60,18 @@ export class CPMEmbeddedMessaging {
      * @param {Record<string, any>} params
      */
     async _notify(method, params) {
+        const diagnosticsTabId = typeof params.tabId === 'number' ? params.tabId : null;
+        this._queueSize += 1;
         const result = this._queue
             .then(() => {
                 return this.nativeMessaging.notify(method, params);
             })
             .catch((e) => {
                 console.error('error in notification queue', e);
+                this._recordDiagnosticsError(diagnosticsTabId, method);
+            })
+            .finally(() => {
+                this._queueSize -= 1;
             });
         this._queue = result;
         await result;
@@ -58,9 +86,11 @@ export class CPMEmbeddedMessaging {
      * @param {Record<string, any>} params
      * @param {string} [cacheKey]
      * @param {number} [ttl]
+     * @param {number=} diagnosticsTabId
      * @returns {Promise<any>}
      */
-    _request(method, params, cacheKey, ttl) {
+    _request(method, params, cacheKey, ttl, diagnosticsTabId) {
+        this._queueSize += 1;
         const job = this._queue
             .then(async () => {
                 if (cacheKey && ttl) {
@@ -83,6 +113,10 @@ export class CPMEmbeddedMessaging {
             })
             .catch((e) => {
                 console.error(`error in request queue for ${method}`, e);
+                this._recordDiagnosticsError(diagnosticsTabId ?? null, method);
+            })
+            .finally(() => {
+                this._queueSize -= 1;
             });
         this._queue = job;
         return job;
@@ -95,11 +129,26 @@ export class CPMEmbeddedMessaging {
         });
     }
 
+    /**
+     * @param {Partial<CpmDashboardState>} dashboardState
+     */
     async refreshDashboardState(tabId, url, dashboardState) {
+        const { cpmErrors, ...rest } = dashboardState;
         await this._notify('refreshCpmDashboardState', {
             tabId,
             url,
-            consentStatus: dashboardState,
+            consentStatus: {
+                ...rest,
+                // convert cpmErrors from Set to a comma-separated string
+                ...(cpmErrors
+                    ? {
+                          // limit the length to avoid overflows in breakage pixel
+                          cpmErrors: Array.from(cpmErrors).join(',').substring(0, 255),
+                      }
+                    : {}),
+                // add the current queue size
+                cpmQueueSize: this._queueSize,
+            },
         });
     }
 
@@ -118,22 +167,23 @@ export class CPMEmbeddedMessaging {
         });
     }
 
-    async checkAutoconsentSettingEnabled() {
-        const result = await this._request('isAutoconsentSettingEnabled', {}, 'userSetting', SETTING_CHECK_TTL);
+    async checkAutoconsentSettingEnabled(tabId) {
+        const result = await this._request('isAutoconsentSettingEnabled', {}, 'userSetting', SETTING_CHECK_TTL, tabId);
         return result?.enabled ?? false;
     }
 
-    async checkAutoconsentEnabledForSite(url) {
-        const result = await this._request('isFeatureEnabled', { featureName: 'autoconsent', url }, `site:${url}`, SITE_CHECK_TTL);
+    async checkAutoconsentEnabledForSite(url, tabId) {
+        const result = await this._request('isFeatureEnabled', { featureName: 'autoconsent', url }, `site:${url}`, SITE_CHECK_TTL, tabId);
         return result?.enabled ?? false;
     }
 
-    async checkSubfeatureEnabled(subfeatureName) {
+    async checkSubfeatureEnabled(subfeatureName, tabId) {
         const result = await this._request(
             'isSubFeatureEnabled',
             { featureName: 'autoconsent', subfeatureName },
             `subfeature:${subfeatureName}`,
             SUBFEATURE_CHECK_TTL,
+            tabId,
         );
         return result?.enabled ?? false;
     }
@@ -167,6 +217,7 @@ export class CPMEmbeddedMessaging {
             }
             return cachedConfig;
         } catch (e) {
+            this._recordDiagnosticsError(null, 'getResourceIfNew');
             this.logMessage(`error refreshing remote config: ${e}`);
             if (cachedConfigVersion !== 'unknown') {
                 return cachedConfig;

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -141,11 +141,11 @@ export class CPMEmbeddedMessaging {
             url,
             consentStatus: {
                 ...rest,
-                // convert cpmErrors from Set to a comma-separated string
+                // convert cpmErrors from an array to a comma-separated string
                 ...(cpmErrors
                     ? {
                           // limit the length to avoid overflows in breakage pixel
-                          cpmErrors: Array.from(cpmErrors).join(',').substring(0, 255),
+                          cpmErrors: cpmErrors.join(',').substring(0, 255),
                       }
                     : {}),
                 // add the current queue size

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -122,9 +122,9 @@ export class CPMEmbeddedMessaging {
         return job;
     }
 
-    async logMessage(message) {
+    async logMessage(message, isDebug = DEBUG) {
         console.log(message);
-        if (DEBUG) {
+        if (isDebug) {
             await this._notify('extensionLog', {
                 message,
             });

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -389,6 +389,188 @@ describe('CookiePromptManagement', () => {
             );
         });
 
+        // A reload loop is detected on `popupFound` (after the main-frame `init` has already
+        // pushed a dashboard update). The `done`/`optout_failed` updates that follow must
+        // re-read `_reloadLoopDetected`, otherwise the native dashboard keeps showing
+        // `consentReloadLoop: false` even though a loop was detected on the same load.
+        it('reports consentReloadLoop in the done state when a reload loop is detected', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+
+            // First visit primes the last-handled CMP used for reload-loop detection.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'test-cmp', isCosmetic: false },
+            });
+
+            // Same-URL reload with the same CMP: popupFound flags the reload loop.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'popupFound', cmp: 'test-cmp' },
+            });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'test-cmp', isCosmetic: false },
+            });
+
+            expect(cpm._reloadLoopDetected.has(1)).toBe(true);
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    cpmStage: 'done',
+                    consentReloadLoop: true,
+                    consentRule: 'test-cmp',
+                }),
+            );
+        });
+
+        it('reports consentReloadLoop in the optout_failed state when a reload loop is detected', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+
+            // First visit primes the last-handled CMP used for reload-loop detection.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'test-cmp', isCosmetic: false },
+            });
+
+            // Same-URL reload with the same CMP: popupFound flags the reload loop.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'popupFound', cmp: 'test-cmp' },
+            });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'optOutResult', result: false, cmp: 'test-cmp' },
+            });
+
+            expect(cpm._reloadLoopDetected.has(1)).toBe(true);
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    optoutFailed: true,
+                    cpmStage: 'optout_failed',
+                    consentReloadLoop: true,
+                    consentRule: 'test-cmp',
+                }),
+            );
+        });
+
+        // The done state must be authoritative: `rememberLastHandledCMP` runs before the done
+        // dashboard update and can clear the reload-loop state (e.g. when a different CMP is
+        // handled). The `true` that popupFound persisted must not leak through.
+        it('clears consentReloadLoop in the done state when a different CMP is handled after a detected loop', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+
+            // First visit primes the last-handled CMP.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'cmp-a', isCosmetic: false },
+            });
+
+            // Same-URL reload: popupFound for the same CMP flags the reload loop...
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'popupFound', cmp: 'cmp-a' },
+            });
+            expect(cpm._reloadLoopDetected.has(1)).toBe(true);
+
+            // ...but a different CMP is then handled, which resets the loop state.
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'cmp-b', isCosmetic: false },
+            });
+
+            expect(cpm._reloadLoopDetected.has(1)).toBe(false);
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    cpmStage: 'done',
+                    consentReloadLoop: false,
+                    consentRule: 'cmp-b',
+                }),
+            );
+        });
+
+        // The primary purpose of reload-loop detection: once a loop is detected, the next
+        // init must tell the content script to stop auto-acting (autoAction: null) to break it.
+        it('disables autoAction on the next init after a reload loop is detected', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const sendMessageSpy = spyOn(chrome.tabs, 'sendMessage');
+            const handler = messageHandlers.autoconsent;
+
+            const lastInitRespAutoAction = () => {
+                const initResps = sendMessageSpy.calls.allArgs().filter(([, message]) => message?.type === 'initResp');
+                return initResps.length ? initResps[initResps.length - 1][1].config.autoAction : undefined;
+            };
+
+            // First visit: opt-out is active, then the CMP is handled (primes last-handled CMP).
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            expect(lastInitRespAutoAction()).toBe('optOut');
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'test-cmp', isCosmetic: false },
+            });
+
+            // Same-URL reload with the same CMP: the loop is detected on popupFound.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'popupFound', cmp: 'test-cmp' },
+            });
+            expect(cpm._reloadLoopDetected.has(1)).toBe(true);
+
+            // The following init must disable autoAction to break the loop.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            expect(lastInitRespAutoAction()).toBe(null);
+        });
+
+        // When init itself detects the loop (and disables autoAction), its own dashboard update
+        // must report the loop -- there is no popupFound/autoconsentDone to fall back on once
+        // autoAction is disabled.
+        it('reports consentReloadLoop in the init state after a loop was detected on a previous load', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+
+            // First visit primes the last-handled CMP.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'autoconsentDone', cmp: 'test-cmp', isCosmetic: false },
+            });
+
+            // Same-URL reload with the same CMP: the loop is detected on popupFound.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: { type: 'popupFound', cmp: 'test-cmp' },
+            });
+            expect(cpm._reloadLoopDetected.has(1)).toBe(true);
+
+            // The next init reports the loop in its own (init_received) dashboard update.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            // Flush the queued reset + init dashboard update and the `.then(refreshDashboardState)` callback.
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    cpmStage: 'init_received',
+                    consentReloadLoop: true,
+                    consentRule: 'test-cmp',
+                }),
+            );
+        });
+
         it('resets stale outcome fields on a same-URL reload (main-frame init)', async () => {
             const mockMessaging = createMockMessaging();
             const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -388,6 +388,53 @@ describe('CookiePromptManagement', () => {
                 }),
             );
         });
+
+        it('resets stale outcome fields on a same-URL reload (main-frame init)', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+
+            // First visit: init then autoconsentDone, so the popup is reported as managed.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'autoconsentDone',
+                    cmp: 'test-cmp',
+                    isCosmetic: false,
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    cosmetic: false,
+                    optoutFailed: false,
+                    cpmStage: 'done',
+                }),
+            );
+
+            // Same-URL reload: a new main-frame init must reset the per-tab outcome fields,
+            // otherwise the native dashboard would show consent as already managed before CPM re-runs.
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+
+            // Wait for the queued reset + init dashboard update and the `.then(refreshDashboardState)` callback.
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    cosmetic: null,
+                    optoutFailed: null,
+                    selftestFailed: null,
+                    cpmStage: 'init_received',
+                    // consentRule is intentionally retained across same-URL reloads for reload-loop detection.
+                    consentRule: 'test-cmp',
+                }),
+            );
+        });
     });
 
     describe('disabled-for-site pixel', () => {

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -98,7 +98,7 @@ describe('CookiePromptManagement', () => {
                     consentRule: null,
                     consentHeuristicEnabled: null,
                     cpmStage: 'config_unavailable',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: 'unknown',
                 }),
             );
@@ -130,7 +130,7 @@ describe('CookiePromptManagement', () => {
                     consentManaged: false,
                     consentHeuristicEnabled: null,
                     cpmStage: 'settings_missing',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: '7',
                 }),
             );
@@ -149,7 +149,7 @@ describe('CookiePromptManagement', () => {
                     consentManaged: false,
                     consentHeuristicEnabled: true,
                     cpmStage: 'setting_disabled',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -168,7 +168,7 @@ describe('CookiePromptManagement', () => {
                     consentManaged: false,
                     consentHeuristicEnabled: true,
                     cpmStage: 'site_disabled',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -191,7 +191,7 @@ describe('CookiePromptManagement', () => {
                     consentManaged: false,
                     consentHeuristicEnabled: true,
                     cpmStage: 'init_received',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -215,7 +215,7 @@ describe('CookiePromptManagement', () => {
                 jasmine.objectContaining({
                     consentManaged: false,
                     cpmStage: 'popup_found',
-                    cpmErrors: new Set(),
+                    cpmErrors: [],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -241,7 +241,7 @@ describe('CookiePromptManagement', () => {
                 jasmine.objectContaining({
                     consentManaged: false,
                     cpmStage: 'init_received',
-                    cpmErrors: new Set(['multiple_cmps']),
+                    cpmErrors: ['multiple_cmps'],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -265,7 +265,7 @@ describe('CookiePromptManagement', () => {
             expect(latestDashboardState(mockMessaging)).toEqual(
                 jasmine.objectContaining({
                     cpmStage: 'popup_found',
-                    cpmErrors: new Set(['tab_isFeatureEnabled']),
+                    cpmErrors: ['tab_isFeatureEnabled'],
                     cpmConfigVersion: '1',
                 }),
             );
@@ -293,12 +293,12 @@ describe('CookiePromptManagement', () => {
 
             expect(latestDashboardState(mockMessaging)).toEqual(
                 jasmine.objectContaining({
-                    cpmErrors: new Set(['tab_isFeatureEnabled', 'multiple_cmps']),
+                    cpmErrors: ['tab_isFeatureEnabled', 'multiple_cmps'],
                 }),
             );
         });
 
-        it('restores persisted dashboard errors as Sets', async () => {
+        it('restores persisted dashboard errors as arrays', async () => {
             const mockMessaging = createMockMessaging();
             const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
             await cpm.remoteConfigJson;
@@ -317,7 +317,7 @@ describe('CookiePromptManagement', () => {
             const restoredCpm = new CookiePromptManagement({ cpmMessaging: createMockMessaging() });
             const restoredState = await restoredCpm.getCpmState();
 
-            expect(restoredState.dashboardStates['1'].cpmErrors).toEqual(new Set(['glob_getResourceIfNew', 'tab_isFeatureEnabled']));
+            expect(restoredState.dashboardStates['1'].cpmErrors).toEqual(['glob_getResourceIfNew', 'tab_isFeatureEnabled']);
             expect(restoredState.globalErrors).toEqual(new Set(['glob_getResourceIfNew']));
         });
 
@@ -337,7 +337,7 @@ describe('CookiePromptManagement', () => {
             expect(latestDashboardState(mockMessaging)).toEqual(
                 jasmine.objectContaining({
                     cpmStage: 'init_received',
-                    cpmErrors: new Set(['glob_getResourceIfNew']),
+                    cpmErrors: ['glob_getResourceIfNew'],
                     cpmConfigVersion: '1',
                 }),
             );

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -6,7 +6,7 @@ import { sessionStorageFallback } from '../../shared/js/background/wrapper';
  * Create a mock CPMMessagingBase with spies.
  */
 function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSettingEnabled = true, subfeatureEnabled = false } = {}) {
-    return {
+    const mockMessaging = {
         logMessage: jasmine.createSpy('logMessage').and.returnValue(Promise.resolve()),
         refreshDashboardState: jasmine.createSpy('refreshDashboardState').and.returnValue(Promise.resolve()),
         showCpmAnimation: jasmine.createSpy('showCpmAnimation').and.returnValue(Promise.resolve()),
@@ -19,6 +19,10 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
             .and.returnValue(Promise.resolve(autoconsentEnabledForSite)),
         checkSubfeatureEnabled: jasmine.createSpy('checkSubfeatureEnabled').and.returnValue(Promise.resolve(subfeatureEnabled)),
         sendPixel: jasmine.createSpy('sendPixel').and.returnValue(Promise.resolve()),
+        setDiagnosticsErrorHandler: jasmine.createSpy('setDiagnosticsErrorHandler').and.callFake((handler) => {
+            mockMessaging.diagnosticsErrorHandler = handler;
+        }),
+        diagnosticsErrorHandler: null,
         refreshRemoteConfig: jasmine.createSpy('refreshRemoteConfig').and.returnValue(
             Promise.resolve({
                 version: 1,
@@ -34,6 +38,11 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
             }),
         ),
     };
+    return mockMessaging;
+}
+
+function latestDashboardState(mockMessaging) {
+    return mockMessaging.refreshDashboardState.calls.mostRecent().args[2];
 }
 
 function makeSender({ tabId = 1, frameId = 0, tabUrl = 'https://example.com/page', frameUrl = undefined } = {}) {
@@ -58,6 +67,327 @@ describe('CookiePromptManagement', () => {
     beforeEach(() => {
         Object.keys(messageHandlers).forEach((k) => delete messageHandlers[k]);
         sessionStorageFallback.clear();
+    });
+
+    describe('CPM diagnostics', () => {
+        it('reports config_unavailable when remote config is unavailable', async () => {
+            const mockMessaging = createMockMessaging();
+            mockMessaging.refreshRemoteConfig.and.returnValue(Promise.resolve(null));
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    cosmetic: null,
+                    optoutFailed: null,
+                    selftestFailed: null,
+                    consentReloadLoop: false,
+                    consentRule: null,
+                    consentHeuristicEnabled: null,
+                    cpmStage: 'config_unavailable',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: 'unknown',
+                }),
+            );
+        });
+
+        it('reports settings_missing when autoconsent settings are absent', async () => {
+            const mockMessaging = createMockMessaging();
+            mockMessaging.refreshRemoteConfig.and.returnValue(
+                Promise.resolve({
+                    version: 7,
+                    features: {
+                        autoconsent: {
+                            state: 'enabled',
+                            exceptions: [],
+                        },
+                    },
+                }),
+            );
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    consentHeuristicEnabled: null,
+                    cpmStage: 'settings_missing',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: '7',
+                }),
+            );
+        });
+
+        it('reports setting_disabled when the user setting disables autoconsent', async () => {
+            const mockMessaging = createMockMessaging({ autoconsentSettingEnabled: false });
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    consentHeuristicEnabled: null,
+                    cpmStage: 'setting_disabled',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports site_disabled when autoconsent is disabled for the site', async () => {
+            const mockMessaging = createMockMessaging({ autoconsentEnabledForSite: false });
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    consentHeuristicEnabled: null,
+                    cpmStage: 'site_disabled',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports init_received on accepted top-frame init', async () => {
+            const mockMessaging = createMockMessaging({ subfeatureEnabled: true });
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+
+            // Wait for the queued CPM state mutation and the `.then(refreshDashboardState)` callback.
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    consentHeuristicEnabled: true,
+                    cpmStage: 'init_received',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports popup_found when a popup is found', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'popupFound',
+                    cmp: 'test-cmp',
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    cpmStage: 'popup_found',
+                    cpmErrors: new Set(),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports multiple_cmps when multiple CMPs are detected', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'autoconsentError',
+                    details: {
+                        msg: 'Found multiple CMPs',
+                    },
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: false,
+                    cpmStage: 'init_received',
+                    cpmErrors: new Set(['multiple_cmps']),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('includes native message errors from the diagnostics error handler', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            mockMessaging.diagnosticsErrorHandler(1, 'tab_isFeatureEnabled');
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'popupFound',
+                    cmp: 'test-cmp',
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    cpmStage: 'popup_found',
+                    cpmErrors: new Set(['tab_isFeatureEnabled']),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('deduplicates cpmErrors in dashboard state', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+            mockMessaging.diagnosticsErrorHandler(1, 'tab_isFeatureEnabled');
+            mockMessaging.diagnosticsErrorHandler(1, 'tab_isFeatureEnabled');
+            await cpm.modifyCpmState(() => {});
+
+            const handler = messageHandlers.autoconsent;
+            const multipleCmpsMessage = {
+                autoconsentPayload: {
+                    type: 'autoconsentError',
+                    details: {
+                        msg: 'Found multiple CMPs',
+                    },
+                },
+            };
+            await handler({}, makeSender({ frameId: 0 }), multipleCmpsMessage);
+            await handler({}, makeSender({ frameId: 0 }), multipleCmpsMessage);
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    cpmErrors: new Set(['tab_isFeatureEnabled', 'multiple_cmps']),
+                }),
+            );
+        });
+
+        it('restores persisted dashboard errors as Sets', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            await cpm.recordCpmDiagnosticError(1, 'tab_isFeatureEnabled');
+            await cpm.recordCpmDiagnosticError(null, 'glob_getResourceIfNew');
+            await cpm.updateCpmDashboardState(1, { cpmStage: 'popup_found', cpmConfigVersion: '1' });
+
+            expect(sessionStorageFallback.get('cpmState').dashboardStates['1'].cpmErrors).toEqual([
+                'glob_getResourceIfNew',
+                'tab_isFeatureEnabled',
+            ]);
+            expect(sessionStorageFallback.get('cpmState').globalErrors).toEqual(['glob_getResourceIfNew']);
+
+            Object.keys(messageHandlers).forEach((k) => delete messageHandlers[k]);
+            const restoredCpm = new CookiePromptManagement({ cpmMessaging: createMockMessaging() });
+            const restoredState = await restoredCpm.getCpmState();
+
+            expect(restoredState.dashboardStates['1'].cpmErrors).toEqual(new Set(['glob_getResourceIfNew', 'tab_isFeatureEnabled']));
+            expect(restoredState.globalErrors).toEqual(new Set(['glob_getResourceIfNew']));
+        });
+
+        it('merges global errors into the next tab dashboard update', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            mockMessaging.diagnosticsErrorHandler(null, 'glob_getResourceIfNew');
+            await cpm.modifyCpmState(() => {});
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await cpm.modifyCpmState(() => {});
+            await Promise.resolve();
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    cpmStage: 'init_received',
+                    cpmErrors: new Set(['glob_getResourceIfNew']),
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports optout_failed when opt out fails', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'optOutResult',
+                    result: false,
+                    cmp: 'test-cmp',
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    optoutFailed: true,
+                    cpmStage: 'optout_failed',
+                    consentRule: 'test-cmp',
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
+
+        it('reports done when autoconsent completes', async () => {
+            const mockMessaging = createMockMessaging();
+            const cpm = new CookiePromptManagement({ cpmMessaging: mockMessaging });
+            await cpm.remoteConfigJson;
+
+            const handler = messageHandlers.autoconsent;
+            await handler({}, makeSender({ frameId: 0 }), { autoconsentPayload: makeInitMessage() });
+            await handler({}, makeSender({ frameId: 0 }), {
+                autoconsentPayload: {
+                    type: 'autoconsentDone',
+                    cmp: 'test-cmp',
+                    isCosmetic: false,
+                },
+            });
+
+            expect(latestDashboardState(mockMessaging)).toEqual(
+                jasmine.objectContaining({
+                    consentManaged: true,
+                    cosmetic: false,
+                    optoutFailed: false,
+                    cpmStage: 'done',
+                    consentRule: 'test-cmp',
+                    cpmConfigVersion: '1',
+                }),
+            );
+        });
     });
 
     describe('disabled-for-site pixel', () => {

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -147,7 +147,7 @@ describe('CookiePromptManagement', () => {
             expect(latestDashboardState(mockMessaging)).toEqual(
                 jasmine.objectContaining({
                     consentManaged: false,
-                    consentHeuristicEnabled: null,
+                    consentHeuristicEnabled: true,
                     cpmStage: 'setting_disabled',
                     cpmErrors: new Set(),
                     cpmConfigVersion: '1',
@@ -166,7 +166,7 @@ describe('CookiePromptManagement', () => {
             expect(latestDashboardState(mockMessaging)).toEqual(
                 jasmine.objectContaining({
                     consentManaged: false,
-                    consentHeuristicEnabled: null,
+                    consentHeuristicEnabled: true,
                     cpmStage: 'site_disabled',
                     cpmErrors: new Set(),
                     cpmConfigVersion: '1',

--- a/unit-test/background/cpm-embedded-messaging.js
+++ b/unit-test/background/cpm-embedded-messaging.js
@@ -283,7 +283,7 @@ describe('CPMEmbeddedMessaging', () => {
 
         it('serializes cpmErrors before sending to native', async () => {
             await messaging.refreshDashboardState(1, 'https://example.com', {
-                cpmErrors: new Set(['tab_isFeatureEnabled', 'multiple_cmps']),
+                cpmErrors: ['tab_isFeatureEnabled', 'multiple_cmps'],
             });
 
             expect(nativeMessaging.notify).toHaveBeenCalledWith('refreshCpmDashboardState', {

--- a/unit-test/background/cpm-embedded-messaging.js
+++ b/unit-test/background/cpm-embedded-messaging.js
@@ -494,6 +494,18 @@ describe('CPMEmbeddedMessaging', () => {
             expect(result).toEqual(cachedConfig);
         });
 
+        it('records config request failures for diagnostics', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            const cachedConfig = { version: '1', features: {} };
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            sessionStorageFallback.set('config', cachedConfig);
+            nativeMessaging.request.and.returnValue(Promise.reject(new Error('network error')));
+
+            await messaging.refreshRemoteConfig();
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(null, 'glob_getResourceIfNew');
+        });
+
         it('throws on error if there is no cached config', async () => {
             const error = new Error('network error');
             nativeMessaging.request.and.returnValue(Promise.reject(error));

--- a/unit-test/background/cpm-embedded-messaging.js
+++ b/unit-test/background/cpm-embedded-messaging.js
@@ -39,6 +39,27 @@ describe('CPMEmbeddedMessaging', () => {
             expect(nativeMessaging.notify).toHaveBeenCalledWith('testMethod', { key: 'value' });
         });
 
+        it('records native notification failures for diagnostics', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            nativeMessaging.notify.and.returnValue(Promise.reject(new Error('test error')));
+            spyOn(console, 'error');
+
+            await messaging._notify('testMethod', { tabId: 7 });
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(7, 'tab_testMethod');
+        });
+
+        it('records global native notification failures for diagnostics', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            nativeMessaging.notify.and.returnValue(Promise.reject(new Error('test error')));
+            spyOn(console, 'error');
+
+            await messaging._notify('testMethod', {});
+            expect(diagnosticsHandler).toHaveBeenCalledWith(null, 'glob_testMethod');
+        });
+
         it('serializes multiple notifications in order', async () => {
             const callOrder = [];
             nativeMessaging.notify.and.callFake(async (method) => {
@@ -75,6 +96,28 @@ describe('CPMEmbeddedMessaging', () => {
             const result = await messaging._request('testMethod', { key: 'value' });
             expect(nativeMessaging.request).toHaveBeenCalledWith('testMethod', { key: 'value' });
             expect(result).toEqual({ data: 42 });
+        });
+
+        it('records native request failures for diagnostics', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            nativeMessaging.request.and.returnValue(Promise.reject(new Error('test error')));
+            spyOn(console, 'error');
+
+            await messaging._request('testMethod', {}, undefined, undefined, 8);
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(8, 'tab_testMethod');
+        });
+
+        it('records global native request failures for diagnostics', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            nativeMessaging.request.and.returnValue(Promise.reject(new Error('test error')));
+            spyOn(console, 'error');
+
+            await messaging._request('testMethod', {});
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(null, 'glob_testMethod');
         });
 
         it('serializes multiple requests in order', async () => {
@@ -210,7 +253,7 @@ describe('CPMEmbeddedMessaging', () => {
 
     describe('logMessage', () => {
         it('sends a notification', async () => {
-            await messaging.logMessage('hello world');
+            await messaging.logMessage('hello world', true);
             expect(nativeMessaging.notify).toHaveBeenCalledWith('extensionLog', { message: 'hello world' });
         });
     });
@@ -222,7 +265,34 @@ describe('CPMEmbeddedMessaging', () => {
             expect(nativeMessaging.notify).toHaveBeenCalledWith('refreshCpmDashboardState', {
                 tabId: 1,
                 url: 'https://example.com',
-                consentStatus: { cosmetic: true },
+                consentStatus: { cosmetic: true, cpmQueueSize: 0 },
+            });
+        });
+
+        it('includes pending native messages in dashboard queue size', async () => {
+            messaging._queueSize = 1;
+
+            await messaging.refreshDashboardState(1, 'https://example.com', {});
+
+            expect(nativeMessaging.notify).toHaveBeenCalledWith('refreshCpmDashboardState', {
+                tabId: 1,
+                url: 'https://example.com',
+                consentStatus: { cpmQueueSize: 1 },
+            });
+        });
+
+        it('serializes cpmErrors before sending to native', async () => {
+            await messaging.refreshDashboardState(1, 'https://example.com', {
+                cpmErrors: new Set(['tab_isFeatureEnabled', 'multiple_cmps']),
+            });
+
+            expect(nativeMessaging.notify).toHaveBeenCalledWith('refreshCpmDashboardState', {
+                tabId: 1,
+                url: 'https://example.com',
+                consentStatus: {
+                    cpmErrors: 'tab_isFeatureEnabled,multiple_cmps',
+                    cpmQueueSize: 0,
+                },
             });
         });
     });


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/task/1215563884985711
Tech Design: https://app.asana.com/1/137249556945/project/1163321984198618/task/1215500947847493?focus=true
See also https://github.com/duckduckgo/apple-browsers/pull/5486

**Reviewer:** @sammacbeth 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
See https://github.com/duckduckgo/apple-browsers/pull/5486

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 


<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Touches the autoconsent message handler and native dashboard payloads on every main-frame init and lifecycle event; mistakes could misreport breakage or add native messaging noise, though behavior changes are mostly diagnostic with targeted reload-loop fixes.
> 
> **Overview**
> Adds **richer CPM diagnostics** for the native protections dashboard by persisting per-tab dashboard state (including **`cpmStage`**, **`cpmConfigVersion`**, **`cpmErrors`**, and global errors) in session storage and pushing updates through the existing `refreshCpmDashboardState` path at each meaningful step—not only on success paths.
> 
> **Lifecycle stages** now cover early exits (`config_unavailable`, `settings_missing`, `setting_disabled`, `site_disabled`) as well as `init_received`, `popup_found`, `optout_failed`, and `done`. Main-frame **`init`** resets per-tab dashboard state on navigation so stale “consent managed” outcomes are not shown after a same-URL reload.
> 
> **Embedded native messaging** records failures from queued `_request`/`_notify` (and config refresh) via an optional diagnostics handler, scopes errors as `tab_<method>` vs `glob_<method>`, includes **`cpmQueueSize`** in consent status, and serializes **`cpmErrors`** for native (comma-separated, length-capped). Setting/site/subfeature checks accept optional **`tabId`** for that attribution. Extension logs to native only when explicitly treated as debug.
> 
> Fixes **reload-loop reporting**: `consentReloadLoop` is re-read when emitting `done`/`optout_failed` so it stays accurate after `popupFound` detection, and can clear when a different CMP is handled.
> 
> Bumps the **embedded extension** manifest version to `2026.6.22`. Adds broad unit coverage for diagnostics, persistence, and reload-loop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5065eb09a00858897f198917800f0daa894ac018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run on every main-frame autoconsent message and alter native `consentStatus` payloads; mis-staging or extra dashboard updates could confuse breakage UI, though core opt-out behavior is mostly unchanged aside from reload-loop reporting fixes.
> 
> **Overview**
> Adds **CPM breakage/diagnostics** for the native protections dashboard by persisting per-tab **`cpmStage`**, **`cpmConfigVersion`**, and **`cpmErrors`** (plus session **`globalErrors`**) and pushing them through **`refreshCpmDashboardState`** at each lifecycle step—including early exits (`config_unavailable`, `settings_missing`, `setting_disabled`, `site_disabled`) as well as `init_received`, `popup_found`, `optout_failed`, and `done`.
> 
> Main-frame **`init`** now **resets** per-tab dashboard state so a same-URL reload does not show stale “consent managed” before CPM runs again. **Embedded native messaging** records failures from queued `_request`/`_notify` and config refresh via an optional diagnostics handler (`tab_<method>` / `glob_<method>`), attaches **`cpmQueueSize`**, serializes **`cpmErrors`** for native (comma-separated, capped), and forwards optional **`tabId`** on setting/site checks. Extension logs to native only when treated as debug.
> 
> **Reload-loop reporting** is tightened: `consentReloadLoop` is re-read for `done`/`optout_failed` after `popupFound` detection and can clear when a different CMP is handled. Bumps embedded manifest to **`2026.6.24`** and adds unit tests for diagnostics, persistence, and reload-loop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9a4d0af477d22c4f63d724c31b8af66220dee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->