### PR TITLE
Add timeouts to native messages

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.6.24",
+    "version": "2026.7.7",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -14,6 +14,29 @@ export const SETTING_CHECK_TTL = 10 * 1000; // 10s
 export const SITE_CHECK_TTL = 3 * 1000; // 3s (to be able to respond to Protections toggle changes)
 export const MAX_CACHE_SIZE = 100;
 
+// Upper bound for a single native message round-trip. Native messages are local IPC and normally
+// complete in milliseconds, but a dropped reply may leave the promise pending forever.
+export const NATIVE_MESSAGE_TIMEOUT_MS = 10 * 1000; // 10s
+
+/**
+ * Reject if `promise` does not settle within `timeoutMs`
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} timeoutMs
+ * @param {string} label - method name, included in the timeout error for diagnostics
+ * @returns {Promise<T>}
+ */
+function withTimeout(promise, timeoutMs, label) {
+    /** @type {ReturnType<typeof setTimeout>} */
+    let timer;
+    const timeout = new Promise((_resolve, reject) => {
+        timer = setTimeout(() => {
+            reject(new Error(`native message "${label}" timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 /**
  * CPM messaging for embedded extension.
  * @implements {CPMMessagingBase}
@@ -64,7 +87,11 @@ export class CPMEmbeddedMessaging {
         this._queueSize += 1;
         const result = this._queue
             .then(() => {
-                return this.nativeMessaging.notify(method, params);
+                return withTimeout(
+                    this.nativeMessaging.notify(method, params),
+                    NATIVE_MESSAGE_TIMEOUT_MS,
+                    method,
+                );
             })
             .catch((e) => {
                 console.error('error in notification queue', e);
@@ -99,7 +126,11 @@ export class CPMEmbeddedMessaging {
                         return cached.value;
                     }
                 }
-                const result = await this.nativeMessaging.request(method, params);
+                const result = await withTimeout(
+                    this.nativeMessaging.request(method, params),
+                    NATIVE_MESSAGE_TIMEOUT_MS,
+                    method,
+                );
                 if (cacheKey && ttl) {
                     // evict the oldest entry if the cache is full
                     if (this._cache.size >= MAX_CACHE_SIZE) {
@@ -211,7 +242,11 @@ export class CPMEmbeddedMessaging {
         try {
             console.log(`fetching config from native, cachedConfigVersion: ${cachedConfigVersion}`);
             // we don't use the request queue here because config fetching should be async
-            const result = await this.nativeMessaging.request('getResourceIfNew', { name: 'config', version: cachedConfigVersion });
+            const result = await withTimeout(
+                this.nativeMessaging.request('getResourceIfNew', { name: 'config', version: cachedConfigVersion }),
+                NATIVE_MESSAGE_TIMEOUT_MS,
+                'getResourceIfNew',
+            );
             if (result.updated) {
                 this._cachedConfig = result.data;
                 try {

--- a/shared/js/background/components/cpm-embedded-messaging.js
+++ b/shared/js/background/components/cpm-embedded-messaging.js
@@ -87,11 +87,7 @@ export class CPMEmbeddedMessaging {
         this._queueSize += 1;
         const result = this._queue
             .then(() => {
-                return withTimeout(
-                    this.nativeMessaging.notify(method, params),
-                    NATIVE_MESSAGE_TIMEOUT_MS,
-                    method,
-                );
+                return withTimeout(this.nativeMessaging.notify(method, params), NATIVE_MESSAGE_TIMEOUT_MS, method);
             })
             .catch((e) => {
                 console.error('error in notification queue', e);
@@ -126,11 +122,7 @@ export class CPMEmbeddedMessaging {
                         return cached.value;
                     }
                 }
-                const result = await withTimeout(
-                    this.nativeMessaging.request(method, params),
-                    NATIVE_MESSAGE_TIMEOUT_MS,
-                    method,
-                );
+                const result = await withTimeout(this.nativeMessaging.request(method, params), NATIVE_MESSAGE_TIMEOUT_MS, method);
                 if (cacheKey && ttl) {
                     // evict the oldest entry if the cache is full
                     if (this._cache.size >= MAX_CACHE_SIZE) {

--- a/unit-test/background/cpm-embedded-messaging.js
+++ b/unit-test/background/cpm-embedded-messaging.js
@@ -4,6 +4,7 @@ import {
     SUBFEATURE_CHECK_TTL,
     SETTING_CHECK_TTL,
     SITE_CHECK_TTL,
+    NATIVE_MESSAGE_TIMEOUT_MS,
 } from '../../shared/js/background/components/cpm-embedded-messaging';
 import { sessionStorageFallback } from '../../shared/js/background/wrapper';
 
@@ -16,6 +17,23 @@ function createMockNativeMessaging() {
         request: jasmine.createSpy('request').and.returnValue(Promise.resolve({})),
         subscribe: jasmine.createSpy('subscribe'),
     };
+}
+
+/**
+ * A promise that never settles, used to simulate a hung native call.
+ */
+function neverSettles() {
+    return new Promise(() => {});
+}
+
+/**
+ * Flush pending microtasks so a queued job can start and schedule its timeout timer
+ * before the mocked clock is advanced.
+ */
+async function flushMicrotasks() {
+    for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+    }
 }
 
 describe('CPMEmbeddedMessaging', () => {
@@ -87,6 +105,28 @@ describe('CPMEmbeddedMessaging', () => {
 
             expect(nativeMessaging.notify).toHaveBeenCalledWith('after', {});
             expect(console.error).toHaveBeenCalled();
+        });
+
+        it('times out a hung notification instead of blocking the queue forever', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            spyOn(console, 'error');
+
+            // native notification never settles
+            nativeMessaging.notify.and.returnValue(neverSettles());
+            const hung = messaging._notify('hang', { tabId: 7 });
+
+            // let the job start and schedule its timeout, then advance past it
+            await flushMicrotasks();
+            jasmine.clock().tick(NATIVE_MESSAGE_TIMEOUT_MS + 1);
+            await hung;
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(7, 'tab_hang');
+
+            // the queue is not blocked: a subsequent notification still goes through
+            nativeMessaging.notify.and.returnValue(Promise.resolve());
+            await messaging._notify('after', {});
+            expect(nativeMessaging.notify).toHaveBeenCalledWith('after', {});
         });
     });
 
@@ -224,6 +264,46 @@ describe('CPMEmbeddedMessaging', () => {
 
             expect(result).toEqual({ ok: true });
             expect(console.error).toHaveBeenCalled();
+        });
+
+        it('times out a hung request instead of blocking the queue forever', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            spyOn(console, 'error');
+
+            // native request never settles
+            nativeMessaging.request.and.returnValue(neverSettles());
+            const hung = messaging._request('hang', {}, undefined, undefined, 5);
+
+            // let the job start and schedule its timeout, then advance past it
+            await flushMicrotasks();
+            jasmine.clock().tick(NATIVE_MESSAGE_TIMEOUT_MS + 1);
+            await hung;
+
+            expect(diagnosticsHandler).toHaveBeenCalledWith(5, 'tab_hang');
+
+            // the queue is not blocked: a subsequent request still resolves
+            nativeMessaging.request.and.returnValue(Promise.resolve({ ok: true }));
+            const result = await messaging._request('after', {});
+            expect(result).toEqual({ ok: true });
+        });
+
+        it('does not cache a timed-out request', async () => {
+            spyOn(console, 'error');
+
+            nativeMessaging.request.and.returnValue(neverSettles());
+            const hung = messaging._request('test', {}, 'myKey', 60000);
+            await flushMicrotasks();
+            jasmine.clock().tick(NATIVE_MESSAGE_TIMEOUT_MS + 1);
+            await hung;
+
+            expect(messaging._cache.size).toBe(0);
+
+            // next call actually hits native again (nothing was cached)
+            nativeMessaging.request.and.returnValue(Promise.resolve({ enabled: true }));
+            const result = await messaging._request('test', {}, 'myKey', 60000);
+            expect(result).toEqual({ enabled: true });
+            expect(messaging._cache.get('myKey')).toBeDefined();
         });
 
         it('the resulting promise resolves only after the request is complete', async () => {
@@ -514,6 +594,22 @@ describe('CPMEmbeddedMessaging', () => {
             nativeMessaging.request.and.returnValue(Promise.reject(error));
 
             await expectAsync(messaging.refreshRemoteConfig()).toBeRejectedWith(error);
+        });
+
+        it('falls back to cached config when the native request hangs past the timeout', async () => {
+            const diagnosticsHandler = jasmine.createSpy('diagnosticsHandler');
+            const cachedConfig = { version: '1', features: {} };
+            messaging.setDiagnosticsErrorHandler(diagnosticsHandler);
+            sessionStorageFallback.set('config', cachedConfig);
+            nativeMessaging.request.and.returnValue(neverSettles());
+
+            const promise = messaging.refreshRemoteConfig();
+            await flushMicrotasks();
+            jasmine.clock().tick(NATIVE_MESSAGE_TIMEOUT_MS + 1);
+            const result = await promise;
+
+            expect(result).toEqual(cachedConfig);
+            expect(diagnosticsHandler).toHaveBeenCalledWith(null, 'glob_getResourceIfNew');
         });
     });
 });


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/1163321984198618/task/1216031389682952?focus=true

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Speculative fix to avoid theoretical infinite deadlock in native messaging


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior for all embedded native CPM IPC; a slow-but-valid native reply past 10s would now fail and fall back to error handling/cached config instead of waiting indefinitely.
> 
> **Overview**
> Adds **`NATIVE_MESSAGE_TIMEOUT_MS` (10s)** and a **`withTimeout`** helper that races native IPC promises against a timer and rejects with a labeled error if no reply arrives.
> 
> **`CPMEmbeddedMessaging`** now wraps **`nativeMessaging.notify`**, **`nativeMessaging.request`** (queued paths), and the out-of-queue **`getResourceIfNew`** call in **`refreshRemoteConfig`** with that timeout. Hung calls surface through existing queue **`.catch`** handling (diagnostics + logging) instead of leaving **`_queue`** stuck indefinitely; timed-out **`_request`** paths do not write to the response cache.
> 
> Unit tests cover hung **`_notify`** / **`_request`** (queue unblocks, diagnostics), no cache after timeout, and **cached config fallback** when config refresh times out. Embedded extension **manifest version** bumps to **2026.7.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a255ce6806ab58cd2a7950ae65acdeebc95e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->