### PR TITLE
Update autoconsent to v16.8.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.6.24",
+    "version": "2026.7.8",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.0.0",
+                "@duckduckgo/autoconsent": "^16.8.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.0.0.tgz",
-            "integrity": "sha512-KhNs66HzfH0dfLwtQtE00ZQQfNn7wsxRoouf2W+8nSM0zl15DlPO+uiKMe8kmdHae/CK7OyEbc9FjXtrXQEEvQ==",
+            "version": "16.8.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.8.0.tgz",
+            "integrity": "sha512-iOl5KUCn1t2+N4rKaid/Ks5AtEGWF5pAOedIuQLrdvu1nMmFyAjhdjI1p2QR5U4AAmt/aqj2A0ERH8wGu19foQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.0.0",
+        "@duckduckgo/autoconsent": "^16.8.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216382609186004
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.8.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1216382434474495 apple_task_gid: 1216382434474495 -->

## Description
Updates Autoconsent to version [v16.8.0](https://github.com/duckduckgo/autoconsent/releases/tag/v16.8.0).

### Autoconsent v16.8.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.8.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local code changes; behavior comes from the upstream autoconsent release, which is the normal low-risk path for CPM updates.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **16.0.0** to **16.8.0** in `package.json` and the lockfile so the extension ships the latest cookie-consent rules and behavior from that release.
> 
> Also bumps the **embedded extension** manifest version to **`2026.7.8`**, consistent with releasing the embedded build that includes this dependency update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fdc968582706bf0e1efb536bd01570ad4a82360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->