### PR TITLE
Update autoconsent to v16.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.8.0",
+                "@duckduckgo/autoconsent": "^16.8.1",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -595,9 +595,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.8.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.8.0.tgz",
-            "integrity": "sha512-iOl5KUCn1t2+N4rKaid/Ks5AtEGWF5pAOedIuQLrdvu1nMmFyAjhdjI1p2QR5U4AAmt/aqj2A0ERH8wGu19foQ==",
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.8.1.tgz",
+            "integrity": "sha512-S1OP2+mYDXvbSi4PVuiLRawl5NGRMR0q2ZFRmbRTigTQnZ6oxrOt9/vJkZEJD8UGczzkDjrTTecNIPNnnuBjFA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.8.0",
+        "@duckduckgo/autoconsent": "^16.8.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216387860503264
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.8.1
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1216387992190369 apple_task_gid: 1216387992190369 -->

## Description
Updates Autoconsent to version [v16.8.1](https://github.com/duckduckgo/autoconsent/releases/tag/v16.8.1).

### Autoconsent v16.8.1 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.8.1/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-version dependency bump with lockfile sync only; behavior changes come from the upstream autoconsent release, not local code edits.
> 
> **Overview**
> Bumps the **`@duckduckgo/autoconsent`** dependency from **16.8.0** to **16.8.1** in `package.json` and refreshes the matching entry in `package-lock.json` (resolved tarball URL and integrity hash). No extension source or config changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def9037d46e4adc3ec18c9953d5043a89e62299f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->