### PR TITLE
CPM heuristic pixel fix

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.7.8",
+    "version": "2026.7.13",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -673,7 +673,7 @@ export default class CookiePromptManagement {
                         cpmStage: 'done',
                     }),
                 );
-                if (msg.cmp === 'HEURISTIC') {
+                if (msg.cmp.startsWith('HEURISTIC')) {
                     this.firePixel('done_heuristic');
                 } else {
                     this.firePixel(msg.isCosmetic ? 'done_cosmetic' : 'done');


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216513297304204?focus=true

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in CPM pixel routing with no auth, data, or consent-handling logic changes beyond telemetry classification.
> 
> **Overview**
> On **autoconsent done**, heuristic completions now fire the `done_heuristic` analytics pixel when `msg.cmp` **starts with** `HEURISTIC`, not only when it equals `HEURISTIC` exactly. That fixes under-counting when autoconsent reports suffixed or tier-specific heuristic CMP identifiers.
> 
> The embedded extension manifest version is bumped to **2026.7.13**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b9d4f6e8d156df1e630bc6bd0c1d18b3b86a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->