### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/packages/ddg2dnr/lib/trackingParams.js
+++ b/packages/ddg2dnr/lib/trackingParams.js
@@ -11,7 +11,7 @@ function generateTrackingParameterRules(config) {
     const allowedDomains = config.features.trackingParameters.exceptions?.map((e) => e.domain);
 
     // Skip any wildcard or regex parameters, we can't support these in MV3
-    const trackingParams = config.features.trackingParameters.settings?.parameters?.filter((param) => !param.match(/[*+?{}[\]]/, 'g'));
+    const trackingParams = config.features.trackingParameters.settings?.parameters?.filter((param) => !String(param).match(/[*+?{}[\]]/));
 
     if (!trackingParams) {
         return [];

--- a/shared/js/background/devbuild-reloader.js
+++ b/shared/js/background/devbuild-reloader.js
@@ -21,7 +21,9 @@ export default function initReloader() {
         try {
             const response = await fetch('/buildtime.txt', { cache: 'no-store' });
             buildTime = await response.text();
-        } catch (e) {}
+        } catch (e) {
+            console.warn('Failed to fetch build time:', e);
+        }
 
         if (buildTime) {
             const previousBuildTime = await getFromSessionStorage('buildTime');


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `packages/ddg2dnr/lib/trackingParams.js:L18`

In `generateTrackingParameterRules`, `param.match(/[*+?{}[\]]/, 'g')` passes a string ('g') as the second argument to `String.prototype.match()`. The second argument of `match()` is not a flag parameter (unlike `RegExp`), so this 'g' is ignored. Additionally, if `param` is not a string (e.g., an object or number), this will throw a TypeError.

## Solution

Remove the second argument to `match()`. If `param` might not be a string, ensure it is cast to a string first or validate its type before calling `match()`.

## Changes

- `packages/ddg2dnr/lib/trackingParams.js` (modified)
- `shared/js/background/devbuild-reloader.js` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small correctness and dev-only logging changes with no auth, security, or production user-flow impact.
> 
> **Overview**
> Fixes **tracking parameter rule generation** so wildcard/regex-style params are filtered safely: `param` is coerced with `String(param)` before `.match()`, and the invalid second argument to `match()` (the `'g'` string) is removed.
> 
> In **dev build auto-reload**, failed fetches of `buildtime.txt` now log a `console.warn` instead of swallowing errors in an empty `catch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33896ff58b8b38dcb55b70e82e86ef2ff0468718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->