### PR TITLE
Fix a flake with the ATB integration tests

### DIFF
--- a/integration-test/atb.spec.js
+++ b/integration-test/atb.spec.js
@@ -37,7 +37,11 @@ test.describe('install workflow', () => {
                     onRequest(request);
                 }
             });
-            await initialExtiFired;
+
+            // Wait for the first exti request, but include a timeout as it will
+            // sometimes complete before we start listening for requests.
+            await backgroundWait.forSetting(backgroundPage, 'extiSent');
+            await Promise.race([initialExtiFired, new Promise((resolve) => setTimeout(resolve, 2000))]);
 
             // clear atb settings
             await backgroundPage.evaluate(() => {


### PR DESCRIPTION
The initial exti request was sometimes firing before the request listener could
be set up, which caused the ATB tests to hang. Let's add a two second timeout,
to avoid failing when that happens.