### PR TITLE
Update the Playwright Firefox harness dependency repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "esbuild": "^0.25.9",
                 "eslint": "^9.13.0",
                 "fake-indexeddb": "^6.0.0",
-                "firefox-webext-playwright-harness": "github:kzar/firefox-webext-playwright-harness#0.3.0",
+                "firefox-webext-playwright-harness": "github:duckduckgo/firefox-webext-playwright-harness#0.3.0",
                 "glob": "^11.0.3",
                 "jasmine": "^5.9.0",
                 "jsdom": "^26.0.0",
@@ -5930,7 +5930,7 @@
         },
         "node_modules/firefox-webext-playwright-harness": {
             "version": "0.3.0",
-            "resolved": "git+ssh://git@github.com/kzar/firefox-webext-playwright-harness.git#c339f623db3b4ee464e6460e32287ca2ee588115",
+            "resolved": "git+ssh://git@github.com/duckduckgo/firefox-webext-playwright-harness.git#c339f623db3b4ee464e6460e32287ca2ee588115",
             "dev": true,
             "license": "Apache-2.0",
             "workspaces": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "esbuild": "^0.25.9",
         "eslint": "^9.13.0",
         "fake-indexeddb": "^6.0.0",
-        "firefox-webext-playwright-harness": "github:kzar/firefox-webext-playwright-harness#0.3.0",
+        "firefox-webext-playwright-harness": "github:duckduckgo/firefox-webext-playwright-harness#0.3.0",
         "glob": "^11.0.3",
         "jasmine": "^5.9.0",
         "jsdom": "^26.0.0",


### PR DESCRIPTION
We have moved the harness repository[1] into the DuckDuckGo account, so let's
update the dependency here to point to that.

1 - https://github.com/duckduckgo/firefox-webext-playwright-harness