### PR TITLE
Mitigate hopculture.com Freestar anti-adblock wall (privacy-config patch)

### DIFF
--- a/scripts/privacy-config-patches/hopculture-pub-network.patch
+++ b/scripts/privacy-config-patches/hopculture-pub-network.patch
@@ -1,0 +1,75 @@
+diff --git a/features/tracker-allowlist.json b/features/tracker-allowlist.json
+index 241d6ff..66a8620 100644
+--- a/features/tracker-allowlist.json
++++ b/features/tracker-allowlist.json
+@@ -4245,7 +4245,8 @@
+                             "smithsonianmag.com",
+                             "stockcharts.com",
+                             "thenation.com",
+-                            "titantv.com"
++                            "titantv.com",
++                            "hopculture.com"
+                         ],
+                         "reason": [
+                             "newrepublic.com - https://github.com/duckduckgo/privacy-configuration/pull/2807",
+@@ -4256,7 +4257,8 @@
+                             "stockcharts.com - https://github.com/duckduckgo/privacy-configuration/pull/2478",
+                             "titantv.com - https://github.com/duckduckgo/privacy-configuration/issues/1925",
+                             "thenation.com - https://github.com/duckduckgo/privacy-configuration/pull/2846",
+-                            "pc-builds.com - https://github.com/duckduckgo/privacy-configuration/pull/4092"
++                            "pc-builds.com - https://github.com/duckduckgo/privacy-configuration/pull/4092",
++                            "hopculture.com - Anti-adblock wall. https://github.com/duckduckgo/privacy-configuration/issues/5642"
+                         ]
+                     },
+                     {
+@@ -4292,6 +4294,50 @@
+                             "pc-builds.com - https://github.com/duckduckgo/privacy-configuration/pull/4092"
+                         ]
+                     },
++                    {
++                        "rule": "a.pub.network/hopculture-com/",
++                        "domains": [
++                            "hopculture.com",
++                            "pc-builds.com"
++                        ],
++                        "reason": [
++                            "hopculture.com - Anti-adblock wall. https://github.com/duckduckgo/privacy-configuration/issues/5642",
++                            "pc-builds.com - domain propagation from pub.network/ catch-all"
++                        ]
++                    },
++                    {
++                        "rule": "a.pub.network/core/imgs/",
++                        "domains": [
++                            "hopculture.com",
++                            "pc-builds.com"
++                        ],
++                        "reason": [
++                            "hopculture.com - Freestar bait image used for adblock detection. https://github.com/duckduckgo/privacy-configuration/issues/5642",
++                            "pc-builds.com - domain propagation from pub.network/ catch-all"
++                        ]
++                    },
++                    {
++                        "rule": "d.pub.network/",
++                        "domains": [
++                            "hopculture.com",
++                            "pc-builds.com"
++                        ],
++                        "reason": [
++                            "hopculture.com - Freestar site config required to clear adblock wall. https://github.com/duckduckgo/privacy-configuration/issues/5642",
++                            "pc-builds.com - domain propagation from pub.network/ catch-all"
++                        ]
++                    },
++                    {
++                        "rule": "c.pub.network/",
++                        "domains": [
++                            "hopculture.com",
++                            "pc-builds.com"
++                        ],
++                        "reason": [
++                            "hopculture.com - Freestar endpoint required to clear adblock wall. https://github.com/duckduckgo/privacy-configuration/issues/5642",
++                            "pc-builds.com - domain propagation from pub.network/ catch-all"
++                        ]
++                    },
+                     {
+                         "rule": "pub.network/",
+                         "domains": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

https://www.hopculture.com/ shows a Freestar anti-adblock wall (“Looks like your ad blocker is on”) when DDG tracker blocking is on. The wall is driven by blocked `pub.network` bait/ad requests.

This PR does **not** change extension runtime code. It carries a ready-to-apply privacy-configuration patch (this agent only has write access to the extension repo).

**Privacy-config issue (with full patch):** https://github.com/duckduckgo/privacy-configuration/issues/5643  
**Patch in this repo:** `scripts/privacy-config-patches/hopculture-pub-network.patch`

### Root cause

Blocked Freestar requests that trip detection:

- `a.pub.network/hopculture-com/cls.css`
- `a.pub.network/hopculture-com/pubfig.min.js`
- `a.pub.network/core/imgs/1.png` (bait pixel)
- `a.pub.network/core/prebid-universal-creative.js`
- `d.pub.network/v2/sites/hopculture-com/configs`
- `c.pub.network/v2/c`

### Mitigation

In `features/tracker-allowlist.json` under `pub.network`:

1. Add `hopculture.com` to existing `a.pub.network/core/prebid-universal-creative.js`
2. Add targeted rules:
   - `a.pub.network/hopculture-com/`
   - `a.pub.network/core/imgs/`
   - `d.pub.network/`
   - `c.pub.network/`
3. Include `pc-builds.com` on new more-specific rules for domain propagation from the existing `pub.network/` catch-all

### Apply in privacy-configuration

```bash
cd /path/to/privacy-configuration
git apply path/to/hopculture-pub-network.patch
npm test
```

### Validation

- Reproduced wall with Chrome MV3 ext + locally hosted `extension-chromemv3-config.json`
- Without extension: no wall
- With allowlist patch: wall cleared; Freestar requests allowed via `ruleException`
- `mocha tests/tracker-allowlist-tests.js`: 66 passing

[Before: adblock wall](https://cursor.com/agents/bc-19dcd21b-10dc-4e6e-af61-0d9822a44631/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhopculture-repro%2Fhopculture-with-extension.png)
[After: wall cleared](https://cursor.com/agents/bc-19dcd21b-10dc-4e6e-af61-0d9822a44631/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhopculture-repro%2Fhopculture-fixed-final.png)

## Test plan

- [x] Reproduce wall with protections on
- [x] Confirm no wall without extension
- [x] Confirm allowlist patch clears wall
- [x] tracker-allowlist unit tests pass
- [ ] Land equivalent change via privacy-configuration PR (issue #5643)
- [ ] Close accidental stubs #5641 / #5642 if desired

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19dcd21b-10dc-4e6e-af61-0d9822a44631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19dcd21b-10dc-4e6e-af61-0d9822a44631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

