### PR TITLE
Update autoconsent to v16.19.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.7.16",
+    "version": "2026.7.31",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.8.1",
+                "@duckduckgo/autoconsent": "^16.19.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -595,9 +595,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.8.1",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.8.1.tgz",
-            "integrity": "sha512-S1OP2+mYDXvbSi4PVuiLRawl5NGRMR0q2ZFRmbRTigTQnZ6oxrOt9/vJkZEJD8UGczzkDjrTTecNIPNnnuBjFA==",
+            "version": "16.19.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.19.0.tgz",
+            "integrity": "sha512-lKScoBgF+YwNvTqu87g6lZS7LWlw62jNvjpyG0XFYxWJ8YBkm1Lmou3zAg02SVyBydN8wx5Hmo+6DusNn4euKQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.8.1",
+        "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217056078488055
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.19.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1217056078604139 apple_task_gid: 1217056078604139 -->

## Description
Updates Autoconsent to version [v16.19.0](https://github.com/duckduckgo/autoconsent/releases/tag/v16.19.0).

### Autoconsent v16.19.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.19.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent runs on pages for cookie/consent handling; a dependency upgrade can change behavior site-by-site even without local code edits, so validation via CI and optional smoke tests is appropriate.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **16.8.1** to **16.19.0** in `package.json` and `package-lock.json`, with no changes to extension source in this repo.
> 
> The embedded extension **`version`** in `browsers/embedded/manifest.json` is updated from **2026.7.16** to **2026.7.31** to align with the release cadence for the embedded build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0435431612482e765673829a42128dfcd60f016c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->