### PR TITLE
Improve parameter naming in chrome storage mock and update eslint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "zod": "^3.25.67"
             },
             "devDependencies": {
-                "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
+                "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.2.1",
                 "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v2.1.0",
                 "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration",
                 "@fingerprintjs/fingerprintjs": "^4.6.2",
@@ -628,15 +628,15 @@
             "link": true
         },
         "node_modules/@duckduckgo/eslint-config": {
-            "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/duckduckgo/eslint-config.git#09f3780bb1826fe123ef3e4eb36dcbd53ca1fd80",
+            "version": "0.2.1",
+            "resolved": "git+ssh://git@github.com/duckduckgo/eslint-config.git#1a2a3f071f76b51a9917df6476211a8f20eb81bd",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@eslint/js": "^9.13.0",
-                "eslint-config-prettier": "^9.1.0",
+                "eslint-config-prettier": "^10.0.0",
                 "eslint-plugin-import": "^2.31.0",
-                "eslint-plugin-n": "^17.11.1",
+                "eslint-plugin-n": "^18.0.0",
                 "eslint-plugin-promise": "^7.1.0"
             },
             "peerDependencies": {
@@ -3571,15 +3571,15 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
                 "set-function-length": "^1.2.2"
             },
             "engines": {
@@ -4768,14 +4768,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -4826,9 +4826,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-            "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4894,6 +4894,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4913,9 +4932,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -4954,15 +4973,18 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+            "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5134,9 +5156,9 @@
             }
         },
         "node_modules/eslint-compat-utils/node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5147,28 +5169,31 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
-            "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-import-resolver-node": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-            "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+            "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^3.2.7",
-                "is-core-module": "^2.13.0",
-                "resolve": "^1.22.4"
+                "is-core-module": "^2.16.1",
+                "resolve": "^2.0.0-next.6"
             }
         },
         "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -5182,9 +5207,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+            "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5290,9 +5315,9 @@
             }
         },
         "node_modules/eslint-plugin-n": {
-            "version": "17.23.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.2.tgz",
-            "integrity": "sha512-RhWBeb7YVPmNa2eggvJooiuehdL76/bbfj/OJewyoGT80qn5PXdz8zMOTO6YHOsI7byPt7+Ighh/i/4a5/v7hw==",
+            "version": "18.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.2.tgz",
+            "integrity": "sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5303,17 +5328,26 @@
                 "globals": "^15.11.0",
                 "globrex": "^0.1.2",
                 "ignore": "^5.3.2",
-                "semver": "^7.6.3",
-                "ts-declaration-location": "^1.0.6"
+                "semver": "^7.6.3"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
-                "eslint": ">=8.23.0"
+                "eslint": ">=8.57.1",
+                "ts-declaration-location": "^1.0.6",
+                "typescript": ">=5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ts-declaration-location": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-plugin-n/node_modules/globals": {
@@ -5330,9 +5364,9 @@
             }
         },
         "node_modules/eslint-plugin-n/node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5352,9 +5386,9 @@
             }
         },
         "node_modules/eslint-plugin-promise": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
-            "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+            "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5367,7 +5401,7 @@
                 "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -6150,18 +6184,21 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+            "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
-                "hasown": "^2.0.2",
-                "is-callable": "^1.2.7"
+                "has-property-descriptors": "^1.0.2",
+                "hasown": "^2.0.4",
+                "is-callable": "^1.2.7",
+                "is-document.all": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6326,9 +6363,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.13.3",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.3.tgz",
-            "integrity": "sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+            "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6595,9 +6632,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -7071,13 +7108,13 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7134,6 +7171,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-document.all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+            "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -8938,6 +8991,25 @@
                 "node": ">=10.5.0"
             }
         },
+        "node_modules/node-exports-info": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+            "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array.prototype.flatmap": "^1.3.3",
+                "es-errors": "^1.3.0",
+                "object.entries": "^1.1.9",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -9097,6 +9169,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object.entries": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+            "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/object.fromentries": {
             "version": "2.0.8",
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
@@ -9224,13 +9312,14 @@
             }
         },
         "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+            "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.6",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "object-keys": "^1.1.1",
                 "safe-push-apply": "^1.0.0"
             },
@@ -10066,13 +10155,16 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.1",
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.2",
+                "node-exports-info": "^1.6.0",
+                "object-keys": "^1.1.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -10202,15 +10294,15 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "get-intrinsic": "^1.2.6",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
@@ -10930,19 +11022,20 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-object-atoms": "^1.0.0",
-                "has-property-descriptors": "^1.0.2"
+                "es-abstract": "^1.24.2",
+                "es-object-atoms": "^1.1.2",
+                "has-property-descriptors": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10952,16 +11045,16 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
+                "es-object-atoms": "^1.1.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -11159,9 +11252,9 @@
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11371,42 +11464,6 @@
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "license": "MIT"
         },
-        "node_modules/ts-declaration-location": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-            "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "ko-fi",
-                    "url": "https://ko-fi.com/rebeccastevens"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "picomatch": "^4.0.2"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.0.0"
-            }
-        },
-        "node_modules/ts-declaration-location/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -11534,18 +11591,18 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0",
-                "reflect.getprototypeof": "^1.0.6"
+                "call-bind": "^1.0.9",
+                "for-each": "^0.3.5",
+                "gopd": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "possible-typed-array-names": "^1.1.0",
+                "reflect.getprototypeof": "^1.0.10"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -12272,14 +12329,14 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
+                "call-bind": "^1.0.9",
                 "call-bound": "^1.0.4",
                 "for-each": "^0.3.5",
                 "get-proto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "validate-pixel-defs": "validate-ddg-pixel-defs pixel-definitions"
     },
     "devDependencies": {
-        "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
+        "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.2.1",
         "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v2.1.0",
         "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration",
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/unit-test/inject-chrome-shim.js
+++ b/unit-test/inject-chrome-shim.js
@@ -66,14 +66,14 @@ const chrome = {
             set: (value) => {
                 chrome.storage.local._setCalls.push(value);
             },
-            get: (args, cb) => {
-                cb({});
+            get: (args, respond) => {
+                respond({});
             },
             _setCalls: [],
         },
         managed: {
-            get: (args, cb) => {
-                cb({});
+            get: (args, respond) => {
+                respond({});
             },
         },
     },


### PR DESCRIPTION
## Description:
This PR makes two changes:

1. **Improved parameter naming in chrome storage mock** (`unit-test/inject-chrome-shim.js`): Renamed the callback parameter from `cb` to `respond` in the `chrome.storage.local.get()` and `chrome.storage.managed.get()` mock implementations. This change improves code clarity by using a more descriptive name that better reflects the parameter's purpose as a response callback.

2. **Updated eslint config dependency** (`package.json`): Bumped `@duckduckgo/eslint-config` from v0.1.0 to v0.2.1 to incorporate the latest linting rules and standards.

## Steps to test this PR:
- Run the existing unit tests to ensure the mock chrome storage API continues to work correctly with the renamed parameter
- Verify that the updated eslint config doesn't introduce new linting errors in the codebase

## Automated tests:
- [x] Unit tests (existing tests should pass with the parameter rename)

https://claude.ai/code/session_01KubcqLJGHpgRqHSAtmhmHT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lint dependency and test mock naming; no runtime extension code changes.
> 
> **Overview**
> Updates **`@duckduckgo/eslint-config`** from **v0.1.0** to **v0.2.1** in `package.json`, with the lockfile refresh pulling newer ESLint plugin stacks (e.g. `eslint-config-prettier` 10, `eslint-plugin-n` 18).
> 
> In **`unit-test/inject-chrome-shim.js`**, the second argument to the mocked `chrome.storage.local.get` and `chrome.storage.managed.get` is renamed from `cb` to `respond` for readability; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22dd0b5d143ce4379fd08d58bb4933287fcee52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->