### PR TITLE
Update autoconsent to v16.23.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.8.6",
+    "version": "2026.8.19",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.19.0",
+                "@duckduckgo/autoconsent": "^16.23.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -602,9 +602,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.19.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.19.0.tgz",
-            "integrity": "sha512-lKScoBgF+YwNvTqu87g6lZS7LWlw62jNvjpyG0XFYxWJ8YBkm1Lmou3zAg02SVyBydN8wx5Hmo+6DusNn4euKQ==",
+            "version": "16.23.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.23.0.tgz",
+            "integrity": "sha512-NTmDhASFf5pUsSwg2TyT9R75GYUcuYZXPyBnRcYgJgozg6RLeXXP9uH8ADxA364yQ2gJBMu83AN/D24Y4nkPKg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.1.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.19.0",
+        "@duckduckgo/autoconsent": "^16.23.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217638037070219
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.23.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1217637772278405 apple_task_gid: 1217637772278405 -->

## Description
Updates Autoconsent to version [v16.23.0](https://github.com/duckduckgo/autoconsent/releases/tag/v16.23.0).

### Autoconsent v16.23.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.23.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent drives cookie-prompt handling site-wide via `cookie-prompt-management.js`; a bad release could break opt-out behavior on many sites, though this is a routine semver bump with upstream testing.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **16.19.0** to **16.23.0** in `package.json` and `package-lock.json`. No local extension code changes—only the bundled CPM/autoconsent library is updated.
> 
> The embedded extension **`manifest.json`** version is bumped from **2026.8.6** to **2026.8.19** to align with this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd3b808688a1c58da5a5d4f1103947566ccdcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->