### PR TITLE
Update Asana sync

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: duckduckgo/action-asana-sync@v11
+            - uses: duckduckgo/action-asana-sync@v16
               with:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
@@ -25,3 +25,4 @@ jobs:
                   USER_MAP: ${{ vars.USER_MAP }}
                   NO_AUTOCLOSE_PROJECTS: '312629933896096'
                   ASSIGN_PR_AUTHOR: 'true'
+                  REVIEW_TASKS_AS_APPROVALS: 'true'

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: duckduckgo/action-asana-sync@v16
+            - uses: duckduckgo/action-asana-sync@v17
               with:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}


### PR DESCRIPTION
Use 'approval' tasks for reviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to third-party CI action version and a sync flag; no runtime or security-sensitive application logic.
> 
> **Overview**
> Updates the **Asana Sync** GitHub workflow to use `duckduckgo/action-asana-sync@v17` (from v11) and sets **`REVIEW_TASKS_AS_APPROVALS: 'true'`**, so PR review handling in Asana uses approval-style tasks instead of whatever the previous default was.
> 
> This aligns Asana task behavior with the PR goal of using approval tasks for reviews; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bbaaea90a7c1a49bfb11e8a8f4d6e4e8b4fb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->