### PR TITLE
ddg2dnr: Bracket bare IPv6 addresses in DNR domain conditions

### DIFF
--- a/packages/ddg2dnr/lib/cookies.js
+++ b/packages/ddg2dnr/lib/cookies.js
@@ -1,4 +1,10 @@
-const { castDNREnum, generateRequestDomainsByTrackerDomain, getTrackerEntryDomain, storeInLookup } = require('./utils');
+const {
+    castDNREnum,
+    generateRequestDomainsByTrackerDomain,
+    getTrackerEntryDomain,
+    normalizeDomainList,
+    storeInLookup,
+} = require('./utils');
 
 const COOKIE_PRIORITY = 40000;
 
@@ -81,9 +87,9 @@ function generateCookieBlockingRuleset(tds, excludedCookieDomains, siteAllowlist
                 ],
             },
             condition: {
-                requestDomains: Array.from(trackerDomains),
-                excludedInitiatorDomains: [...domains, ...siteAllowlist],
-                excludedRequestDomains,
+                requestDomains: normalizeDomainList(Array.from(trackerDomains)),
+                excludedInitiatorDomains: normalizeDomainList([...domains, ...siteAllowlist]),
+                excludedRequestDomains: normalizeDomainList(excludedRequestDomains),
             },
         });
         matchDetailsByRuleId[startingRuleId] = {
@@ -112,8 +118,8 @@ function generateCookieBlockingRuleset(tds, excludedCookieDomains, siteAllowlist
                 ],
             },
             condition: {
-                requestDomains: singleDomainEntityDomains,
-                excludedInitiatorDomains: siteAllowlist,
+                requestDomains: normalizeDomainList(singleDomainEntityDomains),
+                excludedInitiatorDomains: normalizeDomainList(siteAllowlist),
                 domainType: castDNREnum('thirdParty'),
             },
         });

--- a/packages/ddg2dnr/lib/utils.js
+++ b/packages/ddg2dnr/lib/utils.js
@@ -160,6 +160,20 @@ function castDNREnum(s) {
  */
 
 /**
+ * Normalizes a list of domains for use in a declarativeNetRequest rule
+ * condition. Bare IPv6 addresses (e.g. '::1', which appears in the privacy
+ * configuration's localhost exceptions) are enclosed in square brackets (e.g.
+ * '[::1]'), to match the host portion of URLs as required. Firefox rejects
+ * rules containing the bare form outright, while Chrome accepts the bare form
+ * but never matches it against requests.
+ * @param {string[]} [domains]
+ * @returns {string[]|undefined}
+ */
+function normalizeDomainList(domains) {
+    return domains?.map((domain) => (domain.includes(':') && !domain.startsWith('[') ? '[' + domain + ']' : domain));
+}
+
+/**
  * Generates a declarativeNetRequest rule with the given details.
  *
  * @overload
@@ -191,6 +205,11 @@ function generateDNRRule({
     requestMethods,
     excludedRequestMethods,
 }) {
+    requestDomains = normalizeDomainList(requestDomains);
+    excludedRequestDomains = normalizeDomainList(excludedRequestDomains);
+    initiatorDomains = normalizeDomainList(initiatorDomains);
+    excludedInitiatorDomains = normalizeDomainList(excludedInitiatorDomains);
+
     /** @type {Omit<chrome.declarativeNetRequest.Rule, 'id'> & {id?: number}} */
     const dnrRule = {
         priority,
@@ -611,6 +630,7 @@ const resourceTypes = /** @type ResourceType[] */ (
 
 exports.castDNREnum = castDNREnum;
 exports.generateDNRRule = generateDNRRule;
+exports.normalizeDomainList = normalizeDomainList;
 exports.generateRequestDomainsByTrackerDomain = generateRequestDomainsByTrackerDomain;
 exports.getTrackerEntryDomain = getTrackerEntryDomain;
 exports.processRegexTrackerRule = processRegexTrackerRule;

--- a/packages/ddg2dnr/test/cookies.js
+++ b/packages/ddg2dnr/test/cookies.js
@@ -129,6 +129,16 @@ describe('cookie rules', () => {
             assert.ok(ruleset.every((r) => r.condition.excludedInitiatorDomains?.includes('safe.site')));
         });
 
+        it('bare IPv6 site allowlist domains are bracketed and the ruleset loads', /** @this {{ browser: import('../browserInterface').BrowserInterface }} */ async function () {
+            const { ruleset } = generateCookieBlockingRuleset(mockTds, [], ['::1', 'localhost', '127.0.0.1']);
+            assert.ok(ruleset.every((r) => r.condition.excludedInitiatorDomains?.includes('[::1]')));
+            assert.ok(ruleset.every((r) => !r.condition.excludedInitiatorDomains?.includes('::1')));
+
+            // Firefox rejects rules containing the bare '::1' form, so
+            // check the generated rules actually load.
+            await this.browser.addRules(ruleset);
+        });
+
         it('groups single domain entities', () => {
             const { ruleset } = generateCookieBlockingRuleset(mockTds, [], []);
             const thirdPartyRules = ruleset.filter((r) => r.condition.domainType === 'thirdParty');

--- a/packages/ddg2dnr/test/utils.js
+++ b/packages/ddg2dnr/test/utils.js
@@ -518,6 +518,24 @@ describe('generateDNRRule', () => {
             });
         }
     });
+
+    it('should enclose bare IPv6 addresses in domain conditions in brackets', async () => {
+        const { condition } = await generateDNRRule({
+            priority: 10,
+            actionType: 'block',
+            requestDomains: ['::1', 'domain.example'],
+            excludedRequestDomains: ['::1', 'localhost', '127.0.0.1'],
+            initiatorDomains: ['2001:db8::8a2e:370:7334', '[::1]'],
+            excludedInitiatorDomains: ['::1', 'other.example'],
+        });
+
+        await assert.deepEqual(condition, {
+            requestDomains: ['[::1]', 'domain.example'],
+            excludedRequestDomains: ['[::1]', 'localhost', '127.0.0.1'],
+            initiatorDomains: ['[2001:db8::8a2e:370:7334]', '[::1]'],
+            excludedInitiatorDomains: ['[::1]', 'other.example'],
+        });
+    });
 });
 
 describe('generateRequestDomainsByTrackerDomain', () => {


### PR DESCRIPTION
**Reviewer:**

## Description:

The privacy configuration's localhost exceptions include the bare IPv6 address `::1`, which flows into the domain conditions of generated declarativeNetRequest rules (`initiatorDomains`, `excludedInitiatorDomains`, `requestDomains`, `excludedRequestDomains`).

Two problems with the bare form:

- **Firefox rejects rules containing it outright** (`Invalid domain ::1`). Loading today's production config into a Firefox MV3 test extension fails 7 extension-configuration rules and — because every cookie rule carries the exclusion — the **entire combined cookie-blocking ruleset** (407 rules, the `updateDynamicRules` call is atomic). This is a blocker for the Firefox MV3 migration.
- **Chrome accepts it but never matches it**: a rule with `initiatorDomains: ['::1']` does not match requests initiated from `http://[::1]` (verified via `testMatchOutcome`), so the exemption has been silently ineffective on Chrome too.

Both browsers accept **and correctly match** the bracketed `[::1]` form (the host portion of a URL), so this PR normalizes bare IPv6 addresses to the bracketed form:

- `generateDNRRule()` normalizes all four domain-condition keys (covers the extension configuration, GPC, AMP, allowlists, etc.), via a new exported `normalizeDomainList()` helper.
- `generateCookieBlockingRuleset()` builds its rule conditions directly rather than through `generateDNRRule()`, so its domain lists are normalized at the two construction sites.

Already-bracketed entries, hostnames, and IPv4 addresses are left untouched.

## Steps to test this PR:

1. `npm test --workspace=packages/ddg2dnr` — runs the suite against both Chrome and Firefox; the new cookies test loads a ruleset generated from a `::1` site-allowlist entry into the real browser, which fails on Firefox without this change.

## Automated tests:
- [x] Unit tests
- [ ] Integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DNR rule generation used for cookie blocking and other privacy rules; incorrect domain formatting could drop exceptions or fail rule loads, but the change is small and covered by unit/browser tests.
> 
> **Overview**
> Wraps bare IPv6 addresses (e.g. `::1` from localhost exceptions) in brackets in DNR domain conditions so Firefox accepts the rules and Chrome matches them.
> 
> Adds `normalizeDomainList()` and applies it in `generateDNRRule()` for all four domain-condition fields, plus the cookie ruleset which builds conditions itself. Hostnames, IPv4, and already-bracketed IPv6 are unchanged.
> 
> Tests cover `generateDNRRule` and cookie allowlists, including loading the generated cookie ruleset in-browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1239e5afa9dc065ff6e4c6b994528be3162ab48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->