### PR TITLE
Remove cookiePopupPreferenceSetting feature flag.

### DIFF
--- a/shared/js/background/components/cookie-prompt-management.js
+++ b/shared/js/background/components/cookie-prompt-management.js
@@ -789,9 +789,6 @@ export default class CookiePromptManagement {
         if (!featureFlags.heuristicAction) {
             return 'off';
         }
-        if (!featureFlags.cookiePopupPreferenceSetting) {
-            return 'reject';
-        }
         if (userPreference === 'default') {
             return 'tier1';
         }

--- a/shared/js/background/components/cpm-standalone-messaging.js
+++ b/shared/js/background/components/cpm-standalone-messaging.js
@@ -38,7 +38,7 @@ export class CPMStandaloneMessaging {
         // there's no Autoconsent setting in the extension yet
         /** @type {import('./cookie-prompt-management').AutoconsentModePreference} */
         const userPreference = 'default';
-        return { enabled: true, userPreference, featureFlags: { heuristicAction: true, cookiePopupPreferenceSetting: true } };
+        return { enabled: true, userPreference, featureFlags: { heuristicAction: true } };
     }
 
     async checkAutoconsentEnabledForSite(url) {

--- a/unit-test/background/cookie-prompt-management.js
+++ b/unit-test/background/cookie-prompt-management.js
@@ -17,7 +17,6 @@ function createMockMessaging({ autoconsentEnabledForSite = true, autoconsentSett
                 userPreference: 'default',
                 featureFlags: {
                     heuristicAction: true,
-                    cookiePopupPreferenceSetting: true,
                 },
             }),
         ),

--- a/unit-test/background/cpm-standalone-messaging.js
+++ b/unit-test/background/cpm-standalone-messaging.js
@@ -81,7 +81,6 @@ describe('CPMStandaloneMessaging', () => {
                 userPreference: 'default',
                 featureFlags: {
                     heuristicAction: true,
-                    cookiePopupPreferenceSetting: true,
                 },
             });
         });


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/414235014887631/task/1215960699028461?focus=true
**Reviewer:** @muodov 

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Cleaning up the cookiePopupPreferenceSetting feature flag so we can remove from native (https://github.com/duckduckgo/apple-browsers/pull/6498)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how autoconsent heuristic mode is chosen for users who previously relied on the flag-off **`reject`** path, which can alter real cookie-popup handling behavior.
> 
> **Overview**
> Removes the **`cookiePopupPreferenceSetting`** feature flag from cookie prompt management so native can drop it separately.
> 
> **`settingsToHeuristicModeName`** no longer maps a disabled flag to **`reject`** heuristic mode. With autoconsent enabled and **`heuristicAction`** on, **`default`** preference always becomes **`tier1`** (and **`max`** stays **`tier2`**), without the old-settings-UI branch.
> 
> Standalone messaging and unit test mocks no longer expose **`cookiePopupPreferenceSetting`** in **`checkAutoconsentSetting`** feature flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32eeb305c94333ee83b9c53acd78ee666381897a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->