### PR TITLE
Update autoconsent to v16.29.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.8.24",
+    "version": "2026.8.26",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.23.0",
+                "@duckduckgo/autoconsent": "^16.29.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -602,9 +602,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.23.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.23.0.tgz",
-            "integrity": "sha512-NTmDhASFf5pUsSwg2TyT9R75GYUcuYZXPyBnRcYgJgozg6RLeXXP9uH8ADxA364yQ2gJBMu83AN/D24Y4nkPKg==",
+            "version": "16.29.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.29.0.tgz",
+            "integrity": "sha512-s62ngACWEiUQh2M/ERhc7TAQPUUOTvzHD0C68+PYTLG600J07l5RtlaafQSyAwp2ER4+8AleVglggQ2VSI4qUQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.1.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.23.0",
+        "@duckduckgo/autoconsent": "^16.29.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217854953100488
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.29.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1217855014018292 apple_task_gid: 1217855014018292 -->

## Description
Updates Autoconsent to version [v16.29.0](https://github.com/duckduckgo/autoconsent/releases/tag/v16.29.0).

### Autoconsent v16.29.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.29.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autoconsent runs broadly via CPM content scripts on page load; a dependency-only bump can still change consent handling on real sites, though this release is expected to be validated in Autoconsent CI and release testing.
> 
> **Overview**
> Bumps the **@duckduckgo/autoconsent** dependency from **16.23.0** to **16.29.0** in `package.json` and `package-lock.json`, pulling in the latest cookie-prompt / consent automation from the Autoconsent release.
> 
> Also bumps the embedded extension manifest version from **2026.8.24** to **2026.8.26** for the native embedded build. There are no changes to local extension source in this diff—behavior updates come entirely from the upgraded Autoconsent package (see the [v16.29.0 changelog](https://github.com/duckduckgo/autoconsent/blob/v16.29.0/CHANGELOG.md)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c628e64e05ce539ab11300ef8f8fcadf40f563a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->