### PR TITLE
Update autoconsent to v16.34.0

### DIFF
--- a/browsers/embedded/manifest.json
+++ b/browsers/embedded/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "DuckDuckGo Embedded Extension",
     "description": "Embedded extension for native app integration",
-    "version": "2026.8.26",
+    "version": "2026.9.2",
     "manifest_version": 3,
     "default_locale": "en",
     "background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "packages/ddg2dnr"
             ],
             "dependencies": {
-                "@duckduckgo/autoconsent": "^16.29.0",
+                "@duckduckgo/autoconsent": "^16.34.0",
                 "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
                 "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
                 "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",
@@ -602,9 +602,9 @@
             }
         },
         "node_modules/@duckduckgo/autoconsent": {
-            "version": "16.29.0",
-            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.29.0.tgz",
-            "integrity": "sha512-s62ngACWEiUQh2M/ERhc7TAQPUUOTvzHD0C68+PYTLG600J07l5RtlaafQSyAwp2ER4+8AleVglggQ2VSI4qUQ==",
+            "version": "16.34.0",
+            "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.34.0.tgz",
+            "integrity": "sha512-WrHl7E0SH/vHnyaotUohy8eMH1EOjmqmeWDXBkzijZGL2DVt60N0+7fKCsT+Sa0y/rL8RXY1GJBOwddzAu94wg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "tldts-experimental": "^7.4.3"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "yargs": "^18.1.0"
     },
     "dependencies": {
-        "@duckduckgo/autoconsent": "^16.29.0",
+        "@duckduckgo/autoconsent": "^16.34.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.34.0",
         "@duckduckgo/ddg2dnr": "file:packages/ddg2dnr",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218092630457541
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v16.34.0
<!-- THESE COMMENTS ARE USED BY CI, DON"T CHANGE THEM MANUALLY: --> <!-- apple_task_url: https://app.asana.com/1/137249556945/task/1218092616880902 apple_task_gid: 1218092616880902 -->

## Description
Updates Autoconsent to version [v16.34.0](https://github.com/duckduckgo/autoconsent/releases/tag/v16.34.0).

### Autoconsent v16.34.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v16.34.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The upgrade only changes the bundled autoconsent library used for cookie prompt management (e.g. `cookie-prompt-management.js`), so site consent behavior may shift without edits to extension logic in this PR.
> 
> **Overview**
> Bumps **`@duckduckgo/autoconsent`** from **16.29.0** to **16.34.0** in `package.json` and `package-lock.json`, with no local integration changes in this diff.
> 
> Also updates the embedded extension **`version`** in `browsers/embedded/manifest.json` from **2026.8.26** to **2026.9.2**, aligning the embedded build with this dependency release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a45aa158dbab33c97b1078d9b8bd3af37d53af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->